### PR TITLE
feat: Excel一括登録機能

### DIFF
--- a/app/components/BulkImportModal.vue
+++ b/app/components/BulkImportModal.vue
@@ -1,0 +1,290 @@
+<script setup lang="ts">
+import { createTicket, getWorkflowStates, setupDefaultWorkflow } from '~/utils/api'
+import type { CreateTroubleTicket } from '~/types'
+import {
+  parseTsv,
+  buildColumnMappings,
+  rowsToTickets,
+  API_FIELD_OPTIONS,
+} from '~/utils/excel-import'
+import type { ColumnMapping } from '~/utils/excel-import'
+
+const open = defineModel<boolean>('open', { default: false })
+const emit = defineEmits<{ done: [] }>()
+
+const step = ref<1 | 2 | 3>(1)
+
+// Step 1
+const rawText = ref('')
+
+// Step 2
+const columns = ref<ColumnMapping[]>([])
+const rows = ref<string[][]>([])
+
+// Step 3
+const previewData = ref<{ ticket: Record<string, unknown>; warnings: string[]; selected: boolean }[]>([])
+const importing = ref(false)
+const importProgress = ref(0)
+const importResults = ref<{ success: number; failed: { row: number; error: string }[] } | null>(null)
+
+function reset() {
+  step.value = 1
+  rawText.value = ''
+  columns.value = []
+  rows.value = []
+  previewData.value = []
+  importing.value = false
+  importProgress.value = 0
+  importResults.value = null
+}
+
+function handleParse() {
+  const parsed = parseTsv(rawText.value)
+  if (parsed.rows.length === 0) return
+  rows.value = parsed.rows
+  columns.value = buildColumnMappings(parsed.headers, parsed.rows[0] ?? [])
+  step.value = 2
+}
+
+function handlePreview() {
+  const results = rowsToTickets(rows.value, columns.value)
+  previewData.value = results.map(r => ({ ...r, selected: true }))
+  step.value = 3
+}
+
+async function ensureWorkflow() {
+  const states = await getWorkflowStates()
+  if (states.length === 0) await setupDefaultWorkflow()
+}
+
+async function handleImport() {
+  const selected = previewData.value.filter(r => r.selected)
+  if (selected.length === 0) return
+
+  importing.value = true
+  importProgress.value = 0
+  const results = { success: 0, failed: [] as { row: number; error: string }[] }
+
+  try {
+    await ensureWorkflow()
+  } catch (e) {
+    console.error('Workflow setup failed:', e)
+  }
+
+  for (let i = 0; i < selected.length; i++) {
+    try {
+      await createTicket(selected[i]!.ticket as unknown as CreateTroubleTicket)
+      results.success++
+    } catch (e) {
+      results.failed.push({
+        row: i + 1,
+        error: e instanceof Error ? e.message : String(e),
+      })
+    }
+    importProgress.value = i + 1
+  }
+
+  importResults.value = results
+  importing.value = false
+
+  if (results.success > 0) emit('done')
+}
+
+function close() {
+  open.value = false
+  reset()
+}
+
+watch(open, (v) => { if (v) reset() })
+
+const selectedCount = computed(() => previewData.value.filter(r => r.selected).length)
+const totalCount = computed(() => previewData.value.length)
+const mappedFields = computed(() =>
+  columns.value.filter(c => c.apiField !== '__skip__'),
+)
+</script>
+
+<template>
+  <UModal v-model:open="open" :ui="{ content: 'max-w-5xl' }">
+    <template #content>
+      <div class="p-6 space-y-4">
+        <div class="flex items-center justify-between">
+          <h3 class="text-lg font-bold">
+            <template v-if="step === 1">一括登録 - 貼り付け</template>
+            <template v-else-if="step === 2">一括登録 - ヘッダーマッピング</template>
+            <template v-else>一括登録 - プレビュー</template>
+          </h3>
+          <UButton icon="i-lucide-x" variant="ghost" size="sm" @click="close" />
+        </div>
+
+        <!-- Step 1: Paste -->
+        <template v-if="step === 1">
+          <p class="text-sm text-gray-500">
+            Excelからコピーしたデータを貼り付けてください（ヘッダー行あり/なし両対応）
+          </p>
+          <textarea
+            v-model="rawText"
+            class="w-full h-48 p-3 border border-gray-300 dark:border-gray-600 rounded-lg font-mono text-sm bg-gray-50 dark:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-primary-500"
+            placeholder="Excelからコピーしたデータを Ctrl+V で貼り付け..."
+          />
+          <div class="flex justify-end gap-2">
+            <UButton label="キャンセル" variant="outline" @click="close" />
+            <UButton label="次へ" :disabled="!rawText.trim()" @click="handleParse" />
+          </div>
+        </template>
+
+        <!-- Step 2: Header Mapping -->
+        <template v-if="step === 2">
+          <p class="text-sm text-gray-500">
+            {{ rows.length }} 件のデータを検出。各列の対応フィールドを確認・変更してください。
+          </p>
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="border-b border-gray-200 dark:border-gray-700">
+                  <th class="text-left py-2 px-2 font-medium w-40">Excelヘッダー</th>
+                  <th class="text-left py-2 px-2 font-medium w-64">対応フィールド</th>
+                  <th class="text-left py-2 px-2 font-medium">サンプル値</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="(col, idx) in columns"
+                  :key="idx"
+                  class="border-b border-gray-100 dark:border-gray-800"
+                >
+                  <td class="py-2 px-2 font-mono text-xs">{{ col.excelHeader }}</td>
+                  <td class="py-2 px-2">
+                    <USelect
+                      v-model="col.apiField"
+                      :items="API_FIELD_OPTIONS"
+                      value-key="value"
+                      label-key="label"
+                      size="sm"
+                    />
+                  </td>
+                  <td class="py-2 px-2 text-gray-500 text-xs truncate max-w-xs">
+                    {{ col.sampleValue || '-' }}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="flex justify-between">
+            <UButton label="戻る" variant="outline" @click="step = 1" />
+            <UButton label="プレビュー" @click="handlePreview" />
+          </div>
+        </template>
+
+        <!-- Step 3: Preview & Import -->
+        <template v-if="step === 3">
+          <template v-if="importResults">
+            <div class="space-y-3">
+              <div
+                v-if="importResults.success > 0"
+                class="p-3 bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300 rounded-lg"
+              >
+                {{ importResults.success }} 件登録しました
+              </div>
+              <div
+                v-if="importResults.failed.length > 0"
+                class="p-3 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 rounded-lg space-y-1"
+              >
+                <p>{{ importResults.failed.length }} 件失敗:</p>
+                <ul class="text-xs list-disc list-inside">
+                  <li v-for="f in importResults.failed" :key="f.row">
+                    行{{ f.row }}: {{ f.error }}
+                  </li>
+                </ul>
+              </div>
+              <div class="flex justify-end">
+                <UButton label="閉じる" @click="close" />
+              </div>
+            </div>
+          </template>
+
+          <template v-else>
+            <p class="text-sm text-gray-500">
+              {{ selectedCount }} / {{ totalCount }} 件を登録します。チェックを外すと除外できます。
+            </p>
+
+            <div
+              v-if="previewData.some(r => r.warnings.length > 0)"
+              class="p-3 bg-yellow-50 dark:bg-yellow-900/20 text-yellow-700 dark:text-yellow-300 rounded-lg text-xs space-y-1"
+            >
+              <template v-for="(row, idx) in previewData" :key="idx">
+                <p v-for="w in row.warnings" :key="w">{{ w }}</p>
+              </template>
+            </div>
+
+            <div class="overflow-x-auto max-h-96">
+              <table class="w-full text-xs">
+                <thead class="sticky top-0 bg-white dark:bg-gray-900">
+                  <tr class="border-b border-gray-200 dark:border-gray-700">
+                    <th class="py-2 px-1 w-8">
+                      <input
+                        type="checkbox"
+                        :checked="selectedCount === totalCount"
+                        @change="previewData.forEach(r => r.selected = ($event.target as HTMLInputElement).checked)"
+                      >
+                    </th>
+                    <th class="text-left py-2 px-1">#</th>
+                    <th
+                      v-for="f in mappedFields"
+                      :key="f.apiField"
+                      class="text-left py-2 px-1 font-medium whitespace-nowrap"
+                    >
+                      {{ f.excelHeader }}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr
+                    v-for="(row, idx) in previewData"
+                    :key="idx"
+                    class="border-b border-gray-100 dark:border-gray-800"
+                    :class="{ 'opacity-40': !row.selected }"
+                  >
+                    <td class="py-1 px-1">
+                      <input v-model="row.selected" type="checkbox">
+                    </td>
+                    <td class="py-1 px-1 text-gray-400">{{ idx + 1 }}</td>
+                    <td
+                      v-for="f in mappedFields"
+                      :key="f.apiField"
+                      class="py-1 px-1 max-w-48 truncate"
+                    >
+                      {{ row.ticket[f.apiField] ?? '-' }}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div v-if="importing" class="space-y-2">
+              <div class="h-2 bg-gray-200 rounded-full overflow-hidden">
+                <div
+                  class="h-full bg-primary-500 transition-all"
+                  :style="{ width: `${(importProgress / selectedCount) * 100}%` }"
+                />
+              </div>
+              <p class="text-xs text-gray-500 text-center">
+                {{ importProgress }} / {{ selectedCount }} 件処理中...
+              </p>
+            </div>
+
+            <div class="flex justify-between">
+              <UButton label="戻る" variant="outline" :disabled="importing" @click="step = 2" />
+              <UButton
+                :label="`${selectedCount} 件を登録`"
+                :disabled="importing || selectedCount === 0"
+                :loading="importing"
+                @click="handleImport"
+              />
+            </div>
+          </template>
+        </template>
+      </div>
+    </template>
+  </UModal>
+</template>

--- a/app/pages/tickets/index.vue
+++ b/app/pages/tickets/index.vue
@@ -11,6 +11,12 @@ const {
   formatDate, navigateToTicket,
 } = useTicketList()
 
+const showBulkImport = ref(false)
+
+function handleBulkImportDone() {
+  fetchTickets()
+}
+
 onMounted(() => {
   loadStatusFilter()
   fetchTickets()
@@ -26,7 +32,10 @@ watch(() => ({ ...filter }), () => { fetchTickets() }, { deep: true })
     <!-- Header -->
     <div class="flex items-center justify-between">
       <h2 class="text-xl font-bold">チケット一覧</h2>
-      <UButton label="CSV出力" icon="i-lucide-download" variant="outline" size="sm" @click="handleExportCsv" />
+      <div class="flex gap-2">
+        <UButton label="CSV出力" icon="i-lucide-download" variant="outline" size="sm" @click="handleExportCsv" />
+        <UButton label="一括登録" icon="i-lucide-upload" variant="outline" size="sm" @click="showBulkImport = true" />
+      </div>
     </div>
 
     <!-- Filters: single row -->
@@ -197,6 +206,9 @@ watch(() => ({ ...filter }), () => { fetchTickets() }, { deep: true })
         <UPagination v-model="filter.page" :total="total" :items-per-page="filter.per_page || 20" />
       </div>
     </UCard>
+
+    <!-- Bulk import modal -->
+    <BulkImportModal v-model:open="showBulkImport" @done="handleBulkImportDone" />
 
     <!-- Delete modal -->
     <UModal v-model:open="showDeleteModal">

--- a/app/utils/excel-import.ts
+++ b/app/utils/excel-import.ts
@@ -1,0 +1,188 @@
+import { TICKET_CATEGORIES } from '~/types'
+
+/** API field options for header mapping dropdown */
+export const API_FIELD_OPTIONS: { value: string; label: string }[] = [
+  { value: '__skip__', label: 'スキップ' },
+  { value: 'category', label: 'カテゴリ (category)' },
+  { value: 'occurred_date', label: '発生日 (occurred_date)' },
+  { value: 'company_name', label: '会社名 (company_name)' },
+  { value: 'office_name', label: '営業所名 (office_name)' },
+  { value: 'department', label: '部署 (department)' },
+  { value: 'person_name', label: '氏名 (person_name)' },
+  { value: 'registration_number', label: '登録番号 (registration_number)' },
+  { value: 'vehicle_number', label: '車両番号 (vehicle_number)' },
+  { value: 'location', label: '場所 (location)' },
+  { value: 'description', label: '内容 (description)' },
+  { value: 'progress_notes', label: '進捗状況 (progress_notes)' },
+  { value: 'title', label: 'タイトル (title)' },
+  { value: 'allowance', label: '手当等 (allowance)' },
+  { value: 'damage_amount', label: '損害額 (damage_amount)' },
+  { value: 'compensation_amount', label: '補償額 (compensation_amount)' },
+  { value: 'confirmation_notice', label: '確認書 (confirmation_notice)' },
+  { value: 'disciplinary_content', label: '処分検討内容 (disciplinary_content)' },
+  { value: 'disciplinary_action', label: '処分内容 (disciplinary_action)' },
+  { value: 'road_service_cost', label: 'ロードサービス費 (road_service_cost)' },
+  { value: 'counterparty', label: '相手方 (counterparty)' },
+  { value: 'counterparty_insurance', label: '相手方保険 (counterparty_insurance)' },
+  { value: 'due_date', label: '対応期限 (due_date)' },
+] as const
+
+/** Known Excel header → API field mapping */
+const HEADER_MAP: Record<string, string> = {
+  '発生日': 'occurred_date',
+  '所属会社名': 'company_name',
+  '営業所名': 'office_name',
+  '運行課': 'department',
+  '当事者名': 'person_name',
+  '登録番号': 'registration_number',
+  '事故等分類': 'category',
+  '発生場所': 'location',
+  '内容': 'description',
+  '進捗状況': 'progress_notes',
+  '手当等': 'allowance',
+  '損害額': 'damage_amount',
+  '賠償額': 'compensation_amount',
+  '確認書': 'confirmation_notice',
+  '処分検討内容': 'disciplinary_content',
+  '処分内容': 'disciplinary_action',
+  'ロードサービス費用': 'road_service_cost',
+  '相手': 'counterparty',
+  '相手保険会社': 'counterparty_insurance',
+  // skip
+  'リンク': '__skip__',
+  'No.': '__skip__',
+  'No': '__skip__',
+  '発生時間': '__skip__',
+}
+
+const NUMERIC_FIELDS = new Set(['damage_amount', 'compensation_amount', 'road_service_cost'])
+const DATE_FIELDS = new Set(['occurred_date', 'due_date'])
+
+export interface ColumnMapping {
+  excelHeader: string
+  apiField: string
+  sampleValue: string
+}
+
+/** Parse TSV text (from Excel clipboard) */
+export function parseTsv(text: string): { headers: string[]; rows: string[][] } {
+  const lines = text.trim().split(/\r?\n/)
+  if (lines.length === 0) return { headers: [], rows: [] }
+
+  const allRows = lines.map(line => line.split('\t'))
+  const firstRow = allRows[0]
+  if (!firstRow) return { headers: [], rows: [] }
+
+  // Detect header row: check if first row contains known header keywords
+  const knownHeaders = Object.keys(HEADER_MAP)
+  const matchCount = firstRow.filter(cell =>
+    knownHeaders.some(h => cell.trim().includes(h)),
+  ).length
+
+  if (matchCount >= 3) {
+    return {
+      headers: firstRow.map(c => c.trim()),
+      rows: allRows.slice(1).filter(r => r.some(c => c.trim() !== '')),
+    }
+  }
+
+  // No header row detected — generate generic column names
+  const headers = firstRow.map((_, i) => `列${i + 1}`)
+  return {
+    headers,
+    rows: allRows.filter(r => r.some(c => c.trim() !== '')),
+  }
+}
+
+/** Auto-guess API field for a given Excel header */
+export function guessApiField(header: string): string {
+  const trimmed = header.trim()
+  if (HEADER_MAP[trimmed]) return HEADER_MAP[trimmed]
+
+  // Partial match
+  for (const [key, value] of Object.entries(HEADER_MAP)) {
+    if (trimmed.includes(key) || key.includes(trimmed)) return value
+  }
+
+  return '__skip__'
+}
+
+/** Build initial column mappings from parsed headers */
+export function buildColumnMappings(headers: string[], firstRow: string[]): ColumnMapping[] {
+  return headers.map((h, i) => ({
+    excelHeader: h,
+    apiField: guessApiField(h),
+    sampleValue: firstRow[i]?.trim() ?? '',
+  }))
+}
+
+/** Convert date string: YYYY/MM/DD or YYYY年MM月DD日 → YYYY-MM-DD */
+function convertDate(value: string): string | null {
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  // YYYY/MM/DD
+  const slash = trimmed.match(/^(\d{4})\/(\d{1,2})\/(\d{1,2})/)
+  if (slash && slash[1] && slash[2] && slash[3]) {
+    return `${slash[1]}-${slash[2].padStart(2, '0')}-${slash[3].padStart(2, '0')}`
+  }
+
+  // YYYY年MM月DD日
+  const jp = trimmed.match(/^(\d{4})年(\d{1,2})月(\d{1,2})日/)
+  if (jp && jp[1] && jp[2] && jp[3]) {
+    return `${jp[1]}-${jp[2].padStart(2, '0')}-${jp[3].padStart(2, '0')}`
+  }
+
+  // Already YYYY-MM-DD
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return trimmed
+
+  return null
+}
+
+/** Convert parsed rows to ticket payloads using column mappings */
+export function rowsToTickets(
+  rows: string[][],
+  columns: ColumnMapping[],
+): { ticket: Record<string, unknown>; warnings: string[] }[] {
+  const categories = TICKET_CATEGORIES as readonly string[]
+
+  return rows.map((row, rowIdx) => {
+    const ticket: Record<string, unknown> = {}
+    const warnings: string[] = []
+
+    for (let colIdx = 0; colIdx < columns.length; colIdx++) {
+      const mapping = columns[colIdx]!
+      const value = row[colIdx]?.trim() ?? ''
+      if (!value) continue
+
+      const field = mapping.apiField
+      if (field === '__skip__') continue
+
+      if (DATE_FIELDS.has(field)) {
+        const converted = convertDate(value)
+        if (!converted) {
+          warnings.push(`行${rowIdx + 1}: 日付変換失敗 "${value}"`)
+        }
+        ticket[field] = converted
+      } else if (NUMERIC_FIELDS.has(field)) {
+        const num = parseFloat(value.replace(/,/g, ''))
+        ticket[field] = isNaN(num) ? null : num
+      } else if (field === 'category') {
+        ticket[field] = value
+        if (!categories.includes(value)) {
+          warnings.push(`行${rowIdx + 1}: カテゴリ "${value}" は定義済みカテゴリに一致しません`)
+        }
+      } else {
+        ticket[field] = value
+      }
+    }
+
+    // Ensure category exists (required field)
+    if (!ticket.category) {
+      ticket.category = 'その他'
+      warnings.push(`行${rowIdx + 1}: カテゴリ未指定のため「その他」を設定`)
+    }
+
+    return { ticket, warnings }
+  })
+}


### PR DESCRIPTION
## Summary
- Excelからコピーしたデータ(TSV)を貼り付けて、トラブルチケットを一括登録する機能
- 3ステップウィザード: 貼り付け → ヘッダーマッピング編集 → プレビュー・登録
- ヘッダー自動検出、日付変換(YYYY/MM/DD→YYYY-MM-DD)、カテゴリ照合

## Test plan
- [ ] 「一括登録」ボタン表示確認
- [ ] Excelからコピペ → ヘッダー自動マッピング確認
- [ ] マッピングのドロップダウン変更が反映されること
- [ ] プレビューテーブルでチェック外し → 除外確認
- [ ] 登録ボタンでチケット作成 → 一覧に反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)