### PR TITLE
fix: auto-redirect on login + auth-client OAuth path fix

### DIFF
--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -2,6 +2,14 @@
 definePageMeta({ layout: 'auth' })
 
 const { redirectToLogin } = useAuth()
+const config = useRuntimeConfig()
+
+onMounted(() => {
+  // auth-worker 設定時は自動でリダイレクト（ログインページを表示しない）
+  if (config.public.authWorkerUrl) {
+    redirectToLogin({ provider: 'google', callbackPath: '/auth/callback' })
+  }
+})
 </script>
 
 <template>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
-        "@ippoan/auth-client": "0.1.64-dev.771681",
+        "@ippoan/auth-client": "0.1.65-dev.9bf0838",
         "@nuxt/ui": "^4.5.1",
         "@nuxtjs/tailwindcss": "^6.14.0",
         "nuxt": "^4.3.1",
@@ -1619,9 +1619,9 @@
       "license": "MIT"
     },
     "node_modules/@ippoan/auth-client": {
-      "version": "0.1.64-dev.771681",
-      "resolved": "https://npm.pkg.github.com/download/@ippoan/auth-client/0.1.64-dev.771681/2d19d0295edc786f49b8fd33921cb99e8e5b95a2",
-      "integrity": "sha512-mVtIwK0whIKLI47eDpbWbNmWmCjaLFjnPcBjf9SES0pBpLJgYSspJg1Z+j5Ohp6ri2QpHjABjRPQRJlAD86j1g==",
+      "version": "0.1.65-dev.9bf0838",
+      "resolved": "https://npm.pkg.github.com/download/@ippoan/auth-client/0.1.65-dev.9bf0838/65fbea85546054da8658e3aa856c09e2d456a79f",
+      "integrity": "sha512-U5rn7LrtM0jlu1/ZIK3UrA/RV3sCxUAKq6bAgtk1luLXRVApa4oKUHESR1Scig65bsRW0xcTkHnDoUL8vhOygQ==",
       "dependencies": {
         "uqr": "^0.1.2"
       },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@ippoan/auth-client": "0.1.64-dev.771681",
+    "@ippoan/auth-client": "0.1.65-dev.9bf0838",
     "@nuxt/ui": "^4.5.1",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "nuxt": "^4.3.1",


### PR DESCRIPTION
## Summary
- login.vue: authWorkerUrl 設定時に自動で Google OAuth リダイレクト復元
- auth-client 0.1.65: OAuth パス `/api/auth/` → `/oauth/` 修正 (ippoan/auth-worker#65)

## Test plan
- [ ] staging で Google ログインフロー確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)