### PR TITLE
feat: add notification settings + schedule UI (Phase 4)

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -4,7 +4,7 @@ const route = useRoute()
 
 const navigation = [
   { label: 'チケット一覧', icon: 'i-lucide-list', to: '/tickets' },
-  { label: '設定', icon: 'i-lucide-settings', to: '/settings' },
+  { label: '通知設定', icon: 'i-lucide-bell', to: '/settings' },
 ]
 
 async function handleLogout() {

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import type { TroubleCategory, TroubleOffice, TroubleProgressStatus } from '~/types'
-import { TICKET_CATEGORIES } from '~/types'
+import type { TroubleCategory, TroubleOffice, TroubleProgressStatus, TroubleNotificationPref, LineworksMember } from '~/types'
+import { TICKET_CATEGORIES, NOTIFICATION_EVENT_TYPES } from '~/types'
 import {
   getCategories, createCategory, deleteCategory, updateCategorySortOrder,
   getOffices, createOffice, deleteOffice, updateOfficeSortOrder,
   getProgressStatuses, createProgressStatus, deleteProgressStatus, updateProgressStatusSortOrder,
+  getNotificationPrefs, upsertNotificationPref, deleteNotificationPref, getLineworksMembers,
 } from '~/utils/api'
 
 const activeTab = ref('categories')
@@ -14,6 +15,7 @@ const tabs = [
   { label: '営業所', value: 'offices' },
   { label: '進捗状況', value: 'progress' },
   { label: 'ワークフロー', value: 'workflow' },
+  { label: '通知', value: 'notifications' },
 ]
 
 // Categories
@@ -145,10 +147,104 @@ async function handleReorderProgressStatus(id: string, sortOrder: number) {
   }
 }
 
+// Notification Prefs
+const notifPrefs = ref<TroubleNotificationPref[]>([])
+const notifMembers = ref<LineworksMember[]>([])
+const notifLoading = ref(false)
+const notifError = ref<string | null>(null)
+const notifSaving = ref(false)
+const showAddNotifModal = ref(false)
+const newNotifPref = ref({
+  event_type: '',
+  lineworks_user_ids: [] as string[],
+})
+
+async function fetchNotifications() {
+  notifLoading.value = true
+  notifError.value = null
+  try {
+    const [p, m] = await Promise.all([
+      getNotificationPrefs(),
+      getLineworksMembers().catch(() => [] as LineworksMember[]),
+    ])
+    notifPrefs.value = p
+    notifMembers.value = m
+  } catch (e) {
+    notifError.value = e instanceof Error ? e.message : '読み込みに失敗しました'
+  } finally {
+    notifLoading.value = false
+  }
+}
+
+function notifMemberName(userId: string): string {
+  const m = notifMembers.value.find(m => m.user_id === userId)
+  return m?.user_name || m?.email || userId
+}
+
+function eventLabel(eventType: string): string {
+  return NOTIFICATION_EVENT_TYPES.find(e => e.value === eventType)?.label || eventType
+}
+
+async function handleAddNotif() {
+  if (!newNotifPref.value.event_type || newNotifPref.value.lineworks_user_ids.length === 0) return
+  notifSaving.value = true
+  notifError.value = null
+  try {
+    await upsertNotificationPref({
+      event_type: newNotifPref.value.event_type,
+      notify_channel: 'lineworks',
+      enabled: true,
+      lineworks_user_ids: newNotifPref.value.lineworks_user_ids,
+    })
+    showAddNotifModal.value = false
+    newNotifPref.value = { event_type: '', lineworks_user_ids: [] }
+    await fetchNotifications()
+  } catch (e) {
+    notifError.value = e instanceof Error ? e.message : '保存に失敗しました'
+  } finally {
+    notifSaving.value = false
+  }
+}
+
+async function handleToggleNotif(pref: TroubleNotificationPref) {
+  try {
+    await upsertNotificationPref({
+      event_type: pref.event_type,
+      notify_channel: pref.notify_channel,
+      enabled: !pref.enabled,
+    })
+    await fetchNotifications()
+  } catch (e) {
+    notifError.value = e instanceof Error ? e.message : '更新に失敗しました'
+  }
+}
+
+async function handleDeleteNotif(pref: TroubleNotificationPref) {
+  try {
+    await deleteNotificationPref(pref.id)
+    await fetchNotifications()
+  } catch (e) {
+    notifError.value = e instanceof Error ? e.message : '削除に失敗しました'
+  }
+}
+
+const availableEventTypes = computed(() => {
+  const configured = new Set(notifPrefs.value.map(p => p.event_type))
+  return NOTIFICATION_EVENT_TYPES.filter(e => !configured.has(e.value))
+})
+
+const notifMemberOptions = computed(() =>
+  notifMembers.value.map(m => ({
+    label: m.user_name || m.email || m.user_id,
+    value: m.user_id,
+  }))
+)
+
 onMounted(() => {
   fetchCategories()
   fetchOffices()
   fetchProgressStatuses()
+  fetchNotifications()
 })
 </script>
 
@@ -203,6 +299,118 @@ onMounted(() => {
       />
 
       <WorkflowManager v-if="activeTab === 'workflow'" />
+
+      <!-- Notifications tab -->
+      <div v-if="activeTab === 'notifications'" class="space-y-4">
+        <div class="flex items-center justify-between">
+          <h3 class="font-bold">通知設定</h3>
+          <UButton
+            label="追加"
+            icon="i-lucide-plus"
+            size="sm"
+            :disabled="availableEventTypes.length === 0"
+            @click="showAddNotifModal = true"
+          />
+        </div>
+
+        <div v-if="notifError" class="p-3 bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-400 rounded-lg text-sm">
+          {{ notifError }}
+        </div>
+
+        <div v-if="notifLoading" class="flex justify-center py-8">
+          <UIcon name="i-lucide-loader-circle" class="animate-spin size-8 text-gray-400" />
+        </div>
+
+        <template v-else>
+          <div v-if="notifMembers.length === 0" class="p-4 bg-yellow-50 dark:bg-yellow-950 text-yellow-700 dark:text-yellow-300 rounded-lg text-sm">
+            LINE WORKS Bot が未設定です。管理画面で Bot を設定してください。
+          </div>
+
+          <div v-if="notifPrefs.length === 0" class="text-center py-8 text-gray-500">
+            通知設定がありません
+          </div>
+
+          <div v-for="pref in notifPrefs" :key="pref.id" class="p-4 border border-gray-200 dark:border-gray-700 rounded-lg">
+            <div class="flex items-center justify-between">
+              <div class="space-y-1">
+                <div class="flex items-center gap-2">
+                  <span class="font-medium">{{ eventLabel(pref.event_type) }}</span>
+                  <UBadge :color="pref.enabled ? 'success' : 'neutral'" variant="subtle">
+                    {{ pref.enabled ? '有効' : '無効' }}
+                  </UBadge>
+                  <UBadge color="info" variant="subtle">LINE WORKS</UBadge>
+                </div>
+                <div class="text-sm text-gray-500 dark:text-gray-400">
+                  送信先: {{ pref.lineworks_user_ids.map(id => notifMemberName(id)).join(', ') || '-' }}
+                </div>
+              </div>
+              <div class="flex gap-2">
+                <UButton
+                  :icon="pref.enabled ? 'i-lucide-pause' : 'i-lucide-play'"
+                  variant="ghost"
+                  size="sm"
+                  @click="handleToggleNotif(pref)"
+                />
+                <UButton
+                  icon="i-lucide-trash-2"
+                  variant="ghost"
+                  color="error"
+                  size="sm"
+                  @click="handleDeleteNotif(pref)"
+                />
+              </div>
+            </div>
+          </div>
+        </template>
+      </div>
     </UCard>
+
+    <!-- Add notification modal -->
+    <UModal v-model:open="showAddNotifModal">
+      <template #content>
+        <div class="p-6 space-y-4">
+          <h3 class="text-lg font-bold">通知設定を追加</h3>
+
+          <UFormField label="イベント種別">
+            <USelect
+              v-model="newNotifPref.event_type"
+              :items="availableEventTypes.map(e => ({ label: e.label, value: e.value }))"
+              placeholder="選択してください"
+            />
+          </UFormField>
+
+          <UFormField label="送信先 (LINE WORKS メンバー)">
+            <div class="space-y-2">
+              <label
+                v-for="m in notifMemberOptions"
+                :key="m.value"
+                class="flex items-center gap-2 text-sm cursor-pointer"
+              >
+                <input
+                  type="checkbox"
+                  :value="m.value"
+                  v-model="newNotifPref.lineworks_user_ids"
+                  class="rounded border-gray-300"
+                />
+                {{ m.label }}
+              </label>
+              <p v-if="notifMemberOptions.length === 0" class="text-sm text-gray-400">
+                メンバーが取得できません
+              </p>
+            </div>
+          </UFormField>
+
+          <div class="flex justify-end gap-2">
+            <UButton label="キャンセル" variant="outline" @click="showAddNotifModal = false" />
+            <UButton
+              label="追加"
+              :loading="notifSaving"
+              :disabled="!newNotifPref.event_type || newNotifPref.lineworks_user_ids.length === 0"
+              @click="handleAddNotif"
+            />
+          </div>
+        </div>
+      </template>
+    </UModal>
   </div>
 </template>

--- a/app/pages/tickets/[id].vue
+++ b/app/pages/tickets/[id].vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { TroubleCategory, TroubleOffice, TroubleProgressStatus, Employee } from '~/types'
-import { getCategories, getOffices, getProgressStatuses, getEmployees } from '~/utils/api'
+import type { TroubleCategory, TroubleOffice, TroubleProgressStatus, Employee, TroubleSchedule, LineworksMember } from '~/types'
+import { getCategories, getOffices, getProgressStatuses, getEmployees, getTicketSchedules, createSchedule, cancelSchedule, getLineworksMembers } from '~/utils/api'
 
 const route = useRoute()
 const ticketId = route.params.id as string
@@ -16,8 +16,65 @@ const offices = ref<TroubleOffice[]>([])
 const progressStatuses = ref<TroubleProgressStatus[]>([])
 const employees = ref<Employee[]>([])
 
+// --- Schedule notifications ---
+const schedules = ref<TroubleSchedule[]>([])
+const showScheduleModal = ref(false)
+const scheduleForm = ref({
+  scheduled_at: '',
+  message: '',
+  lineworks_user_ids: [] as string[],
+})
+const scheduleSaving = ref(false)
+const scheduleMembers = ref<LineworksMember[]>([])
+
+async function loadSchedules() {
+  try {
+    const [s, m] = await Promise.all([
+      getTicketSchedules(ticketId),
+      getLineworksMembers().catch(() => [] as LineworksMember[]),
+    ])
+    schedules.value = s
+    scheduleMembers.value = m
+  } catch { /* ignore */ }
+}
+
+async function handleCreateSchedule() {
+  if (!scheduleForm.value.scheduled_at || !scheduleForm.value.message.trim()) return
+  scheduleSaving.value = true
+  try {
+    await createSchedule({
+      ticket_id: ticketId,
+      scheduled_at: new Date(scheduleForm.value.scheduled_at).toISOString(),
+      message: scheduleForm.value.message,
+      lineworks_user_ids: scheduleForm.value.lineworks_user_ids,
+    })
+    showScheduleModal.value = false
+    scheduleForm.value = { scheduled_at: '', message: '', lineworks_user_ids: [] }
+    await loadSchedules()
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'スケジュール作成に失敗しました'
+  } finally {
+    scheduleSaving.value = false
+  }
+}
+
+async function handleCancelSchedule(id: string) {
+  try {
+    await cancelSchedule(id)
+    await loadSchedules()
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'キャンセルに失敗しました'
+  }
+}
+
+function scheduleMemberName(userId: string): string {
+  const m = scheduleMembers.value.find(m => m.user_id === userId)
+  return m?.user_name || m?.email || userId
+}
+
 onMounted(() => {
   load()
+  loadSchedules()
   getCategories().then(r => categories.value = r).catch(() => {})
   getOffices().then(r => offices.value = r).catch(() => {})
   getProgressStatuses().then(r => progressStatuses.value = r).catch(() => {})
@@ -121,7 +178,116 @@ onMounted(() => {
       <UCard>
         <TicketFiles :ticket-id="ticketId" />
       </UCard>
+
+      <!-- Schedule notifications -->
+      <UCard>
+        <div class="flex items-center justify-between mb-4">
+          <h3 class="font-bold">スケジュール通知</h3>
+          <UButton
+            label="予約"
+            icon="i-lucide-clock"
+            size="sm"
+            variant="outline"
+            @click="showScheduleModal = true"
+          />
+        </div>
+
+        <div v-if="schedules.length === 0" class="text-sm text-gray-500 text-center py-4">
+          予約された通知はありません
+        </div>
+
+        <div v-else class="space-y-3">
+          <div
+            v-for="s in schedules"
+            :key="s.id"
+            class="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800 rounded-lg"
+          >
+            <div class="space-y-1">
+              <div class="flex items-center gap-2">
+                <UIcon name="i-lucide-clock" class="size-4 text-gray-400" />
+                <span class="text-sm font-medium">
+                  {{ new Date(s.scheduled_at).toLocaleString('ja-JP') }}
+                </span>
+                <UBadge
+                  :color="s.status === 'pending' ? 'warning' : s.status === 'sent' ? 'success' : 'error'"
+                  variant="subtle"
+                  size="xs"
+                >
+                  {{ s.status === 'pending' ? '予約中' : s.status === 'sent' ? '送信済' : s.status === 'cancelled' ? 'キャンセル' : '失敗' }}
+                </UBadge>
+              </div>
+              <p class="text-sm text-gray-600 dark:text-gray-400">{{ s.message }}</p>
+              <p class="text-xs text-gray-400">
+                送信先: {{ s.lineworks_user_ids.map(id => scheduleMemberName(id)).join(', ') }}
+              </p>
+            </div>
+            <UButton
+              v-if="s.status === 'pending'"
+              icon="i-lucide-x"
+              variant="ghost"
+              color="error"
+              size="sm"
+              @click="handleCancelSchedule(s.id)"
+            />
+          </div>
+        </div>
+      </UCard>
     </template>
+
+    <!-- Schedule modal -->
+    <UModal v-model:open="showScheduleModal">
+      <template #content>
+        <div class="p-6 space-y-4">
+          <h3 class="text-lg font-bold">通知を予約</h3>
+
+          <UFormField label="通知日時">
+            <UInput
+              v-model="scheduleForm.scheduled_at"
+              type="datetime-local"
+            />
+          </UFormField>
+
+          <UFormField label="メッセージ">
+            <UTextarea
+              v-model="scheduleForm.message"
+              placeholder="通知メッセージを入力"
+              :rows="3"
+            />
+          </UFormField>
+
+          <UFormField label="送信先">
+            <div class="space-y-2">
+              <label
+                v-for="m in scheduleMembers"
+                :key="m.user_id"
+                class="flex items-center gap-2 text-sm cursor-pointer"
+              >
+                <input
+                  type="checkbox"
+                  :value="m.user_id"
+                  v-model="scheduleForm.lineworks_user_ids"
+                  class="rounded border-gray-300"
+                />
+                {{ m.user_name || m.email || m.user_id }}
+              </label>
+              <p v-if="scheduleMembers.length === 0" class="text-sm text-gray-400">
+                LINE WORKS メンバーが取得できません
+              </p>
+            </div>
+          </UFormField>
+
+          <div class="flex justify-end gap-2">
+            <UButton label="キャンセル" variant="outline" @click="showScheduleModal = false" />
+            <UButton
+              label="予約"
+              :loading="scheduleSaving"
+              :disabled="!scheduleForm.scheduled_at || !scheduleForm.message.trim() || scheduleForm.lineworks_user_ids.length === 0"
+              @click="handleCreateSchedule"
+            />
+          </div>
+        </div>
+      </template>
+    </UModal>
 
     <UModal v-model:open="showDeleteModal">
       <template #content>

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -197,9 +197,9 @@ export interface LineworksMember {
   email: string | null
 }
 
-export const NOTIFICATION_EVENT_TYPES = [
+export const NOTIFICATION_EVENT_TYPES: { value: string; label: string }[] = [
   { value: 'trouble_created', label: 'チケット作成' },
   { value: 'trouble_status_changed', label: 'ステータス変更' },
   { value: 'trouble_comment_added', label: 'コメント追加' },
   { value: 'trouble_assigned', label: '担当者アサイン' },
-] as const
+]

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -144,3 +144,62 @@ export interface Employee {
 
 // Re-export generated types used by new components
 export type { CreateWorkflowState, CreateWorkflowTransition } from './generated'
+
+// --- Notification Prefs ---
+export interface TroubleNotificationPref {
+  id: string
+  tenant_id: string
+  event_type: string
+  notify_channel: string
+  enabled: boolean
+  recipient_ids: string[]
+  notify_admins: boolean
+  lineworks_user_ids: string[]
+  created_at: string
+  updated_at: string
+}
+
+export interface UpsertNotificationPref {
+  event_type: string
+  notify_channel: string
+  enabled?: boolean | null
+  recipient_ids?: string[] | null
+  notify_admins?: boolean | null
+  lineworks_user_ids?: string[] | null
+}
+
+// --- Schedules ---
+export interface TroubleSchedule {
+  id: string
+  tenant_id: string
+  ticket_id: string
+  scheduled_at: string
+  message: string
+  lineworks_user_ids: string[]
+  cloud_task_name: string | null
+  status: string
+  created_by: string | null
+  created_at: string
+  sent_at: string | null
+}
+
+export interface CreateTroubleSchedule {
+  ticket_id: string
+  scheduled_at: string
+  message: string
+  lineworks_user_ids: string[]
+}
+
+// --- LINE WORKS Members ---
+export interface LineworksMember {
+  user_id: string
+  user_name: string | null
+  email: string | null
+}
+
+export const NOTIFICATION_EVENT_TYPES = [
+  { value: 'trouble_created', label: 'チケット作成' },
+  { value: 'trouble_status_changed', label: 'ステータス変更' },
+  { value: 'trouble_comment_added', label: 'コメント追加' },
+  { value: 'trouble_assigned', label: '担当者アサイン' },
+] as const

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -19,6 +19,11 @@ import type {
   CreateWorkflowState,
   CreateWorkflowTransition,
   TransitionRequest,
+  TroubleNotificationPref,
+  UpsertNotificationPref,
+  LineworksMember,
+  TroubleSchedule,
+  CreateTroubleSchedule,
 } from '~/types'
 
 let apiBase = ''
@@ -303,4 +308,42 @@ export async function downloadFile(fileId: string): Promise<void> {
 
 export async function deleteFile(fileId: string): Promise<void> {
   await request<void>(`/api/trouble/files/${encodeURIComponent(fileId)}`, { method: 'DELETE' })
+}
+
+// --- Notification Prefs ---
+
+export async function getNotificationPrefs(): Promise<TroubleNotificationPref[]> {
+  return request<TroubleNotificationPref[]>('/api/trouble/notification-prefs')
+}
+
+export async function upsertNotificationPref(data: UpsertNotificationPref): Promise<TroubleNotificationPref> {
+  return request<TroubleNotificationPref>('/api/trouble/notification-prefs', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  })
+}
+
+export async function deleteNotificationPref(id: string): Promise<void> {
+  await request<void>(`/api/trouble/notification-prefs/${encodeURIComponent(id)}`, { method: 'DELETE' })
+}
+
+export async function getLineworksMembers(): Promise<LineworksMember[]> {
+  return request<LineworksMember[]>('/api/trouble/lineworks/members')
+}
+
+// --- Schedules ---
+
+export async function createSchedule(data: CreateTroubleSchedule): Promise<TroubleSchedule> {
+  return request<TroubleSchedule>('/api/trouble/schedules', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  })
+}
+
+export async function getTicketSchedules(ticketId: string): Promise<TroubleSchedule[]> {
+  return request<TroubleSchedule[]>(`/api/trouble/tickets/${encodeURIComponent(ticketId)}/schedules`)
+}
+
+export async function cancelSchedule(id: string): Promise<void> {
+  await request<void>(`/api/trouble/schedules/${encodeURIComponent(id)}`, { method: 'DELETE' })
 }


### PR DESCRIPTION
## Summary
- 通知設定ページ (`/settings`): イベント種別 × LINE WORKS メンバー選択で通知 CRUD
- チケット詳細にスケジュール通知セクション: 日時指定 + メッセージ + メンバー選択
- API 関数追加: notification prefs / schedules / LINE WORKS members
- サイドバーに「通知設定」リンク追加

## Test plan
- [ ] `/settings` で通知設定の追加/有効無効切替/削除
- [ ] チケット詳細でスケジュール通知の予約/キャンセル
- [ ] LINE WORKS Bot 未設定時の警告表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)