### PR TITLE
chore: add .ippoan-dev.yaml + dev-proxy validate CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,3 +22,6 @@ jobs:
       integration_env: 'API_BASE_URL=http://localhost:18080'
     secrets:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+  dev-proxy:
+    uses: ippoan/ci-workflows/.github/workflows/dev-proxy-validate.yml@main

--- a/.ippoan-dev.yaml
+++ b/.ippoan-dev.yaml
@@ -1,0 +1,5 @@
+# dev-proxy metadata. Source of truth for https://<name>-dev.ippoan.org.
+# Changes here propagate to ippoan/dev-proxy via the sync workflow.
+name: nuxt-trouble
+port: 3017
+cmd: "PORT=$PORT HOST=0.0.0.0 npm run dev"


### PR DESCRIPTION
## Summary
- Declare dev-proxy metadata (name: nuxt-trouble / port: 3017) so ippoan/dev-proxy sync can aggregate it.
- Add dev-proxy-validate reusable workflow to reject port collisions or name mismatches on future PRs.

## Test plan
- [ ] CI dev-proxy job passes (fetches ippoan/dev-proxy registry, confirms port 3017 matches)
- [ ] Existing ci job still passes