### PR TITLE
fix: add public/_headers for charset=utf-8

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,5 @@
+/_nuxt/*.js
+  Content-Type: text/javascript; charset=utf-8
+
+/_nuxt/*.css
+  Content-Type: text/css; charset=utf-8


### PR DESCRIPTION
## Summary
- PR#5 で `public/_headers` が実際にはコミットに含まれていなかった
- Cloudflare Workers の static assets に `charset=utf-8` を付与
- 日本語文字化け修正 (cloudflare/workers-sdk#9599)

## Test plan
- [ ] CI pass
- [ ] staging で `curl -sI /_nuxt/*.js` に `charset=utf-8` が含まれる
- [ ] 日本語が正常表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)