### PR TITLE
fix: correct production API_BASE to alc-api.ippoan.org

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,7 +9,7 @@ pattern = "trouble.ippoan.org"
 custom_domain = true
 
 [vars]
-NUXT_PUBLIC_API_BASE = "https://alc.ippoan.org"
+NUXT_PUBLIC_API_BASE = "https://alc-api.ippoan.org"
 
 [env.staging]
 name = "nuxt-trouble-staging"


### PR DESCRIPTION
## Summary
- `alc.ippoan.org` (フロントエンド) → `alc-api.ippoan.org` (API) に修正
- Google OAuth リダイレクトが正しい API に向くようになる

## Test plan
- [ ] CI pass
- [ ] staging デプロイ確認 (staging URL は変更なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)