### PR TITLE
chore: remove explicit dev-proxy job (now embedded in frontend-ci)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,3 @@ jobs:
       integration_env: 'API_BASE_URL=http://localhost:18080'
     secrets:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-
-  dev-proxy:
-    uses: ippoan/ci-workflows/.github/workflows/dev-proxy-validate.yml@main


### PR DESCRIPTION
## Summary
Since ippoan/ci-workflows embedded the Dev Proxy Validate job directly into frontend-ci.yml, the explicit dev-proxy job is redundant. Remove it.

## Test plan
- [ ] New `ci / Dev Proxy Validate` check appears on the PR and is green (repo already has .ippoan-dev.yaml)
- [ ] No `dev-proxy / validate` check (confirmed removed)