### PR TITLE
feat: rename to 状況管理 + next_action UI

### DIFF
--- a/app/components/TicketTaskCard.vue
+++ b/app/components/TicketTaskCard.vue
@@ -4,6 +4,7 @@ import { TASK_STATUS_LABELS } from '~/types'
 import {
   getActivities, createActivity, deleteActivity,
   getActivityFiles, uploadActivityFile, downloadActivityFile, deleteActivityFile,
+  updateTask,
 } from '~/utils/api'
 
 const props = defineProps<{
@@ -13,14 +14,17 @@ const props = defineProps<{
 const emit = defineEmits<{
   statusChange: [taskId: string, newStatus: string]
   delete: [taskId: string]
+  updated: []
 }>()
 
-const expanded = ref(false)
+const expanded = ref(true)
 const activities = ref<TroubleTaskActivity[]>([])
 const activityFiles = ref<Record<string, TroubleActivityFile[]>>({})
 const newActivityBody = ref('')
 const submittingActivity = ref(false)
 const loadingActivities = ref(false)
+const editingNextAction = ref(false)
+const nextActionDraft = ref(props.task.next_action || '')
 
 const statusColor = computed(() => {
   switch (props.task.status) {
@@ -130,9 +134,34 @@ async function handleDeleteFile(activityId: string, fileId: string) {
   }
 }
 
+watch(() => props.task.next_action, (val) => {
+  nextActionDraft.value = val || ''
+})
+
+async function saveNextAction() {
+  editingNextAction.value = false
+  const trimmed = nextActionDraft.value.trim()
+  if (trimmed === (props.task.next_action || '')) return
+  try {
+    await updateTask(props.task.id, { next_action: trimmed })
+    emit('updated')
+  } catch (e) {
+    console.error('Failed to update next_action:', e)
+    nextActionDraft.value = props.task.next_action || ''
+  }
+}
+
 function formatDate(dateStr: string): string {
   return new Date(dateStr).toLocaleString('ja-JP')
 }
+
+function formatDateShort(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString('ja-JP')
+}
+
+onMounted(() => {
+  loadActivities()
+})
 </script>
 
 <template>
@@ -166,6 +195,43 @@ function formatDate(dateStr: string): string {
         size="xs"
         @click.stop="emit('delete', task.id)"
       />
+    </div>
+
+    <!-- Next action & meta info -->
+    <div class="px-3 pb-2 space-y-1">
+      <!-- Next action -->
+      <div class="flex items-start gap-1 text-sm">
+        <span class="text-gray-500 shrink-0">次のアクション:</span>
+        <div v-if="editingNextAction" class="flex-1">
+          <input
+            v-model="nextActionDraft"
+            class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-0.5 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500"
+            @blur="saveNextAction"
+            @keydown.enter="saveNextAction"
+            ref="nextActionInput"
+          />
+        </div>
+        <span
+          v-else
+          class="flex-1 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 rounded px-1"
+          :class="task.next_action ? '' : 'text-gray-400 italic'"
+          @click="editingNextAction = true; $nextTick(() => ($refs.nextActionInput as HTMLInputElement)?.focus())"
+        >
+          {{ task.next_action || '(未設定 - クリックして入力)' }}
+        </span>
+      </div>
+      <!-- Next action due -->
+      <div v-if="task.next_action_due" class="text-xs text-gray-500">
+        <span>期限: {{ formatDateShort(task.next_action_due) }}</span>
+      </div>
+      <!-- Next action by -->
+      <div v-if="task.next_action_by" class="text-xs text-gray-500">
+        <span>担当: {{ task.next_action_by }}</span>
+      </div>
+      <!-- Created at -->
+      <div class="text-xs text-gray-400">
+        作成: {{ formatDate(task.created_at) }}
+      </div>
     </div>
 
     <!-- Expanded content -->

--- a/app/components/TicketTaskList.vue
+++ b/app/components/TicketTaskList.vue
@@ -131,7 +131,7 @@ onMounted(() => {
   <div>
     <div class="flex items-center justify-between mb-4">
       <div class="flex items-center gap-2">
-        <h3 class="text-base font-semibold">タスク</h3>
+        <h3 class="text-base font-semibold">状況管理</h3>
         <UBadge v-if="tasks.length > 0" variant="subtle" size="xs">
           {{ completionCount.done }}/{{ completionCount.total }} 完了
         </UBadge>
@@ -145,7 +145,7 @@ onMounted(() => {
     <template v-else>
       <!-- Grouped task list -->
       <div v-if="tasks.length === 0" class="text-sm text-gray-500 text-center py-4">
-        タスクはありません
+        状況管理項目はありません
       </div>
 
       <div v-else class="space-y-4">
@@ -160,6 +160,7 @@ onMounted(() => {
               :task="task"
               @status-change="handleStatusChange"
               @delete="handleDeleteTask"
+              @updated="loadTasks"
             />
           </div>
         </div>
@@ -175,7 +176,7 @@ onMounted(() => {
         />
         <UInput
           v-model="newTaskTitle"
-          placeholder="タスクを追加..."
+          placeholder="項目を追加..."
           size="sm"
           class="flex-1"
           @keydown.enter="handleAddTask"

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -14,7 +14,7 @@ const activeTab = ref('categories')
 
 const tabs = [
   { label: 'カテゴリ', value: 'categories' },
-  { label: 'タスクタイプ', value: 'taskTypes' },
+  { label: '状況管理タイプ', value: 'taskTypes' },
   { label: '営業所', value: 'offices' },
   { label: '進捗状況', value: 'progress' },
   { label: 'ワークフロー', value: 'workflow' },
@@ -327,7 +327,7 @@ onMounted(() => {
 
       <MasterDataManager
         v-if="activeTab === 'taskTypes'"
-        title="タスクタイプ管理"
+        title="状況管理タイプ"
         :items="taskTypes"
         :builtin-items="DEFAULT_TASK_TYPES as unknown as string[]"
         :loading="taskTypesLoading"

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -210,6 +210,9 @@ export interface TroubleTask {
   due_date: string | null
   completed_at: string | null
   sort_order: number
+  next_action: string
+  next_action_by: string | null
+  next_action_due: string | null
   created_by: string | null
   created_at: string
   updated_at: string
@@ -222,6 +225,9 @@ export interface CreateTroubleTask {
   assigned_to?: string | null
   due_date?: string | null
   sort_order?: number | null
+  next_action?: string
+  next_action_by?: string | null
+  next_action_due?: string | null
 }
 
 export interface UpdateTroubleTask {
@@ -233,6 +239,9 @@ export interface UpdateTroubleTask {
   due_date?: string | null
   completed_at?: string | null
   sort_order?: number | null
+  next_action?: string
+  next_action_by?: string | null
+  next_action_due?: string | null
 }
 
 export interface TroubleTaskActivity {


### PR DESCRIPTION
## Summary
- 「タスク」→「状況管理」にリネーム（セクション名、settings タブ）
- 次のアクション: インライン編集UI（クリック→入力→blur で保存）
- 期限・担当者表示
- アクティビティをデフォルト展開
- バックエンド: ippoan/rust-alc-api#210

## Test plan
- [ ] 状況管理セクション表示確認
- [ ] 次のアクションをクリックして編集→保存
- [ ] settings > 状況管理タイプ表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)