### PR TITLE
feat: add @ippoan/auth-client StagingFooter

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@ippoan:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/app/app.vue
+++ b/app/app.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 import { initApi } from '~/utils/api'
+import { StagingFooter } from '@ippoan/auth-client'
 
 const config = useRuntimeConfig()
 const { init, accessToken, tenantId, isLoading } = useAuth()
+const apiBase = config.public.apiBase as string
+const stagingTenantId = (config.public.stagingTenantId as string) || ''
 
 onMounted(async () => {
   initApi(
-    config.public.apiBase as string,
+    apiBase,
     () => accessToken.value,
     undefined,
     () => tenantId.value,
@@ -23,5 +26,6 @@ onMounted(async () => {
     <NuxtLayout v-else>
       <NuxtPage />
     </NuxtLayout>
+    <StagingFooter :api-base="apiBase" :tenant-id="stagingTenantId" />
   </UApp>
 </template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -19,5 +19,12 @@ export default defineNuxtConfig({
   ],
 
   css: ['~/assets/css/main.css'],
-})
 
+  typescript: {
+    tsConfig: {
+      compilerOptions: {
+        skipLibCheck: true,
+      },
+    },
+  },
+})

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -6,6 +6,7 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       apiBase: process.env.NUXT_PUBLIC_API_BASE || 'http://localhost:8080',
+      stagingTenantId: process.env.NUXT_PUBLIC_STAGING_TENANT_ID || '',
     },
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
+        "@ippoan/auth-client": "^0.2.13",
         "@nuxt/ui": "^4.5.1",
         "@nuxtjs/tailwindcss": "^6.14.0",
         "nuxt": "^4.3.1",
@@ -1616,6 +1617,18 @@
     "node_modules/@ioredis/commands": {
       "version": "1.5.1",
       "license": "MIT"
+    },
+    "node_modules/@ippoan/auth-client": {
+      "version": "0.2.13",
+      "resolved": "https://npm.pkg.github.com/download/@ippoan/auth-client/0.2.13/3ea38e435fb6003cb80b11251127868f945273cd",
+      "integrity": "sha512-578eOSINqo/i5H/0nf6JE0lfSKvGQwD2VmveCgbbWqmdeySKKdD+GYGjf8qn4/7Nq1GhDOum6r4iP8N2yPiUiQ==",
+      "dependencies": {
+        "uqr": "^0.1.2"
+      },
+      "peerDependencies": {
+        "nuxt": ">=3.0.0",
+        "vue": ">=3.0.0"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@ippoan/auth-client": "^0.2.13",
+    "@ippoan/auth-client": "0.1.60-dev.ee4f002",
     "@nuxt/ui": "^4.5.1",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "nuxt": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@ippoan/auth-client": "^0.2.13",
     "@nuxt/ui": "^4.5.1",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "nuxt": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@ippoan/auth-client": "0.1.60-dev.ee4f002",
+    "@ippoan/auth-client": "0.1.61-dev.40ef3b1",
     "@nuxt/ui": "^4.5.1",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "nuxt": "^4.3.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,17 @@
 {
-  "extends": "./.nuxt/tsconfig.json"
+  "files": [],
+  "references": [
+    {
+      "path": "./.nuxt/tsconfig.app.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.node.json"
+    }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "./.nuxt/tsconfig.json"
+  "extends": "./.nuxt/tsconfig.json",
+  "compilerOptions": {
+    "skipLibCheck": true
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "./.nuxt/tsconfig.json",
-  "compilerOptions": {
-    "skipLibCheck": true
-  }
+  "extends": "./.nuxt/tsconfig.json"
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -19,3 +19,4 @@ pattern = "trouble-staging.ippoan.org"
 custom_domain = true
 [env.staging.vars]
 NUXT_PUBLIC_API_BASE = "https://rust-alc-api-staging-566bls5vfq-an.a.run.app"
+NUXT_PUBLIC_STAGING_TENANT_ID = "11111111-1111-1111-1111-111111111111"


### PR DESCRIPTION
## Summary
- `@ippoan/auth-client` の `StagingFooter` を追加
- staging 環境で Export/Import UI を表示
- `NUXT_PUBLIC_STAGING_TENANT_ID` を staging env vars に追加

## Test plan
- [ ] CI pass
- [ ] staging で StagingFooter 表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)