### PR TITLE
feat(tickets): canonicalize registration_number input to half-width

### DIFF
--- a/app/pages/tickets/index.vue
+++ b/app/pages/tickets/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { updateTicket } from '~/utils/api'
+import { toHalfWidth } from '~/utils/normalize'
 import type { TroubleTicket } from '~/types'
 
 const {
@@ -83,7 +84,13 @@ watch(() => ({ ...filter }), () => { fetchTickets() }, { deep: true })
     <!-- Filters: single row -->
     <div class="flex flex-wrap items-end gap-2">
       <USelect v-model="filter.category" :items="categoryOptions" placeholder="カテゴリ" size="sm" class="w-32" />
-      <UInput v-model="filter.q" placeholder="検索" size="sm" class="w-28" />
+      <UInput
+        :model-value="filter.q"
+        placeholder="検索"
+        size="sm"
+        class="w-28"
+        @update:model-value="(v: string | number) => { filter.q = toHalfWidth(String(v ?? '')) }"
+      />
       <UInput v-model="filter.person_name" placeholder="氏名" size="sm" class="w-24" />
       <UInput v-model="filter.company_name" placeholder="会社名" size="sm" class="w-28" />
       <USelect v-model="filter.office_name" :items="officeOptions" placeholder="営業所(全て)" size="sm" class="w-28" :disabled="officeOptions.length === 0" />
@@ -145,11 +152,12 @@ watch(() => ({ ...filter }), () => { fetchTickets() }, { deep: true })
         <UInput v-model="newTicket.department" placeholder="運行課" size="sm" class="w-20" />
         <UInput v-model="newTicket.person_name" placeholder="当事者名" size="sm" class="w-24" />
         <UInput
-          v-model="newTicket.registration_number"
+          :model-value="newTicket.registration_number"
           placeholder="登録番号"
           size="sm"
           class="w-24"
           list="car-inspection-registrations"
+          @update:model-value="(v: string | number) => { newTicket.registration_number = toHalfWidth(String(v ?? '')) }"
         />
         <UInput v-model="newTicket.location" placeholder="発生場所" size="sm" class="w-24" />
         <UInput v-model="newTicket.description" placeholder="内容" size="sm" class="w-32" />
@@ -232,6 +240,7 @@ watch(() => ({ ...filter }), () => { fetchTickets() }, { deep: true })
                   placeholder="登録番号を入力"
                   class="w-28 rounded border border-dashed border-gray-300 dark:border-gray-600 bg-transparent px-1.5 py-0.5 text-xs focus:border-solid focus:border-blue-500 focus:outline-none"
                   :disabled="savingRegistrationIds.has(ticket.id)"
+                  @input="(e: Event) => { const el = e.target as HTMLInputElement; const v = toHalfWidth(el.value); if (el.value !== v) el.value = v }"
                   @keydown.enter.prevent="saveRegistration(ticket.id, $event)"
                   @change="saveRegistration(ticket.id, $event)"
                 >

--- a/app/utils/normalize.ts
+++ b/app/utils/normalize.ts
@@ -1,0 +1,6 @@
+export function toHalfWidth(s: string): string {
+  if (!s) return s
+  return s
+    .replace(/[０-９]/g, c => String.fromCharCode(c.charCodeAt(0) - 0xFEE0))
+    .replace(/[－ー]/g, '-')
+}

--- a/tests/utils/normalize.test.ts
+++ b/tests/utils/normalize.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { toHalfWidth } from '~/utils/normalize'
+
+describe('toHalfWidth', () => {
+  it('converts full-width digits to half-width', () => {
+    expect(toHalfWidth('１２３４')).toBe('1234')
+  })
+
+  it('converts full-width hyphen and chouon to half-width hyphen', () => {
+    expect(toHalfWidth('１２－３４')).toBe('12-34')
+    expect(toHalfWidth('１２ー３４')).toBe('12-34')
+  })
+
+  it('preserves kana/kanji and only normalizes digits + hyphen', () => {
+    expect(toHalfWidth('品川５００あ１２－３４')).toBe('品川500あ12-34')
+  })
+
+  it('is a no-op for already half-width strings', () => {
+    expect(toHalfWidth('12-34')).toBe('12-34')
+    expect(toHalfWidth('品川500あ1234')).toBe('品川500あ1234')
+  })
+
+  it('returns empty string unchanged', () => {
+    expect(toHalfWidth('')).toBe('')
+  })
+
+  it('passes through nullish-like falsy inputs without throwing', () => {
+    expect(toHalfWidth(undefined as unknown as string)).toBe(undefined as unknown as string)
+    expect(toHalfWidth(null as unknown as string)).toBe(null as unknown as string)
+  })
+})


### PR DESCRIPTION
tickets/index.vue の検索窓・登録番号入力欄 (3 箇所) で、入力中に全角数字 (０-９) と全角ハイフン類 (－/ー) を半角に即時変換する toHalfWidth() を適用。新規データは DB 上も半角統一になる。既存全角データは rust-alc-api PR #250 の SQL translate() 正規化で引き続き検索可能。vitest 6 ケース追加。