### PR TITLE
fix: expand gantt container height + popup z-index

### DIFF
--- a/app/components/TicketGanttChart.vue
+++ b/app/components/TicketGanttChart.vue
@@ -123,12 +123,23 @@ watch(() => props.ticketId, async () => {
       </span>
     </div>
 
-    <div ref="chartRef" class="gantt-container overflow-x-auto" />
+    <div ref="chartRef" class="gantt-wrapper" />
   </div>
 </template>
 
 <style>
-.gantt-container .gantt {
+/* Override frappe-gantt container height to fill parent */
+.gantt-wrapper .gantt-container {
+  height: auto !important;
+  min-height: 200px;
+}
+
+/* Ensure popup is not clipped by overflow */
+.gantt-wrapper .gantt-container .popup-wrapper {
+  z-index: 9999;
+}
+
+.gantt-wrapper .gantt {
   background: transparent;
 }
 


### PR DESCRIPTION
## Summary
- gantt-container の height:auto でフルスクリーンモーダルを埋める
- popup z-index:9999 でスクロール領域に隠れない
- ローカル全156テスト pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)