### PR TITLE
fix: TSVパーサーのクォート対応

### DIFF
--- a/app/components/BulkImportModal.vue
+++ b/app/components/BulkImportModal.vue
@@ -131,6 +131,19 @@ const totalCount = computed(() => previewData.value.length)
 const mappedFields = computed(() =>
   columns.value.filter(c => c.apiField !== '__skip__'),
 )
+
+async function copyDebug() {
+  try {
+    await navigator.clipboard.writeText(debugInfo.value)
+  } catch {
+    const ta = document.createElement('textarea')
+    ta.value = debugInfo.value
+    document.body.appendChild(ta)
+    ta.select()
+    document.execCommand('copy')
+    document.body.removeChild(ta)
+  }
+}
 </script>
 
 <template>
@@ -201,7 +214,10 @@ const mappedFields = computed(() =>
           </div>
           <details class="text-xs">
             <summary class="cursor-pointer text-gray-400 hover:text-gray-600">Debug</summary>
-            <pre class="mt-2 p-2 bg-gray-900 text-green-400 rounded overflow-auto max-h-48 text-[10px]">{{ debugInfo }}</pre>
+            <div class="mt-2 relative">
+              <button class="absolute top-1 right-1 px-2 py-0.5 text-[10px] bg-gray-700 text-gray-300 rounded hover:bg-gray-600" @click="copyDebug">Copy</button>
+              <pre class="p-2 bg-gray-900 text-green-400 rounded overflow-auto max-h-48 text-[10px]">{{ debugInfo }}</pre>
+            </div>
           </details>
 
           <div class="flex justify-between">

--- a/app/utils/excel-import.ts
+++ b/app/utils/excel-import.ts
@@ -52,7 +52,10 @@ const HEADER_MAP: Record<string, string> = {
   'リンク': '__skip__',
   'No.': '__skip__',
   'No': '__skip__',
+  '№': '__skip__',
   '発生時間': '__skip__',
+  '賞罰委員会内容': 'disciplinary_content',
+  '決定通知書': '__skip__',
 }
 
 const NUMERIC_FIELDS = new Set(['damage_amount', 'compensation_amount', 'road_service_cost'])
@@ -64,12 +67,15 @@ export interface ColumnMapping {
   sampleValue: string
 }
 
-/** Parse TSV text (from Excel clipboard) */
+/**
+ * Parse TSV text from Excel clipboard.
+ * Handles quoted fields with embedded newlines (RFC 4180 style).
+ * Excel wraps cells containing newlines in double quotes.
+ */
 export function parseTsv(text: string): { headers: string[]; rows: string[][] } {
-  const lines = text.trim().split(/\r?\n/)
-  if (lines.length === 0) return { headers: [], rows: [] }
+  const allRows = parseTsvQuoted(text.trim())
+  if (allRows.length === 0) return { headers: [], rows: [] }
 
-  const allRows = lines.map(line => line.split('\t'))
   const firstRow = allRows[0]
   if (!firstRow) return { headers: [], rows: [] }
 
@@ -92,6 +98,69 @@ export function parseTsv(text: string): { headers: string[]; rows: string[][] } 
     headers,
     rows: allRows.filter(r => r.some(c => c.trim() !== '')),
   }
+}
+
+/** Parse TSV handling double-quoted fields with embedded newlines */
+function parseTsvQuoted(text: string): string[][] {
+  const rows: string[][] = []
+  let currentRow: string[] = []
+  let currentField = ''
+  let inQuotes = false
+  let i = 0
+
+  while (i < text.length) {
+    const ch = text[i]
+
+    if (inQuotes) {
+      if (ch === '"') {
+        if (i + 1 < text.length && text[i + 1] === '"') {
+          currentField += '"'
+          i += 2
+        } else {
+          inQuotes = false
+          i++
+        }
+      } else {
+        currentField += ch
+        i++
+      }
+    } else {
+      if (ch === '"' && currentField === '') {
+        inQuotes = true
+        i++
+      } else if (ch === '\t') {
+        currentRow.push(currentField)
+        currentField = ''
+        i++
+      } else if (ch === '\n' || (ch === '\r' && i + 1 < text.length && text[i + 1] === '\n')) {
+        currentRow.push(currentField)
+        currentField = ''
+        if (currentRow.some(c => c.trim() !== '')) {
+          rows.push(currentRow)
+        }
+        currentRow = []
+        i += ch === '\r' ? 2 : 1
+      } else if (ch === '\r') {
+        currentRow.push(currentField)
+        currentField = ''
+        if (currentRow.some(c => c.trim() !== '')) {
+          rows.push(currentRow)
+        }
+        currentRow = []
+        i++
+      } else {
+        currentField += ch
+        i++
+      }
+    }
+  }
+
+  currentRow.push(currentField)
+  if (currentRow.some(c => c.trim() !== '')) {
+    rows.push(currentRow)
+  }
+
+  return rows
 }
 
 /** Auto-guess API field for a given Excel header */


### PR DESCRIPTION
## Summary
- Excelのセル内改行（ダブルクォート囲み）を正しくパースするRFC 4180準拠パーサーに置換
- デバッグパネルにCopyボタン追加
- ヘッダーマッピング追加: №, 賞罰委員会内容, 決定通知書

## Test plan
- [ ] セル内改行を含むExcelデータのコピペで行が分割されないこと
- [ ] 全列が正しくマッピングされること
- [ ] Debug → Copy でクリップボードにコピーされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)