### PR TITLE
fix: use runtimeConfig for Bot setup link

### DIFF
--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -8,6 +8,7 @@ import {
   getNotificationPrefs, upsertNotificationPref, deleteNotificationPref, getLineworksMembers,
 } from '~/utils/api'
 
+const { authWorkerUrl } = useRuntimeConfig().public
 const activeTab = ref('categories')
 
 const tabs = [
@@ -323,7 +324,9 @@ onMounted(() => {
 
         <template v-else>
           <div v-if="notifMembers.length === 0" class="p-4 bg-yellow-50 dark:bg-yellow-950 text-yellow-700 dark:text-yellow-300 rounded-lg text-sm">
-            LINE WORKS Bot が未設定です。管理画面で Bot を設定してください。
+            LINE WORKS Bot が未設定です。
+            <a :href="`${authWorkerUrl}/admin/sso`" target="_blank" class="underline font-medium">管理画面</a>
+            で Bot を設定してください。
           </div>
 
           <div v-if="notifPrefs.length === 0" class="text-center py-8 text-gray-500">

--- a/tests/pages/settings.test.ts
+++ b/tests/pages/settings.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { allStubs } from '../helpers/nuxt-stubs'
 
+vi.stubGlobal('useRuntimeConfig', () => ({
+  public: { authWorkerUrl: 'https://auth.example.com' },
+}))
+
 vi.mock('~/utils/api', () => ({
   getCategories: vi.fn().mockResolvedValue([]),
   createCategory: vi.fn(),
@@ -15,6 +19,10 @@ vi.mock('~/utils/api', () => ({
   createProgressStatus: vi.fn(),
   deleteProgressStatus: vi.fn(),
   updateProgressStatusSortOrder: vi.fn(),
+  getNotificationPrefs: vi.fn().mockResolvedValue([]),
+  upsertNotificationPref: vi.fn(),
+  deleteNotificationPref: vi.fn(),
+  getLineworksMembers: vi.fn().mockResolvedValue([]),
 }))
 
 import SettingsPage from '~/pages/settings.vue'

--- a/tests/pages/settings.test.ts
+++ b/tests/pages/settings.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { allStubs } from '../helpers/nuxt-stubs'
 
-vi.stubGlobal('useRuntimeConfig', () => ({
-  public: { authWorkerUrl: 'https://auth.example.com' },
+vi.mock('#app/nuxt', () => ({
+  useRuntimeConfig: () => ({ public: { authWorkerUrl: 'https://auth.example.com' } }),
+  useNuxtApp: () => ({}),
 }))
 
 vi.mock('~/utils/api', () => ({


### PR DESCRIPTION
## Summary
- Bot未設定警告のリンクをハードコードURLから `authWorkerUrl` (runtimeConfig) に変更
- staging/本番で正しいURLにリンク (`/admin/sso`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)