### PR TITLE
fix: remove consumeFragment from app init

### DIFF
--- a/app/composables/useAppInit.ts
+++ b/app/composables/useAppInit.ts
@@ -2,7 +2,7 @@ import { initApi } from '~/utils/api'
 
 export function useAppInit() {
   const config = useRuntimeConfig()
-  const { consumeFragment, loadFromStorage, token, orgId, isLoading, clearAuth } = useAuth()
+  const { loadFromStorage, token, orgId, isLoading, clearAuth } = useAuth()
   const apiBase = config.public.apiBase as string
   const stagingTenantId = (config.public.stagingTenantId as string) || ''
 
@@ -17,7 +17,6 @@ export function useAppInit() {
         navigateTo('/login')
       },
     )
-    consumeFragment()
     loadFromStorage()
   }
 

--- a/tests/composables/useAppInit.test.ts
+++ b/tests/composables/useAppInit.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const initApiMock = vi.fn()
-const consumeFragmentMock = vi.fn()
 const loadFromStorageMock = vi.fn()
 const clearAuthMock = vi.fn()
 
@@ -13,7 +12,6 @@ vi.mock('~/composables/useAuth', () => {
   const { ref } = require('vue')
   return {
     useAuth: () => ({
-      consumeFragment: consumeFragmentMock,
       loadFromStorage: loadFromStorageMock,
       clearAuth: clearAuthMock,
       token: ref('test-token'),
@@ -42,7 +40,6 @@ import { useAppInit } from '~/composables/useAppInit'
 describe('useAppInit', () => {
   beforeEach(() => {
     initApiMock.mockReset()
-    consumeFragmentMock.mockReset()
     loadFromStorageMock.mockReset()
     clearAuthMock.mockReset()
   })
@@ -53,7 +50,7 @@ describe('useAppInit', () => {
     expect(stagingTenantId).toBe('stg-tenant')
   })
 
-  it('setup calls initApi with correct args, consumeFragment, and loadFromStorage', async () => {
+  it('setup calls initApi and loadFromStorage', async () => {
     const { setup } = useAppInit()
     await setup()
 
@@ -64,10 +61,8 @@ describe('useAppInit', () => {
       expect.any(Function),
       expect.any(Function),
     )
-    expect(consumeFragmentMock).toHaveBeenCalled()
     expect(loadFromStorageMock).toHaveBeenCalled()
 
-    // Exercise the arrow function getters
     const tokenGetter = initApiMock.mock.calls[0][1]
     const orgIdGetter = initApiMock.mock.calls[0][3]
     expect(tokenGetter()).toBe('test-token')


### PR DESCRIPTION
## Summary
- `app.vue` の `onMounted` → `useAppInit.setup()` で `consumeFragment()` を呼んでいたため、callback ページより先に URL hash fragment が消費されていた
- callback.vue の `consumeFragment()` 実行時には hash が既に空 → 常に認証失敗

## Test plan
- [ ] staging で Google ログインフロー確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)