### PR TITLE
feat: fullscreen gantt modal

### DIFF
--- a/app/components/TicketGanttChart.vue
+++ b/app/components/TicketGanttChart.vue
@@ -103,7 +103,6 @@ watch(() => props.ticketId, async () => {
 <template>
   <div v-if="!loading && tasks.length > 0">
     <div class="flex items-center justify-between mb-3">
-      <h3 class="text-base font-semibold">ガントチャート</h3>
       <div class="flex gap-1">
         <UButton
           v-for="mode in (['Day', 'Week', 'Month'] as const)"

--- a/app/pages/tickets/[id].vue
+++ b/app/pages/tickets/[id].vue
@@ -178,12 +178,18 @@ onMounted(() => {
       </UCard>
 
       <!-- Gantt Chart Dialog -->
-      <UModal v-model:open="showGantt">
+      <UModal v-model:open="showGantt" fullscreen>
         <template #content>
-          <div class="p-6 min-w-[80vw]">
-            <ClientOnly>
-              <TicketGanttChart :key="ganttKey" :ticket-id="ticketId" />
-            </ClientOnly>
+          <div class="p-6 h-full flex flex-col">
+            <div class="flex items-center justify-between mb-4">
+              <h2 class="text-lg font-bold">ガントチャート</h2>
+              <UButton icon="i-lucide-x" variant="ghost" size="sm" @click="showGantt = false" />
+            </div>
+            <div class="flex-1 overflow-auto">
+              <ClientOnly>
+                <TicketGanttChart :key="ganttKey" :ticket-id="ticketId" />
+              </ClientOnly>
+            </div>
           </div>
         </template>
       </UModal>

--- a/tests/components/TicketGanttChart.test.ts
+++ b/tests/components/TicketGanttChart.test.ts
@@ -44,7 +44,7 @@ describe('TicketGanttChart', () => {
       global: { stubs },
     })
     await flushPromises()
-    expect(wrapper.text()).not.toContain('ガントチャート')
+    expect(wrapper.text()).not.toContain('未着手')
   })
 
   it('renders gantt container when tasks exist', async () => {
@@ -54,6 +54,6 @@ describe('TicketGanttChart', () => {
       global: { stubs },
     })
     await flushPromises()
-    expect(wrapper.text()).toContain('ガントチャート')
+    expect(wrapper.text()).toContain('未着手')
   })
 })


### PR DESCRIPTION
## Summary
- ガントチャートモーダルを fullscreen に変更
- ヘッダーにタイトル + 閉じるボタン
- コンポーネント側の重複見出し削除
- ローカル全156テスト pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)