### PR TITLE
fix: staging tenant_id を常に上書き

### DIFF
--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -69,9 +69,9 @@ export function useAuth() {
       }
     }
 
-    // Staging auth bypass: JWT なしでも tenantId をセット
+    // Staging: 常に staging tenant_id を使用（JWT の tenant_id を上書き）
     const stagingTid = config.public.stagingTenantId as string
-    if (stagingTid && !isAuthenticated.value) {
+    if (stagingTid) {
       tenantId.value = stagingTid
     }
 


### PR DESCRIPTION
## Summary
- Google OAuth ログイン済みでも staging tenant_id (`11111111-...`) を強制使用
- JWT の tenant_id (auth-worker DB 由来) は staging DB に存在しないため FK 違反で 500 になっていた

## Test plan
- [ ] Import → 一括登録 → チケット作成が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)