### PR TITLE
feat: task management UI with compact overview

### DIFF
--- a/app/components/TicketCompactOverview.vue
+++ b/app/components/TicketCompactOverview.vue
@@ -1,0 +1,117 @@
+<script setup lang="ts">
+import type { TroubleTicket, TroubleWorkflowState } from '~/types'
+
+const props = defineProps<{
+  ticket: TroubleTicket
+  workflowStates: TroubleWorkflowState[]
+}>()
+
+const expanded = ref(false)
+
+const locationLine = computed(() => {
+  const parts = [props.ticket.company_name, props.ticket.office_name].filter(Boolean)
+  const loc = props.ticket.location
+  if (parts.length === 0 && !loc) return null
+  let line = parts.join(' / ')
+  if (loc) line = line ? `${line} | ${loc}` : loc
+  return line
+})
+
+const moneyLine = computed(() => {
+  const items: string[] = []
+  if (props.ticket.damage_amount != null) {
+    items.push(`損害額: ${Number(props.ticket.damage_amount).toLocaleString()}円`)
+  }
+  if (props.ticket.compensation_amount != null) {
+    items.push(`補償額: ${Number(props.ticket.compensation_amount).toLocaleString()}円`)
+  }
+  if (props.ticket.road_service_cost != null) {
+    items.push(`ロードサービス: ${Number(props.ticket.road_service_cost).toLocaleString()}円`)
+  }
+  return items.length > 0 ? items.join(' / ') : null
+})
+
+const counterpartyLine = computed(() => {
+  if (!props.ticket.counterparty) return null
+  let line = props.ticket.counterparty
+  if (props.ticket.counterparty_insurance) {
+    line += ` (${props.ticket.counterparty_insurance})`
+  }
+  return line
+})
+
+const fields: Array<{ label: string; key: string }> = [
+  { label: 'カテゴリ', key: 'category' },
+  { label: 'タイトル', key: 'title' },
+  { label: '説明', key: 'description' },
+  { label: '発生日', key: 'occurred_date' },
+  { label: '会社名', key: 'company_name' },
+  { label: '営業所名', key: 'office_name' },
+  { label: '部署名', key: 'department' },
+  { label: '氏名', key: 'person_name' },
+  { label: '車両番号', key: 'vehicle_number' },
+  { label: '場所', key: 'location' },
+  { label: '損害額', key: 'damage_amount' },
+  { label: '補償額', key: 'compensation_amount' },
+  { label: 'ロードサービス費', key: 'road_service_cost' },
+  { label: '相手方', key: 'counterparty' },
+  { label: '相手方保険', key: 'counterparty_insurance' },
+  { label: '対応期限', key: 'due_date' },
+]
+
+function displayValue(key: string): string {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const val = (props.ticket as any)[key]
+  if (val == null || val === '') return '-'
+  if (key === 'due_date' || key === 'occurred_date') return String(val).substring(0, 10)
+  return String(val)
+}
+</script>
+
+<template>
+  <div class="space-y-1">
+    <!-- Line 1: person_name + occurred_date -->
+    <div class="flex items-center gap-2 text-sm">
+      <span v-if="ticket.person_name" class="font-medium">{{ ticket.person_name }}</span>
+      <span v-if="ticket.occurred_date" class="text-gray-500">
+        {{ ticket.occurred_date.substring(0, 10) }}
+      </span>
+    </div>
+
+    <!-- Line 2: company / office | location -->
+    <div v-if="locationLine" class="text-sm text-gray-600 dark:text-gray-400">
+      {{ locationLine }}
+    </div>
+
+    <!-- Line 3: money amounts -->
+    <div v-if="moneyLine" class="text-sm text-gray-600 dark:text-gray-400">
+      {{ moneyLine }}
+    </div>
+
+    <!-- Line 4: counterparty -->
+    <div v-if="counterpartyLine" class="text-sm text-gray-600 dark:text-gray-400">
+      {{ counterpartyLine }}
+    </div>
+
+    <!-- Toggle -->
+    <button
+      class="text-xs text-primary-500 hover:text-primary-600 mt-2 flex items-center gap-1"
+      @click="expanded = !expanded"
+    >
+      {{ expanded ? '閉じる' : '詳細を表示' }}
+      <UIcon :name="expanded ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" class="size-3" />
+    </button>
+
+    <!-- Expanded full grid -->
+    <dl v-if="expanded" class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
+      <div v-for="field in fields" :key="field.key" class="space-y-1">
+        <dt class="text-xs text-gray-500 dark:text-gray-400">{{ field.label }}</dt>
+        <dd class="text-sm">{{ displayValue(field.key) }}</dd>
+      </div>
+      <div class="space-y-1">
+        <dt class="text-xs text-gray-500 dark:text-gray-400">作成日</dt>
+        <dd class="text-sm">{{ ticket.created_at.substring(0, 10) }}</dd>
+      </div>
+    </dl>
+  </div>
+</template>

--- a/app/components/TicketTaskCard.vue
+++ b/app/components/TicketTaskCard.vue
@@ -1,0 +1,248 @@
+<script setup lang="ts">
+import type { TroubleTask, TroubleTaskActivity, TroubleActivityFile } from '~/types'
+import { TASK_STATUS_LABELS } from '~/types'
+import {
+  getActivities, createActivity, deleteActivity,
+  getActivityFiles, uploadActivityFile, downloadActivityFile, deleteActivityFile,
+} from '~/utils/api'
+
+const props = defineProps<{
+  task: TroubleTask
+}>()
+
+const emit = defineEmits<{
+  statusChange: [taskId: string, newStatus: string]
+  delete: [taskId: string]
+}>()
+
+const expanded = ref(false)
+const activities = ref<TroubleTaskActivity[]>([])
+const activityFiles = ref<Record<string, TroubleActivityFile[]>>({})
+const newActivityBody = ref('')
+const submittingActivity = ref(false)
+const loadingActivities = ref(false)
+
+const statusColor = computed(() => {
+  switch (props.task.status) {
+    case 'open': return '#9CA3AF'
+    case 'in_progress': return '#3B82F6'
+    case 'done': return '#10B981'
+    default: return '#9CA3AF'
+  }
+})
+
+const statusOptions = [
+  { label: TASK_STATUS_LABELS.open, value: 'open' },
+  { label: TASK_STATUS_LABELS.in_progress, value: 'in_progress' },
+  { label: TASK_STATUS_LABELS.done, value: 'done' },
+]
+
+const selectedStatus = ref(props.task.status)
+
+watch(() => props.task.status, (val) => {
+  selectedStatus.value = val
+})
+
+function handleStatusChange(newStatus: string) {
+  if (newStatus !== props.task.status) {
+    emit('statusChange', props.task.id, newStatus)
+  }
+}
+
+async function loadActivities() {
+  if (loadingActivities.value) return
+  loadingActivities.value = true
+  try {
+    activities.value = await getActivities(props.task.id)
+    // Load files for each activity
+    for (const act of activities.value) {
+      try {
+        activityFiles.value[act.id] = await getActivityFiles(act.id)
+      } catch {
+        activityFiles.value[act.id] = []
+      }
+    }
+  } catch (e) {
+    console.error('Failed to load activities:', e)
+  } finally {
+    loadingActivities.value = false
+  }
+}
+
+async function handleToggle() {
+  expanded.value = !expanded.value
+  if (expanded.value && activities.value.length === 0) {
+    await loadActivities()
+  }
+}
+
+async function handleAddActivity() {
+  if (!newActivityBody.value.trim()) return
+  submittingActivity.value = true
+  try {
+    await createActivity(props.task.id, { body: newActivityBody.value.trim() })
+    newActivityBody.value = ''
+    await loadActivities()
+  } catch (e) {
+    console.error('Failed to add activity:', e)
+  } finally {
+    submittingActivity.value = false
+  }
+}
+
+async function handleDeleteActivity(activityId: string) {
+  try {
+    await deleteActivity(activityId)
+    await loadActivities()
+  } catch (e) {
+    console.error('Failed to delete activity:', e)
+  }
+}
+
+async function handleFileUpload(activityId: string, event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+  try {
+    await uploadActivityFile(activityId, file)
+    activityFiles.value[activityId] = await getActivityFiles(activityId)
+  } catch (e) {
+    console.error('Failed to upload file:', e)
+  } finally {
+    input.value = ''
+  }
+}
+
+async function handleDownloadFile(fileId: string) {
+  try {
+    await downloadActivityFile(fileId)
+  } catch (e) {
+    console.error('Failed to download file:', e)
+  }
+}
+
+async function handleDeleteFile(activityId: string, fileId: string) {
+  try {
+    await deleteActivityFile(fileId)
+    activityFiles.value[activityId] = await getActivityFiles(activityId)
+  } catch (e) {
+    console.error('Failed to delete file:', e)
+  }
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleString('ja-JP')
+}
+</script>
+
+<template>
+  <div class="border border-gray-200 dark:border-gray-700 rounded-lg">
+    <!-- Header -->
+    <div class="flex items-center gap-2 p-3 cursor-pointer" @click="handleToggle">
+      <UIcon
+        :name="expanded ? 'i-lucide-chevron-down' : 'i-lucide-chevron-right'"
+        class="size-4 text-gray-400 shrink-0"
+      />
+      <span class="text-sm font-medium flex-1 truncate">{{ task.title }}</span>
+      <UBadge
+        :style="{ backgroundColor: statusColor + '20', color: statusColor }"
+        variant="subtle"
+        size="xs"
+      >
+        {{ TASK_STATUS_LABELS[task.status as keyof typeof TASK_STATUS_LABELS] || task.status }}
+      </UBadge>
+      <USelect
+        v-model="selectedStatus"
+        :items="statusOptions"
+        size="xs"
+        class="w-24"
+        @update:model-value="handleStatusChange"
+        @click.stop
+      />
+      <UButton
+        icon="i-lucide-trash-2"
+        variant="ghost"
+        color="error"
+        size="xs"
+        @click.stop="emit('delete', task.id)"
+      />
+    </div>
+
+    <!-- Expanded content -->
+    <div v-if="expanded" class="border-t border-gray-200 dark:border-gray-700 p-3 space-y-3">
+      <div v-if="loadingActivities" class="flex justify-center py-4">
+        <UIcon name="i-lucide-loader-circle" class="animate-spin size-5 text-gray-400" />
+      </div>
+
+      <template v-else>
+        <!-- Activities timeline -->
+        <div v-if="activities.length === 0" class="text-sm text-gray-500 text-center py-2">
+          活動記録はありません
+        </div>
+
+        <div v-else class="space-y-3">
+          <div
+            v-for="activity in activities"
+            :key="activity.id"
+            class="relative pl-4 border-l-2 border-gray-200 dark:border-gray-600"
+          >
+            <div class="flex items-start justify-between gap-2">
+              <div class="space-y-1 flex-1">
+                <div class="text-xs text-gray-400">{{ formatDate(activity.occurred_at) }}</div>
+                <p class="text-sm">{{ activity.body }}</p>
+
+                <!-- Files for this activity -->
+                <div v-if="activityFiles[activity.id]?.length" class="flex flex-wrap gap-1 mt-1">
+                  <div
+                    v-for="f in activityFiles[activity.id]"
+                    :key="f.id"
+                    class="flex items-center gap-1 text-xs bg-gray-100 dark:bg-gray-800 rounded px-2 py-1"
+                  >
+                    <UIcon name="i-lucide-paperclip" class="size-3" />
+                    <button class="hover:underline text-primary-500" @click="handleDownloadFile(f.id)">
+                      {{ f.filename }}
+                    </button>
+                    <button class="text-red-400 hover:text-red-600 ml-1" @click="handleDeleteFile(activity.id, f.id)">
+                      <UIcon name="i-lucide-x" class="size-3" />
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="flex items-center gap-1 shrink-0">
+                <label class="cursor-pointer">
+                  <UIcon name="i-lucide-upload" class="size-4 text-gray-400 hover:text-gray-600" />
+                  <input type="file" class="hidden" @change="handleFileUpload(activity.id, $event)" />
+                </label>
+                <UButton
+                  icon="i-lucide-trash-2"
+                  variant="ghost"
+                  color="error"
+                  size="xs"
+                  @click="handleDeleteActivity(activity.id)"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Add activity form -->
+        <div class="flex gap-2 pt-2 border-t border-gray-100 dark:border-gray-700">
+          <UInput
+            v-model="newActivityBody"
+            placeholder="活動を記録..."
+            size="sm"
+            class="flex-1"
+            @keydown.enter="handleAddActivity"
+          />
+          <UButton
+            label="追加"
+            size="sm"
+            :loading="submittingActivity"
+            :disabled="!newActivityBody.trim()"
+            @click="handleAddActivity"
+          />
+        </div>
+      </template>
+    </div>
+  </div>
+</template>

--- a/app/components/TicketTaskList.vue
+++ b/app/components/TicketTaskList.vue
@@ -1,0 +1,178 @@
+<script setup lang="ts">
+import type { TroubleTask, TroubleWorkflowState } from '~/types'
+import { TASK_TYPES, TASK_STATUS_LABELS } from '~/types'
+import { getTasks, createTask, updateTask, deleteTask } from '~/utils/api'
+
+const props = defineProps<{
+  ticketId: string
+  workflowStates: TroubleWorkflowState[]
+  currentStatusId: string | null
+}>()
+
+const emit = defineEmits<{
+  suggestTransition: [toStateId: string, message: string]
+}>()
+
+const tasks = ref<TroubleTask[]>([])
+const loading = ref(false)
+const newTaskType = ref(TASK_TYPES[0]!.value)
+const newTaskTitle = ref('')
+const adding = ref(false)
+
+const groupedTasks = computed(() => {
+  const groups: Record<string, TroubleTask[]> = {}
+  for (const task of tasks.value) {
+    if (!groups[task.task_type]) groups[task.task_type] = []
+    groups[task.task_type]!.push(task)
+  }
+  return groups
+})
+
+const completionCount = computed(() => {
+  const total = tasks.value.length
+  const done = tasks.value.filter(t => t.status === 'done').length
+  return { total, done }
+})
+
+function taskTypeLabel(value: string): string {
+  return TASK_TYPES.find(t => t.value === value)?.label || value
+}
+
+async function loadTasks() {
+  loading.value = true
+  try {
+    tasks.value = await getTasks(props.ticketId)
+    checkSuggestions()
+  } catch (e) {
+    console.error('Failed to load tasks:', e)
+  } finally {
+    loading.value = false
+  }
+}
+
+function checkSuggestions() {
+  if (tasks.value.length === 0) return
+
+  const allDone = tasks.value.every(t => t.status === 'done')
+  const anyInProgress = tasks.value.some(t => t.status === 'in_progress')
+
+  if (allDone) {
+    // Suggest transitioning to terminal state
+    const terminalState = props.workflowStates.find(s => s.is_terminal)
+    if (terminalState && props.currentStatusId !== terminalState.id) {
+      emit('suggestTransition', terminalState.id, '全てのタスクが完了しました。ステータスを変更しますか？')
+    }
+  } else if (anyInProgress) {
+    // Suggest transitioning to "対応中" state (non-initial, non-terminal)
+    const inProgressState = props.workflowStates.find(
+      s => !s.is_initial && !s.is_terminal && s.label.includes('対応中'),
+    )
+    if (inProgressState && props.currentStatusId !== inProgressState.id) {
+      emit('suggestTransition', inProgressState.id, 'タスクが進行中です。ステータスを「対応中」に変更しますか？')
+    }
+  }
+}
+
+async function handleAddTask() {
+  if (!newTaskTitle.value.trim()) return
+  adding.value = true
+  try {
+    await createTask(props.ticketId, {
+      task_type: newTaskType.value,
+      title: newTaskTitle.value.trim(),
+    })
+    newTaskTitle.value = ''
+    await loadTasks()
+  } catch (e) {
+    console.error('Failed to add task:', e)
+  } finally {
+    adding.value = false
+  }
+}
+
+async function handleStatusChange(taskId: string, newStatus: string) {
+  try {
+    await updateTask(taskId, { status: newStatus })
+    await loadTasks()
+  } catch (e) {
+    console.error('Failed to update task status:', e)
+  }
+}
+
+async function handleDeleteTask(taskId: string) {
+  try {
+    await deleteTask(taskId)
+    await loadTasks()
+  } catch (e) {
+    console.error('Failed to delete task:', e)
+  }
+}
+
+onMounted(loadTasks)
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center justify-between mb-4">
+      <div class="flex items-center gap-2">
+        <h3 class="text-base font-semibold">タスク</h3>
+        <UBadge v-if="tasks.length > 0" variant="subtle" size="xs">
+          {{ completionCount.done }}/{{ completionCount.total }} 完了
+        </UBadge>
+      </div>
+    </div>
+
+    <div v-if="loading" class="flex justify-center py-4">
+      <UIcon name="i-lucide-loader-circle" class="animate-spin size-5 text-gray-400" />
+    </div>
+
+    <template v-else>
+      <!-- Grouped task list -->
+      <div v-if="tasks.length === 0" class="text-sm text-gray-500 text-center py-4">
+        タスクはありません
+      </div>
+
+      <div v-else class="space-y-4">
+        <div v-for="(groupTasks, type) in groupedTasks" :key="type">
+          <h4 class="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase">
+            {{ taskTypeLabel(type) }}
+          </h4>
+          <div class="space-y-2">
+            <TicketTaskCard
+              v-for="task in groupTasks"
+              :key="task.id"
+              :task="task"
+              @status-change="handleStatusChange"
+              @delete="handleDeleteTask"
+            />
+          </div>
+        </div>
+      </div>
+
+      <!-- Add task form -->
+      <div class="flex gap-2 mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+        <USelect
+          v-model="newTaskType"
+          :items="TASK_TYPES"
+          size="sm"
+          class="w-32"
+        />
+        <UInput
+          v-model="newTaskTitle"
+          placeholder="タスクを追加..."
+          size="sm"
+          class="flex-1"
+          @keydown.enter="handleAddTask"
+        />
+        <UButton
+          label="追加"
+          icon="i-lucide-plus"
+          size="sm"
+          :loading="adding"
+          :disabled="!newTaskTitle.trim()"
+          @click="handleAddTask"
+        />
+      </div>
+    </template>
+  </div>
+</template>

--- a/app/pages/tickets/[id].vue
+++ b/app/pages/tickets/[id].vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { TroubleCategory, TroubleOffice, TroubleProgressStatus, Employee, TroubleSchedule, LineworksMember } from '~/types'
-import { getCategories, getOffices, getProgressStatuses, getEmployees, getTicketSchedules, createSchedule, cancelSchedule, getLineworksMembers } from '~/utils/api'
+import { getCategories, getOffices, getProgressStatuses, getEmployees, getTicketSchedules, createSchedule, cancelSchedule, getLineworksMembers, transitionTicket } from '~/utils/api'
 
 const route = useRoute()
 const ticketId = route.params.id as string
@@ -64,6 +64,27 @@ async function handleCancelSchedule(id: string) {
     await loadSchedules()
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'キャンセルに失敗しました'
+  }
+}
+
+// --- Task suggestion ---
+const suggestedTransition = ref<{ toStateId: string; message: string } | null>(null)
+
+function handleTransitionSuggestion(toStateId: string, message: string) {
+  suggestedTransition.value = { toStateId, message }
+}
+
+async function handleSuggestedTransition() {
+  if (!suggestedTransition.value) return
+  try {
+    await transitionTicket(ticketId, {
+      to_state_id: suggestedTransition.value.toStateId,
+      comment: null,
+    })
+    suggestedTransition.value = null
+    await load()
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'ステータス変更に失敗しました'
   }
 }
 
@@ -135,20 +156,7 @@ onMounted(() => {
       </UCard>
 
       <UCard v-else>
-        <dl class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div v-for="field in fields" :key="field.key" class="space-y-1">
-            <dt class="text-xs text-gray-500 dark:text-gray-400">{{ field.label }}</dt>
-            <dd class="text-sm">{{ displayValue(field.key) }}</dd>
-          </div>
-          <div class="space-y-1">
-            <dt class="text-xs text-gray-500 dark:text-gray-400">対応期限</dt>
-            <dd class="text-sm">{{ ticket.due_date ? ticket.due_date.substring(0, 10) : '-' }}</dd>
-          </div>
-          <div class="space-y-1">
-            <dt class="text-xs text-gray-500 dark:text-gray-400">作成日</dt>
-            <dd class="text-sm">{{ ticket.created_at.substring(0, 10) }}</dd>
-          </div>
-        </dl>
+        <TicketCompactOverview :ticket="ticket" :workflow-states="workflowStates" />
       </UCard>
 
       <!-- Status Transition -->
@@ -158,6 +166,28 @@ onMounted(() => {
           :current-status-id="ticket.status_id"
           :workflow-states="workflowStates"
           @transitioned="load"
+        />
+      </UCard>
+
+      <!-- Task suggestion banner -->
+      <div
+        v-if="suggestedTransition"
+        class="flex items-center justify-between p-3 bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg"
+      >
+        <span class="text-sm text-blue-700 dark:text-blue-300">{{ suggestedTransition.message }}</span>
+        <div class="flex gap-2">
+          <UButton label="変更する" size="xs" @click="handleSuggestedTransition" />
+          <UButton label="閉じる" size="xs" variant="outline" @click="suggestedTransition = null" />
+        </div>
+      </div>
+
+      <!-- Tasks -->
+      <UCard>
+        <TicketTaskList
+          :ticket-id="ticketId"
+          :workflow-states="workflowStates"
+          :current-status-id="ticket.status_id"
+          @suggest-transition="handleTransitionSuggestion"
         />
       </UCard>
 

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -197,6 +197,85 @@ export interface LineworksMember {
   email: string | null
 }
 
+// --- Tasks ---
+export interface TroubleTask {
+  id: string
+  tenant_id: string
+  ticket_id: string
+  task_type: string
+  title: string
+  description: string | null
+  status: string
+  assigned_to: string | null
+  due_date: string | null
+  completed_at: string | null
+  sort_order: number
+  created_by: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface CreateTroubleTask {
+  task_type: string
+  title: string
+  description?: string | null
+  assigned_to?: string | null
+  due_date?: string | null
+  sort_order?: number | null
+}
+
+export interface UpdateTroubleTask {
+  task_type?: string | null
+  title?: string | null
+  description?: string | null
+  status?: string | null
+  assigned_to?: string | null
+  due_date?: string | null
+  completed_at?: string | null
+  sort_order?: number | null
+}
+
+export interface TroubleTaskActivity {
+  id: string
+  tenant_id: string
+  task_id: string
+  body: string
+  occurred_at: string
+  created_by: string | null
+  created_at: string
+}
+
+export interface CreateTroubleTaskActivity {
+  body: string
+  occurred_at?: string | null
+}
+
+export interface TroubleActivityFile {
+  id: string
+  tenant_id: string
+  activity_id: string
+  filename: string
+  content_type: string
+  size_bytes: number
+  storage_key: string
+  created_at: string
+}
+
+export const TASK_TYPES: { value: string; label: string }[] = [
+  { value: 'investigation', label: '調査' },
+  { value: 'repair', label: '修理' },
+  { value: 'negotiation', label: '交渉' },
+  { value: 'documentation', label: '書類作成' },
+  { value: 'insurance', label: '保険対応' },
+  { value: 'other', label: 'その他' },
+]
+
+export const TASK_STATUS_LABELS: Record<string, string> = {
+  open: '未着手',
+  in_progress: '対応中',
+  done: '完了',
+}
+
 export const NOTIFICATION_EVENT_TYPES: { value: string; label: string }[] = [
   { value: 'trouble_created', label: 'チケット作成' },
   { value: 'trouble_status_changed', label: 'ステータス変更' },

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -24,6 +24,12 @@ import type {
   LineworksMember,
   TroubleSchedule,
   CreateTroubleSchedule,
+  TroubleTask,
+  CreateTroubleTask,
+  UpdateTroubleTask,
+  TroubleTaskActivity,
+  CreateTroubleTaskActivity,
+  TroubleActivityFile,
 } from '~/types'
 
 let apiBase = ''
@@ -361,4 +367,79 @@ export async function getTicketSchedules(ticketId: string): Promise<TroubleSched
 
 export async function cancelSchedule(id: string): Promise<void> {
   await request<void>(`/api/trouble/schedules/${encodeURIComponent(id)}`, { method: 'DELETE' })
+}
+
+// --- Tasks ---
+
+export async function getTasks(ticketId: string): Promise<TroubleTask[]> {
+  return request<TroubleTask[]>(`/api/trouble/tickets/${encodeURIComponent(ticketId)}/tasks`)
+}
+
+export async function createTask(ticketId: string, data: CreateTroubleTask): Promise<TroubleTask> {
+  return request<TroubleTask>(`/api/trouble/tickets/${encodeURIComponent(ticketId)}/tasks`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  })
+}
+
+export async function updateTask(taskId: string, data: UpdateTroubleTask): Promise<TroubleTask> {
+  return request<TroubleTask>(`/api/trouble/tasks/${encodeURIComponent(taskId)}`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  })
+}
+
+export async function deleteTask(taskId: string): Promise<void> {
+  await request<void>(`/api/trouble/tasks/${encodeURIComponent(taskId)}`, { method: 'DELETE' })
+}
+
+// --- Task Activities ---
+
+export async function getActivities(taskId: string): Promise<TroubleTaskActivity[]> {
+  return request<TroubleTaskActivity[]>(`/api/trouble/tasks/${encodeURIComponent(taskId)}/activities`)
+}
+
+export async function createActivity(taskId: string, data: CreateTroubleTaskActivity): Promise<TroubleTaskActivity> {
+  return request<TroubleTaskActivity>(`/api/trouble/tasks/${encodeURIComponent(taskId)}/activities`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  })
+}
+
+export async function deleteActivity(activityId: string): Promise<void> {
+  await request<void>(`/api/trouble/activities/${encodeURIComponent(activityId)}`, { method: 'DELETE' })
+}
+
+// --- Activity Files ---
+
+export async function getActivityFiles(activityId: string): Promise<TroubleActivityFile[]> {
+  return request<TroubleActivityFile[]>(`/api/trouble/activities/${encodeURIComponent(activityId)}/files`)
+}
+
+export async function uploadActivityFile(activityId: string, file: File): Promise<TroubleActivityFile> {
+  const formData = new FormData()
+  formData.append('file', file)
+  return request<TroubleActivityFile>(`/api/trouble/activities/${encodeURIComponent(activityId)}/files`, {
+    method: 'POST',
+    body: formData,
+  })
+}
+
+export async function downloadActivityFile(fileId: string): Promise<void> {
+  const headers = buildAuthHeaders()
+  const res = await fetch(`${apiBase}/api/trouble/activity-files/${encodeURIComponent(fileId)}/download`, { headers })
+  if (!res.ok) throw new Error(`ダウンロード失敗: ${res.status}`)
+  const blob = await res.blob()
+  const disposition = res.headers.get('Content-Disposition')
+  const filename = disposition?.match(/filename="?(.+?)"?$/)?.[1] || 'download'
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+export async function deleteActivityFile(fileId: string): Promise<void> {
+  await request<void>(`/api/trouble/activity-files/${encodeURIComponent(fileId)}`, { method: 'DELETE' })
 }


### PR DESCRIPTION
## Summary
- TicketCompactOverview: 概要を1-4行にコンパクト化（展開トグル付き）
- TicketTaskList: タスク一覧（task_type グルーピング、完了カウンター）
- TicketTaskCard: 個別タスク（アクティビティタイムライン、ファイル添付）
- ステータス遷移サジェスト（案C）: 全タスク完了時に完了遷移を提案

## Test plan
- [ ] タスク追加（タイプ選択、タイトル入力）
- [ ] タスクステータス変更（未着手→進行中→完了）
- [ ] アクティビティ追加・削除
- [ ] アクティビティへのファイル添付
- [ ] 概要コンパクト表示 + 展開トグル

🤖 Generated with [Claude Code](https://claude.com/claude-code)