### PR TITLE
feat: task type master data management

### DIFF
--- a/app/components/TicketTaskCard.vue
+++ b/app/components/TicketTaskCard.vue
@@ -32,9 +32,9 @@ const statusColor = computed(() => {
 })
 
 const statusOptions = [
-  { label: TASK_STATUS_LABELS.open, value: 'open' },
-  { label: TASK_STATUS_LABELS.in_progress, value: 'in_progress' },
-  { label: TASK_STATUS_LABELS.done, value: 'done' },
+  { label: TASK_STATUS_LABELS.open.label, value: 'open' },
+  { label: TASK_STATUS_LABELS.in_progress.label, value: 'in_progress' },
+  { label: TASK_STATUS_LABELS.done.label, value: 'done' },
 ]
 
 const selectedStatus = ref(props.task.status)
@@ -149,7 +149,7 @@ function formatDate(dateStr: string): string {
         variant="subtle"
         size="xs"
       >
-        {{ TASK_STATUS_LABELS[task.status as keyof typeof TASK_STATUS_LABELS] || task.status }}
+        {{ TASK_STATUS_LABELS[task.status]?.label || task.status }}
       </UBadge>
       <USelect
         v-model="selectedStatus"

--- a/app/components/TicketTaskCard.vue
+++ b/app/components/TicketTaskCard.vue
@@ -32,9 +32,9 @@ const statusColor = computed(() => {
 })
 
 const statusOptions = [
-  { label: TASK_STATUS_LABELS.open.label, value: 'open' },
-  { label: TASK_STATUS_LABELS.in_progress.label, value: 'in_progress' },
-  { label: TASK_STATUS_LABELS.done.label, value: 'done' },
+  { label: TASK_STATUS_LABELS['open']!.label, value: 'open' },
+  { label: TASK_STATUS_LABELS['in_progress']!.label, value: 'in_progress' },
+  { label: TASK_STATUS_LABELS['done']!.label, value: 'done' },
 ]
 
 const selectedStatus = ref(props.task.status)

--- a/app/components/TicketTaskList.vue
+++ b/app/components/TicketTaskList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { TroubleTask, TroubleWorkflowState } from '~/types'
-import { TASK_TYPES, TASK_STATUS_LABELS } from '~/types'
-import { getTasks, createTask, updateTask, deleteTask } from '~/utils/api'
+import { DEFAULT_TASK_TYPES, TASK_STATUS_LABELS } from '~/types'
+import { getTasks, getTaskTypes, createTask, updateTask, deleteTask } from '~/utils/api'
 
 const props = defineProps<{
   ticketId: string
@@ -15,9 +15,22 @@ const emit = defineEmits<{
 
 const tasks = ref<TroubleTask[]>([])
 const loading = ref(false)
-const newTaskType = ref(TASK_TYPES[0]!.value)
+const taskTypes = ref<string[]>([])
+const newTaskType = ref('')
 const newTaskTitle = ref('')
 const adding = ref(false)
+
+async function fetchTaskTypes() {
+  try {
+    const types = await getTaskTypes()
+    taskTypes.value = types.map(t => t.name)
+  } catch {
+    taskTypes.value = [...DEFAULT_TASK_TYPES]
+  }
+  if (taskTypes.value.length > 0 && !newTaskType.value) {
+    newTaskType.value = taskTypes.value[0]!
+  }
+}
 
 const groupedTasks = computed(() => {
   const groups: Record<string, TroubleTask[]> = {}
@@ -35,7 +48,7 @@ const completionCount = computed(() => {
 })
 
 function taskTypeLabel(value: string): string {
-  return TASK_TYPES.find(t => t.value === value)?.label || value
+  return value || 'その他'
 }
 
 async function loadTasks() {
@@ -108,7 +121,10 @@ async function handleDeleteTask(taskId: string) {
   }
 }
 
-onMounted(loadTasks)
+onMounted(() => {
+  fetchTaskTypes()
+  loadTasks()
+})
 </script>
 
 <template>
@@ -153,7 +169,7 @@ onMounted(loadTasks)
       <div class="flex gap-2 mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
         <USelect
           v-model="newTaskType"
-          :items="TASK_TYPES"
+          :items="taskTypes"
           size="sm"
           class="w-32"
         />

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import type { TroubleCategory, TroubleOffice, TroubleProgressStatus, TroubleNotificationPref, LineworksMember } from '~/types'
-import { TICKET_CATEGORIES, NOTIFICATION_EVENT_TYPES } from '~/types'
+import type { TroubleCategory, TroubleOffice, TroubleProgressStatus, TroubleNotificationPref, LineworksMember, TroubleTaskType } from '~/types'
+import { TICKET_CATEGORIES, DEFAULT_TASK_TYPES, NOTIFICATION_EVENT_TYPES } from '~/types'
 import {
   getCategories, createCategory, deleteCategory, updateCategorySortOrder,
   getOffices, createOffice, deleteOffice, updateOfficeSortOrder,
   getProgressStatuses, createProgressStatus, deleteProgressStatus, updateProgressStatusSortOrder,
+  getTaskTypes, createTaskType, deleteTaskType, updateTaskTypeSortOrder,
   getNotificationPrefs, upsertNotificationPref, deleteNotificationPref, getLineworksMembers,
 } from '~/utils/api'
 
@@ -13,6 +14,7 @@ const activeTab = ref('categories')
 
 const tabs = [
   { label: 'カテゴリ', value: 'categories' },
+  { label: 'タスクタイプ', value: 'taskTypes' },
   { label: '営業所', value: 'offices' },
   { label: '進捗状況', value: 'progress' },
   { label: 'ワークフロー', value: 'workflow' },
@@ -59,6 +61,49 @@ async function handleReorderCategory(id: string, sortOrder: number) {
     if (idx >= 0) categories.value[idx] = updated
   } catch (e) {
     console.error('カテゴリ順序変更エラー:', e)
+  }
+}
+
+// Task Types
+const taskTypes = ref<TroubleTaskType[]>([])
+const taskTypesLoading = ref(false)
+
+async function fetchTaskTypes() {
+  taskTypesLoading.value = true
+  try {
+    taskTypes.value = await getTaskTypes()
+  } catch (e) {
+    console.error('タスクタイプ取得エラー:', e)
+  } finally {
+    taskTypesLoading.value = false
+  }
+}
+
+async function handleCreateTaskType(name: string) {
+  try {
+    const created = await createTaskType({ name })
+    taskTypes.value = [...taskTypes.value, created]
+  } catch (e) {
+    console.error('タスクタイプ作成エラー:', e)
+  }
+}
+
+async function handleDeleteTaskType(id: string) {
+  try {
+    await deleteTaskType(id)
+    taskTypes.value = taskTypes.value.filter(t => t.id !== id)
+  } catch (e) {
+    console.error('タスクタイプ削除エラー:', e)
+  }
+}
+
+async function handleReorderTaskType(id: string, sortOrder: number) {
+  try {
+    const updated = await updateTaskTypeSortOrder(id, sortOrder)
+    const idx = taskTypes.value.findIndex(t => t.id === id)
+    if (idx >= 0) taskTypes.value[idx] = updated
+  } catch (e) {
+    console.error('タスクタイプ順序変更エラー:', e)
   }
 }
 
@@ -243,6 +288,7 @@ const notifMemberOptions = computed(() =>
 
 onMounted(() => {
   fetchCategories()
+  fetchTaskTypes()
   fetchOffices()
   fetchProgressStatuses()
   fetchNotifications()
@@ -277,6 +323,17 @@ onMounted(() => {
         @create="handleCreateCategory"
         @delete="handleDeleteCategory"
         @reorder="handleReorderCategory"
+      />
+
+      <MasterDataManager
+        v-if="activeTab === 'taskTypes'"
+        title="タスクタイプ管理"
+        :items="taskTypes"
+        :builtin-items="DEFAULT_TASK_TYPES as unknown as string[]"
+        :loading="taskTypesLoading"
+        @create="handleCreateTaskType"
+        @delete="handleDeleteTaskType"
+        @reorder="handleReorderTaskType"
       />
 
       <MasterDataManager

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -261,19 +261,29 @@ export interface TroubleActivityFile {
   created_at: string
 }
 
-export const TASK_TYPES: { value: string; label: string }[] = [
-  { value: 'investigation', label: '調査' },
-  { value: 'repair', label: '修理' },
-  { value: 'negotiation', label: '交渉' },
-  { value: 'documentation', label: '書類作成' },
-  { value: 'insurance', label: '保険対応' },
-  { value: 'other', label: 'その他' },
-]
+export interface TroubleTaskType {
+  id: string
+  tenant_id: string
+  name: string
+  sort_order: number
+  created_at: string
+}
 
-export const TASK_STATUS_LABELS: Record<string, string> = {
-  open: '未着手',
-  in_progress: '対応中',
-  done: '完了',
+export const DEFAULT_TASK_TYPES = [
+  'レッカー対応',
+  '修理手配',
+  '保険対応',
+  '示談交渉',
+  '処分決定',
+  '再発防止策',
+  '現場確認',
+  'その他',
+] as const
+
+export const TASK_STATUS_LABELS: Record<string, { label: string; color: string }> = {
+  open: { label: '未着手', color: '#9CA3AF' },
+  in_progress: { label: '進行中', color: '#3B82F6' },
+  done: { label: '完了', color: '#10B981' },
 }
 
 export const NOTIFICATION_EVENT_TYPES: { value: string; label: string }[] = [

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -30,6 +30,7 @@ import type {
   TroubleTaskActivity,
   CreateTroubleTaskActivity,
   TroubleActivityFile,
+  TroubleTaskType,
 } from '~/types'
 
 let apiBase = ''
@@ -367,6 +368,30 @@ export async function getTicketSchedules(ticketId: string): Promise<TroubleSched
 
 export async function cancelSchedule(id: string): Promise<void> {
   await request<void>(`/api/trouble/schedules/${encodeURIComponent(id)}`, { method: 'DELETE' })
+}
+
+// --- Task Types ---
+
+export async function getTaskTypes(): Promise<TroubleTaskType[]> {
+  return request<TroubleTaskType[]>('/api/trouble/task-types')
+}
+
+export async function createTaskType(data: { name: string; sort_order?: number }): Promise<TroubleTaskType> {
+  return request<TroubleTaskType>('/api/trouble/task-types', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  })
+}
+
+export async function deleteTaskType(id: string): Promise<void> {
+  await request<void>(`/api/trouble/task-types/${encodeURIComponent(id)}`, { method: 'DELETE' })
+}
+
+export async function updateTaskTypeSortOrder(id: string, sortOrder: number): Promise<TroubleTaskType> {
+  return request<TroubleTaskType>(`/api/trouble/task-types/${encodeURIComponent(id)}`, {
+    method: 'PUT',
+    body: JSON.stringify({ sort_order: sortOrder }),
+  })
 }
 
 // --- Tasks ---


### PR DESCRIPTION
## Summary
- Settings ページにタスクタイプ管理タブ追加（MasterDataManager 再利用）
- TicketTaskList: ハードコードからAPI取得に変更（fallback: DEFAULT_TASK_TYPES）
- TASK_STATUS_LABELS: color付きオブジェクトに修正
- TicketTaskCard: ステータスバッジ表示修正

バックエンド: ippoan/rust-alc-api#209

## Test plan
- [ ] Settings > タスクタイプ管理で追加・削除・並べ替え
- [ ] タスク追加時のドロップダウンにマスタデータ反映
- [ ] タスクタイプ未登録時のデフォルト自動シード

🤖 Generated with [Claude Code](https://claude.com/claude-code)