### PR TITLE
fix: exclude auth-client from Vite pre-bundle

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -19,6 +19,11 @@ export default defineNuxtConfig({
     server: {
       allowedHosts: ['nuxt-trouble.dev.ippoan.org'],
     },
+    optimizeDeps: {
+      // @ippoan/auth-client は .ts ソースで公開されており Vite の dep pre-bundle で
+      // `#imports` の解決がバグって invalid JS になる。exclude で SSR/ESM 経路に委ねる。
+      exclude: ['@ippoan/auth-client'],
+    },
   },
 
   modules: [


### PR DESCRIPTION
## Summary
dev 起動時に `@ippoan/auth-client` の pre-bundle された JS が壊れていて
`Pre-transform error: invalid JS syntax` で app が SSR 初期表示 (spinner)
のまま hydrate せず止まる。

### 原因
`auth-client` の `package.json` は `main: ./src/index.ts` を指しており
.ts ソースが Vite dep pre-bundler (esbuild) に渡る。`#imports` を含む
コードが pre-bundle されると import 文が壊れて invalid JS になる。

### 修正
`optimizeDeps.exclude` で pre-bundle 対象から外し、Nuxt の SSR/ESM 経路で
通常 resolve させる (prod build には影響なし)。

## Test plan
- [ ] CI pass
- [ ] dev で `https://nuxt-trouble.dev.ippoan.org` にアクセスしログイン画面が表示される