### PR TITLE
fix: decode JWT with TextDecoder for multibyte UTF-8

### DIFF
--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -35,8 +35,10 @@ function decodeJwt(token: string): JwtPayload | null {
   try {
     const parts = token.split('.')
     if (!parts[1]) return null
-    const payload = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')))
-    return payload
+    const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/')
+    const binary = atob(base64)
+    const bytes = Uint8Array.from(binary, c => c.charCodeAt(0))
+    return JSON.parse(new TextDecoder().decode(bytes))
   } catch {
     return null
   }


### PR DESCRIPTION
## Summary
- `atob()` は Latin-1 のみ対応で日本語ユーザー名が文字化け
- `Uint8Array` + `TextDecoder` で正しく UTF-8 デコード (alc-app と同じパターン)

## Test plan
- [ ] CI pass
- [ ] staging でサイドバーのユーザー名が日本語で正常表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)