### PR TITLE
fix: use /oauth/google/redirect for auth-worker

### DIFF
--- a/app/middleware/auth.global.ts
+++ b/app/middleware/auth.global.ts
@@ -9,7 +9,7 @@ export default defineNuxtRouteMiddleware((to) => {
     const authWorkerUrl = config.public.authWorkerUrl as string
     if (authWorkerUrl) {
       const callbackUrl = `${window.location.origin}/auth/callback`
-      window.location.href = `${authWorkerUrl}/oauth/google/login?redirect_uri=${encodeURIComponent(callbackUrl)}`
+      window.location.href = `${authWorkerUrl}/oauth/google/redirect?redirect_uri=${encodeURIComponent(callbackUrl)}`
       return false
     }
     return navigateTo('/login')

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -8,7 +8,7 @@ onMounted(() => {
   const authWorkerUrl = config.public.authWorkerUrl as string
   if (authWorkerUrl) {
     const callbackUrl = `${window.location.origin}/auth/callback`
-    window.location.href = `${authWorkerUrl}/oauth/google/login?redirect_uri=${encodeURIComponent(callbackUrl)}`
+    window.location.href = `${authWorkerUrl}/oauth/google/redirect?redirect_uri=${encodeURIComponent(callbackUrl)}`
   }
 })
 </script>


### PR DESCRIPTION
## Summary
- `/oauth/google/login` → `/oauth/google/redirect` (auth-worker の正しいエンドポイント)

## Test plan
- [x] 161 テスト全パス
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)