### PR TITLE
chore: add dev-proxy host to Vite allowedHosts

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -15,6 +15,12 @@ export default defineNuxtConfig({
     preset: 'cloudflare_module',
   },
 
+  vite: {
+    server: {
+      allowedHosts: ['nuxt-trouble.dev.ippoan.org'],
+    },
+  },
+
   modules: [
     '@nuxt/ui',
   ],


### PR DESCRIPTION
## Summary
dev-proxy (Caddy reverse proxy) 経由で Vite dev server にアクセスすると
「Blocked request」で 403 になるため `nuxt-trouble.dev.ippoan.org` を
Vite allowedHosts に追加。

- 本番: Nitro cloudflare_module を使うため `vite.server.*` は無視される
- dev: `https://nuxt-trouble.dev.ippoan.org/` 経由 (dev-proxy Caddy → localhost:3017) で Vite にアクセス可能になる

## Test plan
- [ ] CI pass
- [ ] dev-proxy 経由で画面表示確認