### PR TITLE
fix: remove all value:'' from USelect (SelectItem error)

### DIFF
--- a/app/composables/useTicketList.ts
+++ b/app/composables/useTicketList.ts
@@ -88,7 +88,7 @@ export function useTicketList() {
       ...categories.value.map(c => c.name),
       ...hardcoded,
     ]
-    return [{ label: '全て', value: '' }, ...allCats.map(c => ({ label: c, value: c }))]
+    return allCats.map(c => ({ label: c, value: c }))
   })
 
   const createCategoryOptions = computed(() => {

--- a/app/pages/tickets/index.vue
+++ b/app/pages/tickets/index.vue
@@ -44,7 +44,7 @@ watch(() => ({ ...filter }), () => { fetchTickets() }, { deep: true })
       <UInput v-model="filter.q" placeholder="検索" size="sm" class="w-28" />
       <UInput v-model="filter.person_name" placeholder="氏名" size="sm" class="w-24" />
       <UInput v-model="filter.company_name" placeholder="会社名" size="sm" class="w-28" />
-      <USelect v-model="filter.office_name" :items="[{ label: '全て', value: '' }, ...officeOptions]" placeholder="営業所" size="sm" class="w-28" :disabled="officeOptions.length === 0" />
+      <USelect v-model="filter.office_name" :items="officeOptions" placeholder="営業所(全て)" size="sm" class="w-28" :disabled="officeOptions.length === 0" />
       <UInput v-model="filter.date_from" type="date" size="sm" class="w-36" />
       <span class="text-gray-400 text-xs">〜</span>
       <UInput v-model="filter.date_to" type="date" size="sm" class="w-36" />

--- a/tests/composables/useTicketList.test.ts
+++ b/tests/composables/useTicketList.test.ts
@@ -106,19 +106,18 @@ describe('useTicketList', () => {
 
   it('categoryOptions includes all hardcoded categories when no DB categories', () => {
     const l = useTicketList()
-    expect(l.categoryOptions.value[0]).toEqual({ label: '全て', value: '' })
-    // 7 hardcoded + 1 "全て"
-    expect(l.categoryOptions.value.length).toBe(8)
+    // 7 hardcoded categories (no "全て" — use USelect placeholder)
+    expect(l.categoryOptions.value.length).toBe(7)
+    expect(l.categoryOptions.value[0]).toEqual({ label: '苦情・トラブル', value: '苦情・トラブル' })
   })
 
   it('categoryOptions merges DB and hardcoded categories', () => {
     const l = useTicketList()
-    // Simulate DB categories
     l.categories.value = [{ id: 'c1', tenant_id: 't1', name: '貨物事故', sort_order: 1, created_at: '' }]
     // DB has '貨物事故' which is also hardcoded — should deduplicate
-    // Total: 1 "全て" + 1 DB + 6 remaining hardcoded = 8
-    expect(l.categoryOptions.value.length).toBe(8)
-    expect(l.categoryOptions.value[1]).toEqual({ label: '貨物事故', value: '貨物事故' })
+    // Total: 1 DB + 6 remaining hardcoded = 7
+    expect(l.categoryOptions.value.length).toBe(7)
+    expect(l.categoryOptions.value[0]).toEqual({ label: '貨物事故', value: '貨物事故' })
   })
 
   it('clearFilter resets all fields and status', () => {


### PR DESCRIPTION
## Summary
- categoryOptions から `{ label: '全て', value: '' }` を削除 → placeholder で代替
- office_name フィルターも同様に修正
- USelect v4 で `value: ''` は SelectItem エラーになる

## Test plan
- [x] ローカル全156テスト pass
- [ ] CI pass
- [ ] staging でコンソールエラーなし確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)