### PR TITLE
fix: bump auth-client to 0.1.64-dev (provider redirect fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
-        "@ippoan/auth-client": "0.1.63-dev.d1607fd",
+        "@ippoan/auth-client": "0.1.64-dev.771681",
         "@nuxt/ui": "^4.5.1",
         "@nuxtjs/tailwindcss": "^6.14.0",
         "nuxt": "^4.3.1",
@@ -1619,9 +1619,9 @@
       "license": "MIT"
     },
     "node_modules/@ippoan/auth-client": {
-      "version": "0.1.63-dev.d1607fd",
-      "resolved": "https://npm.pkg.github.com/download/@ippoan/auth-client/0.1.63-dev.d1607fd/7cca08219c438e875f992f969af57c9c48996484",
-      "integrity": "sha512-Q6uzzFCjtcIFbmMLMu/JK96vOgcIv+wlDdWt17k8VkmxO4HrTgps3n251gKTiQgQnkVsW7Lo1A6IwQks7FnMww==",
+      "version": "0.1.64-dev.771681",
+      "resolved": "https://npm.pkg.github.com/download/@ippoan/auth-client/0.1.64-dev.771681/2d19d0295edc786f49b8fd33921cb99e8e5b95a2",
+      "integrity": "sha512-mVtIwK0whIKLI47eDpbWbNmWmCjaLFjnPcBjf9SES0pBpLJgYSspJg1Z+j5Ohp6ri2QpHjABjRPQRJlAD86j1g==",
       "dependencies": {
         "uqr": "^0.1.2"
       },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@ippoan/auth-client": "0.1.63-dev.d1607fd",
+    "@ippoan/auth-client": "0.1.64-dev.771681",
     "@nuxt/ui": "^4.5.1",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "nuxt": "^4.3.1",


### PR DESCRIPTION
## Summary
- auth-client を 0.1.64-dev に更新
- `redirectToLogin({ provider: 'google' })` が authWorkerUrl 設定時でも直接 Google OAuth にリダイレクトするよう修正 (ippoan/auth-worker#64)

## Test plan
- [ ] staging で Google ログインフロー確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)