### PR TITLE
fix(tickets): apply toHalfWidth to detail form inputs

### DIFF
--- a/app/components/TicketCompactOverview.vue
+++ b/app/components/TicketCompactOverview.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { TroubleTicket, TroubleWorkflowState } from '~/types'
 import { updateTicket } from '~/utils/api'
+import { toHalfWidth } from '~/utils/normalize'
 
 const props = defineProps<{
   ticket: TroubleTicket
@@ -172,6 +173,7 @@ function displayValue(key: string): string {
         placeholder="登録番号を入力"
         class="flex-1 max-w-xs rounded border border-dashed border-gray-300 dark:border-gray-600 bg-transparent px-2 py-1 focus:border-solid focus:border-blue-500 focus:outline-none"
         :disabled="savingRegistration"
+        @input="(e: Event) => { const el = e.target as HTMLInputElement; const v = toHalfWidth(el.value); if (el.value !== v) el.value = v }"
         @keydown.enter.prevent="saveRegistration($event)"
         @change="saveRegistration($event)"
       >

--- a/app/components/TicketFormFields.vue
+++ b/app/components/TicketFormFields.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { TroubleCategory, TroubleOffice, TroubleProgressStatus, Employee } from '~/types'
 import { TICKET_CATEGORIES } from '~/types'
+import { toHalfWidth } from '~/utils/normalize'
 
 const model = defineModel<Record<string, unknown>>({ required: true })
 
@@ -164,7 +165,7 @@ function updateEmployee(employeeId: string) {
           <UInput
             :model-value="(model.vehicle_number as string) || ''"
             placeholder="車両番号"
-            @update:model-value="update('vehicle_number', $event)"
+            @update:model-value="(v: string | number) => update('vehicle_number', toHalfWidth(String(v ?? '')))"
           />
         </UFormField>
 
@@ -173,7 +174,7 @@ function updateEmployee(employeeId: string) {
             :model-value="(model.registration_number as string) || ''"
             placeholder="登録番号 (車検証と照合)"
             list="ticket-form-registrations"
-            @update:model-value="update('registration_number', $event)"
+            @update:model-value="(v: string | number) => update('registration_number', toHalfWidth(String(v ?? '')))"
           />
           <datalist id="ticket-form-registrations">
             <option


### PR DESCRIPTION
詳細画面 TicketFormFields.vue の 登録番号・車両番号、および TicketCompactOverview.vue のインライン登録番号入力に toHalfWidth を適用。PR #96 では list 画面のみ対応だったため、詳細画面で全角入力が半角化されない問題を修正。