### PR TITLE
ci: add tag-release workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,12 @@
+name: Tag Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: ippoan/ci-workflows/.github/workflows/tag-release.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- ci-dashboard の Deploy ボタンが叩く `tag-release.yml` を追加
- `ippoan/ci-workflows/.github/workflows/tag-release.yml@main` をそのまま呼び出し
- 既存の nuxt-pwa-carins / alc-app / auth-worker と同じパターン

## Test plan
- [ ] マージ後、ci-dashboard の Deploy ボタンで 404 が出ないこと
- [ ] patch タグが自動生成されデプロイが走ること