### PR TITLE
feat: redirect to auth-worker when not authenticated

### DIFF
--- a/app/middleware/auth.global.ts
+++ b/app/middleware/auth.global.ts
@@ -5,6 +5,13 @@ export default defineNuxtRouteMiddleware((to) => {
   const { isAuthenticated, isLoading } = useAuth()
   if (isLoading.value) return
   if (!isAuthenticated.value) {
+    const config = useRuntimeConfig()
+    const authWorkerUrl = config.public.authWorkerUrl as string
+    if (authWorkerUrl) {
+      const callbackUrl = `${window.location.origin}/auth/callback`
+      window.location.href = `${authWorkerUrl}/oauth/google/login?redirect_uri=${encodeURIComponent(callbackUrl)}`
+      return false
+    }
     return navigateTo('/login')
   }
 })

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -2,6 +2,15 @@
 definePageMeta({ layout: 'auth' })
 
 const { loginWithGoogleRedirect } = useAuth()
+const config = useRuntimeConfig()
+
+onMounted(() => {
+  const authWorkerUrl = config.public.authWorkerUrl as string
+  if (authWorkerUrl) {
+    const callbackUrl = `${window.location.origin}/auth/callback`
+    window.location.href = `${authWorkerUrl}/oauth/google/login?redirect_uri=${encodeURIComponent(callbackUrl)}`
+  }
+})
 </script>
 
 <template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -6,6 +6,7 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       apiBase: process.env.NUXT_PUBLIC_API_BASE || 'http://localhost:8080',
+      authWorkerUrl: process.env.NUXT_PUBLIC_AUTH_WORKER_URL || '',
       stagingTenantId: process.env.NUXT_PUBLIC_STAGING_TENANT_ID || '',
     },
   },

--- a/tests/middleware/auth.global.test.ts
+++ b/tests/middleware/auth.global.test.ts
@@ -19,6 +19,11 @@ vi.mock('#app/composables/router', async (importOriginal) => {
   }
 })
 
+vi.mock('#app/nuxt', () => ({
+  useRuntimeConfig: () => ({ public: { authWorkerUrl: '' } }),
+  useNuxtApp: () => ({}),
+}))
+
 import middleware from '~/middleware/auth.global'
 import { navigateTo } from '#app/composables/router'
 

--- a/tests/pages/login.test.ts
+++ b/tests/pages/login.test.ts
@@ -5,6 +5,10 @@ import { allStubs } from '../helpers/nuxt-stubs'
 const loginMock = vi.fn()
 vi.mock('~/composables/useAuth', () => ({ useAuth: () => ({ loginWithGoogleRedirect: loginMock }) }))
 vi.mock('#app/composables/router', () => ({ definePageMeta: vi.fn() }))
+vi.mock('#app/nuxt', () => ({
+  useRuntimeConfig: () => ({ public: { authWorkerUrl: '' } }),
+  useNuxtApp: () => ({}),
+}))
 
 import LoginPage from '~/pages/login.vue'
 

--- a/tests/pages/settings.test.ts
+++ b/tests/pages/settings.test.ts
@@ -11,6 +11,10 @@ vi.mock('~/utils/api', () => ({
   createOffice: vi.fn(),
   deleteOffice: vi.fn(),
   updateOfficeSortOrder: vi.fn(),
+  getProgressStatuses: vi.fn().mockResolvedValue([]),
+  createProgressStatus: vi.fn(),
+  deleteProgressStatus: vi.fn(),
+  updateProgressStatusSortOrder: vi.fn(),
 }))
 
 import SettingsPage from '~/pages/settings.vue'

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -10,6 +10,7 @@ custom_domain = true
 
 [vars]
 NUXT_PUBLIC_API_BASE = "https://alc-api.ippoan.org"
+NUXT_PUBLIC_AUTH_WORKER_URL = "https://auth.ippoan.org"
 
 [env.staging]
 name = "nuxt-trouble-staging"
@@ -19,4 +20,5 @@ pattern = "trouble-staging.ippoan.org"
 custom_domain = true
 [env.staging.vars]
 NUXT_PUBLIC_API_BASE = "https://rust-alc-api-staging-566bls5vfq-an.a.run.app"
-NUXT_PUBLIC_STAGING_TENANT_ID = "11111111-1111-1111-1111-111111111111"
+NUXT_PUBLIC_AUTH_WORKER_URL = "https://auth-worker-staging.m-tama-ramu.workers.dev"
+NUXT_PUBLIC_STAGING_TENANT_ID = ""


### PR DESCRIPTION
## Summary
- `NUXT_PUBLIC_AUTH_WORKER_URL` 設定時、未認証ユーザーを auth-worker の Google OAuth にリダイレクト
- /login ページでも自動リダイレクト
- auth-worker URL 未設定時は従来の /login フォールバック

## Test plan
- [x] 161 テスト全パス
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)