### PR TITLE
fix: disable selects when master data empty

### DIFF
--- a/app/components/TicketFormFields.vue
+++ b/app/components/TicketFormFields.vue
@@ -107,16 +107,10 @@ function updateEmployee(employeeId: string) {
 
         <UFormField label="営業所名">
           <USelect
-            v-if="officeOptions.length > 0"
             :model-value="(model.office_name as string) || ''"
             :items="officeOptions"
             placeholder="営業所を選択"
-            @update:model-value="update('office_name', $event)"
-          />
-          <UInput
-            v-else
-            :model-value="(model.office_name as string) || ''"
-            placeholder="営業所名"
+            :disabled="officeOptions.length === 0"
             @update:model-value="update('office_name', $event)"
           />
         </UFormField>
@@ -131,17 +125,11 @@ function updateEmployee(employeeId: string) {
 
         <UFormField label="氏名">
           <USelect
-            v-if="employeeOptions.length > 0"
             :model-value="(model.person_id as string) || ''"
             :items="employeeOptions"
             placeholder="従業員を選択"
+            :disabled="employeeOptions.length === 0"
             @update:model-value="updateEmployee($event as string)"
-          />
-          <UInput
-            v-else
-            :model-value="(model.person_name as string) || ''"
-            placeholder="氏名"
-            @update:model-value="update('person_name', $event)"
           />
         </UFormField>
       </div>
@@ -177,16 +165,10 @@ function updateEmployee(employeeId: string) {
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <UFormField label="進捗状況">
           <USelect
-            v-if="progressOptions.length > 0"
             :model-value="(model.progress_notes as string) || ''"
             :items="progressOptions"
             placeholder="進捗状況を選択"
-            @update:model-value="update('progress_notes', $event)"
-          />
-          <UInput
-            v-else
-            :model-value="(model.progress_notes as string) || ''"
-            placeholder="進捗状況"
+            :disabled="progressOptions.length === 0"
             @update:model-value="update('progress_notes', $event)"
           />
         </UFormField>

--- a/app/composables/useTicketList.ts
+++ b/app/composables/useTicketList.ts
@@ -1,6 +1,6 @@
-import { getTickets, getWorkflowStates, deleteTicket, exportTicketsCsv, createTicket, setupDefaultWorkflow, getCategories, getOffices } from '~/utils/api'
+import { getTickets, getWorkflowStates, deleteTicket, exportTicketsCsv, createTicket, setupDefaultWorkflow, getCategories, getOffices, getProgressStatuses } from '~/utils/api'
 import { TICKET_CATEGORIES } from '~/types'
-import type { TroubleTicket, TroubleWorkflowState, TroubleCategory, TroubleOffice, CreateTroubleTicket } from '~/types'
+import type { TroubleTicket, TroubleWorkflowState, TroubleCategory, TroubleOffice, TroubleProgressStatus, CreateTroubleTicket } from '~/types'
 
 const STORAGE_KEY = 'trouble_filter_status'
 
@@ -79,6 +79,7 @@ export function useTicketList() {
   // Master data
   const categories = shallowRef<TroubleCategory[]>([])
   const offices = shallowRef<TroubleOffice[]>([])
+  const progressStatuses = shallowRef<TroubleProgressStatus[]>([])
 
   const categoryOptions = computed(() => {
     const dbNames = new Set(categories.value.map(c => c.name))
@@ -104,14 +105,20 @@ export function useTicketList() {
     offices.value.map(o => ({ label: o.name, value: o.name })),
   )
 
+  const progressOptions = computed(() =>
+    progressStatuses.value.map(p => ({ label: p.name, value: p.name })),
+  )
+
   async function fetchMasterData() {
     try {
-      const [cats, offs] = await Promise.all([
+      const [cats, offs, progs] = await Promise.all([
         getCategories().catch(() => []),
         getOffices().catch(() => []),
+        getProgressStatuses().catch(() => []),
       ])
       categories.value = cats
       offices.value = offs
+      progressStatuses.value = progs
     } catch { /* ignore */ }
   }
 
@@ -255,9 +262,9 @@ export function useTicketList() {
   return {
     filter, selectedStatuses, tickets, total, workflowStates, loading,
     deleteTarget, showDeleteModal, stateMap, totalPages,
-    categoryOptions, createCategoryOptions, officeOptions, filteredTickets,
+    categoryOptions, createCategoryOptions, officeOptions, progressOptions, filteredTickets,
     showInlineCreate, creating, newTicket,
-    categories, offices,
+    categories, offices, progressStatuses,
     loadStatusFilter, toggleStatus, toggleAllStatuses,
     resetNewTicket, handleInlineCreate,
     fetchTickets, fetchWorkflowStates, fetchMasterData,

--- a/app/pages/tickets/index.vue
+++ b/app/pages/tickets/index.vue
@@ -2,7 +2,7 @@
 const {
   filter, selectedStatuses, loading,
   deleteTarget, showDeleteModal, stateMap, totalPages,
-  categoryOptions, createCategoryOptions, officeOptions, filteredTickets,
+  categoryOptions, createCategoryOptions, officeOptions, progressOptions, filteredTickets,
   showInlineCreate, creating, newTicket, workflowStates, total,
   loadStatusFilter, toggleStatus, toggleAllStatuses,
   resetNewTicket, handleInlineCreate,
@@ -35,8 +35,7 @@ watch(() => ({ ...filter }), () => { fetchTickets() }, { deep: true })
       <UInput v-model="filter.q" placeholder="検索" size="sm" class="w-28" />
       <UInput v-model="filter.person_name" placeholder="氏名" size="sm" class="w-24" />
       <UInput v-model="filter.company_name" placeholder="会社名" size="sm" class="w-28" />
-      <USelect v-if="officeOptions.length > 0" v-model="filter.office_name" :items="[{ label: '全て', value: '' }, ...officeOptions]" placeholder="営業所" size="sm" class="w-28" />
-      <UInput v-else v-model="filter.office_name" placeholder="営業所" size="sm" class="w-24" />
+      <USelect v-model="filter.office_name" :items="[{ label: '全て', value: '' }, ...officeOptions]" placeholder="営業所" size="sm" class="w-28" :disabled="officeOptions.length === 0" />
       <UInput v-model="filter.date_from" type="date" size="sm" class="w-36" />
       <span class="text-gray-400 text-xs">〜</span>
       <UInput v-model="filter.date_to" type="date" size="sm" class="w-36" />
@@ -91,14 +90,13 @@ watch(() => ({ ...filter }), () => { fetchTickets() }, { deep: true })
         <USelect v-model="newTicket.category" :items="createCategoryOptions" placeholder="カテゴリ" size="sm" class="w-28" />
         <UInput v-model="newTicket.occurred_date" type="date" size="sm" class="w-32" />
         <UInput v-model="newTicket.company_name" placeholder="会社名" size="sm" class="w-24" />
-        <USelect v-if="officeOptions.length > 0" v-model="newTicket.office_name" :items="officeOptions" placeholder="営業所" size="sm" class="w-24" />
-        <UInput v-else v-model="newTicket.office_name" placeholder="営業所" size="sm" class="w-24" />
+        <USelect v-model="newTicket.office_name" :items="officeOptions" placeholder="営業所" size="sm" class="w-24" :disabled="officeOptions.length === 0" />
         <UInput v-model="newTicket.department" placeholder="運行課" size="sm" class="w-20" />
         <UInput v-model="newTicket.person_name" placeholder="当事者名" size="sm" class="w-24" />
         <UInput v-model="newTicket.registration_number" placeholder="登録番号" size="sm" class="w-24" />
         <UInput v-model="newTicket.location" placeholder="発生場所" size="sm" class="w-24" />
         <UInput v-model="newTicket.description" placeholder="内容" size="sm" class="w-32" />
-        <UInput v-model="newTicket.progress_notes" placeholder="進捗状況" size="sm" class="w-24" />
+        <USelect v-model="newTicket.progress_notes" :items="progressOptions" placeholder="進捗状況" size="sm" class="w-24" :disabled="progressOptions.length === 0" />
         <UInput v-model="newTicket.allowance" placeholder="手当等" size="sm" class="w-20" />
         <UInput v-model="newTicket.damage_amount" type="number" placeholder="損害額" size="sm" class="w-20" />
         <UInput v-model="newTicket.compensation_amount" type="number" placeholder="賠償額" size="sm" class="w-20" />

--- a/tests/fixtures/seed.sql
+++ b/tests/fixtures/seed.sql
@@ -10,6 +10,16 @@ INSERT INTO tenants (id, name, slug) VALUES
 -- Setup default trouble workflow for test tenant
 SELECT set_config('app.current_tenant_id', '11111111-1111-1111-1111-111111111111', false);
 
+-- Default categories for test tenant
+INSERT INTO trouble_categories (tenant_id, name, sort_order) VALUES
+  ('11111111-1111-1111-1111-111111111111', '苦情・トラブル', 0),
+  ('11111111-1111-1111-1111-111111111111', '貨物事故', 1),
+  ('11111111-1111-1111-1111-111111111111', '被害事故', 2),
+  ('11111111-1111-1111-1111-111111111111', '対物事故(他損)', 3),
+  ('11111111-1111-1111-1111-111111111111', '対物事故(自損)', 4),
+  ('11111111-1111-1111-1111-111111111111', '人身事故', 5),
+  ('11111111-1111-1111-1111-111111111111', 'その他', 6);
+
 INSERT INTO trouble_workflow_states (id, tenant_id, name, label, color, sort_order, is_initial, is_terminal) VALUES
   ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', '新規', '新規', '#3B82F6', 0, true, false),
   ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '11111111-1111-1111-1111-111111111111', '対応中', '対応中', '#F59E0B', 1, false, false),


### PR DESCRIPTION
## Summary
- マスタ空 → disabled USelect (入力不可)、v-if/v-else フォールバック削除
- 営業所・進捗状況・従業員のフォーム・フィルタ・インライン作成すべて統一

🤖 Generated with [Claude Code](https://claude.com/claude-code)