### PR TITLE
fix: staging auth bypass (tenant_id 不一致修正)

### DIFF
--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -69,6 +69,12 @@ export function useAuth() {
       }
     }
 
+    // Staging auth bypass: JWT なしでも tenantId をセット
+    const stagingTid = config.public.stagingTenantId as string
+    if (stagingTid && !isAuthenticated.value) {
+      tenantId.value = stagingTid
+    }
+
     isLoading.value = false
   }
 

--- a/app/middleware/auth.global.ts
+++ b/app/middleware/auth.global.ts
@@ -2,10 +2,13 @@ export default defineNuxtRouteMiddleware((to) => {
   const publicPaths = ['/login', '/auth/callback']
   if (publicPaths.some(p => to.path.startsWith(p))) return
 
+  // Staging auth bypass
+  const config = useRuntimeConfig()
+  if (config.public.stagingTenantId) return
+
   const { isAuthenticated, isLoading } = useAuth()
   if (isLoading.value) return
   if (!isAuthenticated.value) {
-    const config = useRuntimeConfig()
     const authWorkerUrl = config.public.authWorkerUrl as string
     if (authWorkerUrl) {
       const callbackUrl = `${window.location.origin}/auth/callback`


### PR DESCRIPTION
## Summary
- staging で auth-worker の JWT tenant_id と Import データの tenant_id が不一致で 500 エラー
- `NUXT_PUBLIC_STAGING_TENANT_ID` 設定時に JWT なしで tenantId をセット（Import の `11111111-...` と一致）
- auth middleware も staging 時はログインリダイレクトをスキップ

## Test plan
- [ ] staging でログインなしでチケット一覧が表示されること
- [ ] Import → 一括登録 → チケット作成が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)