### PR TITLE
fix: gantt bar_height + debug log

### DIFF
--- a/app/components/TicketGanttChart.vue
+++ b/app/components/TicketGanttChart.vue
@@ -68,11 +68,15 @@ async function renderGantt() {
     chartRef.value.innerHTML = ''
   }
 
+  console.log('[GanttChart] tasks:', JSON.stringify(ganttTasks, null, 2))
+
   ganttInstance = new Gantt(chartRef.value, ganttTasks, {
     view_mode: viewMode.value,
     date_format: 'YYYY-MM-DD',
     language: 'ja',
-    readonly: true,
+    bar_height: 30,
+    bar_corner_radius: 4,
+    padding: 18,
   })
 }
 

--- a/app/types/frappe-gantt.d.ts
+++ b/app/types/frappe-gantt.d.ts
@@ -13,11 +13,15 @@ declare module 'frappe-gantt' {
     view_mode?: 'Quarter Day' | 'Half Day' | 'Day' | 'Week' | 'Month' | 'Year'
     date_format?: string
     language?: string
-    readonly?: boolean
+    bar_height?: number
+    bar_corner_radius?: number
+    padding?: number
+    arrow_curve?: number
     on_click?: (task: GanttTask) => void
     on_date_change?: (task: GanttTask, start: Date, end: Date) => void
     on_progress_change?: (task: GanttTask, progress: number) => void
     on_view_change?: (mode: string) => void
+    [key: string]: unknown
   }
 
   export default class Gantt {


### PR DESCRIPTION
## Summary
- bar_height: 30, padding: 18 を明示指定
- readonly 削除（公式オプション外の可能性）
- console.log でタスクデータをデバッグ出力

🤖 Generated with [Claude Code](https://claude.com/claude-code)