### PR TITLE
feat: inline registration_number input when empty

### DIFF
--- a/app/components/TicketCompactOverview.vue
+++ b/app/components/TicketCompactOverview.vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
 import type { TroubleTicket, TroubleWorkflowState } from '~/types'
+import { updateTicket } from '~/utils/api'
 
 const props = defineProps<{
   ticket: TroubleTicket
   workflowStates: TroubleWorkflowState[]
+}>()
+
+const emit = defineEmits<{
+  (e: 'updated'): void
 }>()
 
 const expanded = ref(false)
@@ -11,6 +16,7 @@ const expanded = ref(false)
 const {
   load: loadCarInspections,
   lookupByRegistration: lookupCarInspection,
+  registrationOptions: carInspectionRegistrations,
 } = useCarInspections()
 
 onMounted(() => {
@@ -20,6 +26,24 @@ onMounted(() => {
 const carInspectionMatch = computed(() =>
   lookupCarInspection(props.ticket.registration_number),
 )
+
+const savingRegistration = ref(false)
+
+async function saveRegistration(event: Event) {
+  const target = event.target as HTMLInputElement
+  const value = target.value.trim()
+  if (!value) return
+  savingRegistration.value = true
+  try {
+    await updateTicket(props.ticket.id, { registration_number: value })
+    emit('updated')
+  } catch (e) {
+    console.error('登録番号の保存に失敗:', e)
+    target.value = ''
+  } finally {
+    savingRegistration.value = false
+  }
+}
 
 function formatExpiry(v: string): string {
   if (!v) return '-'
@@ -134,6 +158,29 @@ function displayValue(key: string): string {
       <template v-else>
         登録番号 {{ ticket.registration_number }} — 車検証マスタに登録なし
       </template>
+    </div>
+    <!-- 登録番号未入力: インライン入力 -->
+    <div
+      v-else
+      class="mt-2 flex items-center gap-2 text-xs"
+    >
+      <span class="text-gray-500">登録番号:</span>
+      <input
+        type="text"
+        list="overview-car-inspection-registrations"
+        placeholder="登録番号を入力"
+        class="flex-1 max-w-xs rounded border border-dashed border-gray-300 dark:border-gray-600 bg-transparent px-2 py-1 focus:border-solid focus:border-blue-500 focus:outline-none"
+        :disabled="savingRegistration"
+        @keydown.enter.prevent="saveRegistration($event)"
+        @blur="saveRegistration($event)"
+      >
+      <datalist id="overview-car-inspection-registrations">
+        <option
+          v-for="reg in carInspectionRegistrations"
+          :key="reg"
+          :value="reg"
+        />
+      </datalist>
     </div>
 
     <!-- Toggle -->

--- a/app/pages/tickets/[id].vue
+++ b/app/pages/tickets/[id].vue
@@ -166,7 +166,11 @@ onMounted(() => {
       </UCard>
 
       <UCard v-else>
-        <TicketCompactOverview :ticket="ticket" :workflow-states="workflowStates" />
+        <TicketCompactOverview
+          :ticket="ticket"
+          :workflow-states="workflowStates"
+          @updated="load"
+        />
       </UCard>
 
       <!-- Tasks -->

--- a/app/pages/tickets/index.vue
+++ b/app/pages/tickets/index.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { updateTicket } from '~/utils/api'
+
 const {
   filter, selectedStatuses, loading,
   deleteTarget, showDeleteModal, stateMap, totalPages,
@@ -26,6 +28,24 @@ function handleBulkImportDone() {
 function formatExpiry(v: string): string {
   if (!v) return '-'
   return v.length > 10 ? v.substring(0, 10) : v
+}
+
+const savingRegistration = ref<string | null>(null)
+
+async function saveRegistration(ticketId: string, event: Event) {
+  const target = event.target as HTMLInputElement
+  const value = target.value.trim()
+  if (!value) return
+  savingRegistration.value = ticketId
+  try {
+    await updateTicket(ticketId, { registration_number: value })
+    await fetchTickets()
+  } catch (e) {
+    console.error('登録番号の保存に失敗:', e)
+    target.value = ''
+  } finally {
+    savingRegistration.value = null
+  }
 }
 
 onMounted(() => {
@@ -185,7 +205,7 @@ watch(() => ({ ...filter }), () => { fetchTickets() }, { deep: true })
               <td class="py-2 px-2">{{ ticket.office_name || '-' }}</td>
               <td class="py-2 px-2">{{ ticket.department || '-' }}</td>
               <td class="py-2 px-2">{{ ticket.person_name || '-' }}</td>
-              <td class="py-2 px-2">
+              <td class="py-2 px-2" @click.stop>
                 <template v-if="ticket.registration_number">
                   <span>{{ ticket.registration_number }}</span>
                   <UIcon
@@ -195,7 +215,16 @@ watch(() => ({ ...filter }), () => { fetchTickets() }, { deep: true })
                     :title="(() => { const s = lookupCarInspection(ticket.registration_number)!; return `所有者: ${s.ownerName || '-'}\n車種: ${s.carName || '-'}\n型式: ${s.model || '-'}\n車検満了日: ${formatExpiry(s.validPeriodExpirdate)}` })()"
                   />
                 </template>
-                <span v-else>-</span>
+                <input
+                  v-else
+                  type="text"
+                  list="car-inspection-registrations"
+                  placeholder="登録番号を入力"
+                  class="w-28 rounded border border-dashed border-gray-300 dark:border-gray-600 bg-transparent px-1.5 py-0.5 text-xs focus:border-solid focus:border-blue-500 focus:outline-none"
+                  :disabled="savingRegistration === ticket.id"
+                  @keydown.enter.prevent="saveRegistration(ticket.id, $event)"
+                  @blur="saveRegistration(ticket.id, $event)"
+                >
               </td>
               <td class="py-2 px-2"><TicketCategoryBadge :category="ticket.category" /></td>
               <td class="py-2 px-2 max-w-[120px] truncate">{{ ticket.location || '-' }}</td>


### PR DESCRIPTION
## Summary
- 登録番号が未入力のチケットで、一覧と詳細から直接入力できるように
- 一覧: セル内 datalist 付き input、Enter/blur で保存 → 再取得
- 詳細: 車検証情報ブロックの代わりに input、保存後に load() 再取得
- datalist 補完で車検証マスタからの選択も可能 (既存と同じ挙動)

## Test plan
- [ ] CI の vitest / typecheck が pass
- [ ] 登録番号未入力チケットで一覧セルが入力欄になる
- [ ] 入力 + Enter で保存 → マッチすればℹ️が出る
- [ ] 詳細ページでも同様に空欄なら入力欄表示