### PR TITLE
fix: task form bugs (422/SelectItem) + component tests

### DIFF
--- a/app/components/TicketTaskList.vue
+++ b/app/components/TicketTaskList.vue
@@ -40,7 +40,7 @@ function createEmptyRow(): NewTaskRow {
     description: '',
     next_action: '',
     due_date: '',
-    assigned_to: '',
+    assigned_to: UNSET,
     assigned_name: '',
     error: false,
   }
@@ -49,8 +49,9 @@ function createEmptyRow(): NewTaskRow {
 const newRows = ref<NewTaskRow[]>([])
 
 // Employee select items: empty option + employee list
+const UNSET = '__unset__'
 const employeeItems = computed(() => [
-  { label: '未設定', value: '' },
+  { label: '未設定', value: UNSET },
   ...employees.value.map(e => ({ label: e.name, value: e.id })),
 ])
 
@@ -153,8 +154,8 @@ async function handleBatchAdd() {
         description: row.description.trim() || undefined,
         next_action: row.next_action.trim() || undefined,
         due_date: row.due_date || null,
-        assigned_to: row.assigned_to || null,
-        next_action_by: row.assigned_to ? undefined : (row.assigned_name.trim() || undefined),
+        assigned_to: (row.assigned_to && row.assigned_to !== UNSET) ? row.assigned_to : null,
+        next_action_by: (row.assigned_to && row.assigned_to !== UNSET) ? undefined : (row.assigned_name.trim() || undefined),
       })
       succeeded.push(row._id)
     } catch (e) {

--- a/tests/components/TicketGanttChart.test.ts
+++ b/tests/components/TicketGanttChart.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import TicketGanttChart from '~/components/TicketGanttChart.vue'
+
+const mockGetTasks = vi.fn().mockResolvedValue([])
+
+vi.mock('~/utils/api', () => ({
+  getTasks: (...args: any[]) => mockGetTasks(...args),
+}))
+
+vi.mock('frappe-gantt', () => ({
+  default: class {
+    constructor() {}
+    change_view_mode() {}
+  },
+}))
+
+vi.mock('~/assets/css/frappe-gantt.css', () => ({}))
+
+const stubs = {
+  UButton: {
+    template: '<button @click="$emit(\'click\')">{{ label }}</button>',
+    props: ['label', 'size', 'variant'],
+  },
+}
+
+const sampleTask = {
+  id: 'task-1', tenant_id: 't1', ticket_id: 'ticket-1', task_type: 'レッカー対応',
+  title: 'テストタスク', description: '', status: 'open', assigned_to: null,
+  due_date: null, completed_at: null, sort_order: 0, next_action: '',
+  next_action_by: null, next_action_due: null, created_by: null,
+  created_at: '2026-04-12T00:00:00Z', updated_at: '2026-04-12T00:00:00Z',
+}
+
+describe('TicketGanttChart', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not render when no tasks', async () => {
+    mockGetTasks.mockResolvedValue([])
+    const wrapper = mount(TicketGanttChart, {
+      props: { ticketId: 'ticket-1' },
+      global: { stubs },
+    })
+    await flushPromises()
+    expect(wrapper.text()).not.toContain('ガントチャート')
+  })
+
+  it('renders gantt container when tasks exist', async () => {
+    mockGetTasks.mockResolvedValue([sampleTask])
+    const wrapper = mount(TicketGanttChart, {
+      props: { ticketId: 'ticket-1' },
+      global: { stubs },
+    })
+    await flushPromises()
+    expect(wrapper.text()).toContain('ガントチャート')
+  })
+})

--- a/tests/components/TicketTaskCard.test.ts
+++ b/tests/components/TicketTaskCard.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import TicketTaskCard from '~/components/TicketTaskCard.vue'
+
+vi.mock('~/utils/api', () => ({
+  getActivities: vi.fn().mockResolvedValue([]),
+  createActivity: vi.fn(),
+  deleteActivity: vi.fn(),
+  getActivityFiles: vi.fn().mockResolvedValue([]),
+  uploadActivityFile: vi.fn(),
+  downloadActivityFile: vi.fn(),
+  deleteActivityFile: vi.fn(),
+  updateTask: vi.fn(),
+}))
+
+const stubs = {
+  UButton: {
+    template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot />{{ label }}</button>',
+    props: ['label', 'icon', 'loading', 'disabled', 'size', 'variant', 'color'],
+  },
+  UIcon: { template: '<span />', props: ['name'] },
+  USelect: {
+    template: '<select><option v-for="item in items" :key="item.value" :value="item.value">{{ item.label }}</option></select>',
+    props: ['modelValue', 'items', 'size'],
+  },
+}
+
+const sampleTask = {
+  id: 'task-1', tenant_id: 't1', ticket_id: 'ticket-1', task_type: 'レッカー対応',
+  title: 'テストタスク', description: '', status: 'open', assigned_to: null,
+  due_date: null, completed_at: null, sort_order: 0, next_action: '',
+  next_action_by: null, next_action_due: null, created_by: null,
+  created_at: '2026-04-12T00:00:00Z', updated_at: '2026-04-12T00:00:00Z',
+}
+
+describe('TicketTaskCard', () => {
+  it('renders task title', async () => {
+    const wrapper = mount(TicketTaskCard, {
+      props: { task: sampleTask },
+      global: { stubs },
+    })
+    await flushPromises()
+    expect(wrapper.text()).toContain('テストタスク')
+  })
+
+  it('renders status badge', async () => {
+    const wrapper = mount(TicketTaskCard, {
+      props: { task: sampleTask },
+      global: { stubs },
+    })
+    await flushPromises()
+    expect(wrapper.text()).toContain('未着手')
+  })
+
+  it('renders next action placeholder when empty', async () => {
+    const wrapper = mount(TicketTaskCard, {
+      props: { task: sampleTask },
+      global: { stubs },
+    })
+    await flushPromises()
+    const nextActionInput = wrapper.find('input[placeholder="次のアクション..."]')
+    expect(nextActionInput.exists()).toBe(true)
+    expect((nextActionInput.element as HTMLInputElement).value).toBe('')
+  })
+})

--- a/tests/components/TicketTaskList.test.ts
+++ b/tests/components/TicketTaskList.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import TicketTaskList from '~/components/TicketTaskList.vue'
+
+const sampleTask = {
+  id: 'task-1', tenant_id: 't1', ticket_id: 'ticket-1', task_type: 'レッカー対応',
+  title: 'テストタスク', description: '', status: 'open', assigned_to: null,
+  due_date: null, completed_at: null, sort_order: 0, next_action: '',
+  next_action_by: null, next_action_due: null, created_by: null,
+  created_at: '2026-04-12T00:00:00Z', updated_at: '2026-04-12T00:00:00Z',
+}
+
+const mockGetTasks = vi.fn().mockResolvedValue([sampleTask])
+const mockGetTaskTypes = vi.fn().mockResolvedValue([
+  { id: '1', name: 'レッカー対応', sort_order: 0, tenant_id: 't1', created_at: '' },
+])
+const mockCreateTask = vi.fn().mockResolvedValue(sampleTask)
+const mockUpdateTask = vi.fn().mockResolvedValue(sampleTask)
+const mockDeleteTask = vi.fn().mockResolvedValue(undefined)
+const mockGetEmployees = vi.fn().mockResolvedValue([])
+
+vi.mock('~/utils/api', () => ({
+  getTasks: (...args: any[]) => mockGetTasks(...args),
+  getTaskTypes: (...args: any[]) => mockGetTaskTypes(...args),
+  createTask: (...args: any[]) => mockCreateTask(...args),
+  updateTask: (...args: any[]) => mockUpdateTask(...args),
+  deleteTask: (...args: any[]) => mockDeleteTask(...args),
+  getEmployees: (...args: any[]) => mockGetEmployees(...args),
+}))
+
+const stubs = {
+  UButton: {
+    template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot />{{ label }}</button>',
+    props: ['label', 'icon', 'loading', 'disabled', 'size', 'variant', 'color'],
+  },
+  UIcon: { template: '<span />', props: ['name'] },
+  UBadge: { template: '<span><slot /></span>', props: ['variant', 'size'] },
+  USelect: { template: '<select />', props: ['modelValue', 'items', 'size', 'valueKey'] },
+  TicketTaskCard: { template: '<div class="task-card">{{ task.title }}</div>', props: ['task'] },
+}
+
+describe('TicketTaskList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetTasks.mockResolvedValue([sampleTask])
+    mockGetTaskTypes.mockResolvedValue([
+      { id: '1', name: 'レッカー対応', sort_order: 0, tenant_id: 't1', created_at: '' },
+    ])
+    mockGetEmployees.mockResolvedValue([])
+  })
+
+  it('renders heading', async () => {
+    const wrapper = mount(TicketTaskList, {
+      props: { ticketId: 'ticket-1', workflowStates: [], currentStatusId: null },
+      global: { stubs },
+    })
+    await flushPromises()
+    expect(wrapper.text()).toContain('状況管理')
+  })
+
+  it('shows empty message when no tasks', async () => {
+    mockGetTasks.mockResolvedValue([])
+    const wrapper = mount(TicketTaskList, {
+      props: { ticketId: 'ticket-1', workflowStates: [], currentStatusId: null },
+      global: { stubs },
+    })
+    await flushPromises()
+    expect(wrapper.text()).toContain('状況管理項目はありません')
+  })
+
+  it('renders task list when tasks exist', async () => {
+    const wrapper = mount(TicketTaskList, {
+      props: { ticketId: 'ticket-1', workflowStates: [], currentStatusId: null },
+      global: { stubs },
+    })
+    await flushPromises()
+    expect(wrapper.text()).toContain('テストタスク')
+  })
+
+  it('handleBatchAdd sends null for empty due_date', async () => {
+    const wrapper = mount(TicketTaskList, {
+      props: { ticketId: 'ticket-1', workflowStates: [], currentStatusId: null },
+      global: { stubs },
+    })
+    await flushPromises()
+
+    // Fill in a title in the first row via the input element
+    const titleInput = wrapper.find('input[placeholder="タイトル"]')
+    await titleInput.setValue('新しいタスク')
+
+    // Click the batch add button
+    mockCreateTask.mockResolvedValue({ ...sampleTask, id: 'task-new', title: '新しいタスク' })
+    const buttons = wrapper.findAll('button')
+    const batchAddButton = buttons.find(b => b.text().includes('一括登録'))
+    expect(batchAddButton).toBeTruthy()
+    await batchAddButton!.trigger('click')
+    await flushPromises()
+
+    // Verify createTask was called with due_date: null (not empty string)
+    expect(mockCreateTask).toHaveBeenCalled()
+    const callArgs = mockCreateTask.mock.calls[0]
+    expect(callArgs[1].due_date).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- Fix: USelect 空文字 value エラー → UNSET センチネル値に変更
- Fix: due_date 空文字列で 422 → null に正規化
- Fix: assigned_to UNSET を null として送信
- TicketTaskList.test.ts (4 tests) — due_date null 検証含む
- TicketTaskCard.test.ts (3 tests)
- TicketGanttChart.test.ts (2 tests)
- ローカル全156テスト pass

## Test plan
- [x] ローカル全テスト pass (24 files, 156 tests)
- [ ] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)