### PR TITLE
fix: align task form columns

### DIFF
--- a/app/components/TicketTaskList.vue
+++ b/app/components/TicketTaskList.vue
@@ -292,7 +292,7 @@ onMounted(() => {
       <!-- Batch add task form -->
       <div class="border-t border-gray-200 dark:border-gray-700 mt-4 pt-3">
         <!-- Header row labels -->
-        <div class="grid grid-cols-[6rem_1fr_1fr_1fr_7rem_8rem_2rem] gap-1 mb-1 px-0.5">
+        <div class="grid grid-cols-[5rem_1fr_1fr_1fr_6.5rem_7rem_1.5rem] gap-1 mb-1 px-0.5">
           <span class="text-[10px] text-gray-400">種別</span>
           <span class="text-[10px] text-gray-400">タイトル</span>
           <span class="text-[10px] text-gray-400">内容</span>
@@ -303,30 +303,30 @@ onMounted(() => {
         </div>
 
         <!-- Rows -->
-        <div v-for="row in newRows" :key="row._id" class="grid grid-cols-[6rem_1fr_1fr_1fr_7rem_8rem_2rem] gap-1 mb-1" :class="{ 'ring-1 ring-red-400 rounded': row.error }">
-          <USelect v-model="row.task_type" :items="taskTypes" size="xs" />
+        <div v-for="row in newRows" :key="row._id" class="grid grid-cols-[5rem_1fr_1fr_1fr_6.5rem_7rem_1.5rem] gap-1 mb-1" :class="{ 'ring-1 ring-red-400 rounded': row.error }">
+          <USelect v-model="row.task_type" :items="taskTypes" size="xs" class="min-w-0" />
           <input
             v-model="row.title"
             placeholder="タイトル"
-            class="text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500"
+            class="min-w-0 text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500"
             @keydown.enter="handleBatchAdd"
           />
           <input
             v-model="row.description"
             placeholder="内容"
-            class="text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500"
+            class="min-w-0 text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500"
           />
           <input
             v-model="row.next_action"
             placeholder="次のアクション"
-            class="text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500"
+            class="min-w-0 text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500"
           />
           <input
             v-model="row.due_date"
             type="date"
-            class="text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500"
+            class="min-w-0 text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500"
           />
-          <USelect v-model="row.assigned_to" :items="employeeItems" value-key="value" size="xs" />
+          <USelect v-model="row.assigned_to" :items="employeeItems" value-key="value" size="xs" class="min-w-0" />
           <UButton
             icon="i-lucide-x"
             size="xs"


### PR DESCRIPTION
## Summary
- グリッド列幅を調整（種別5rem、期限6.5rem、対応者7rem、削除1.5rem）
- 全入力欄に min-w-0 追加でグリッドオーバーフロー防止
- ヘッダーと入力欄のずれを修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)