### PR TITLE
chore: refresh .ippoan-dev.yaml header comment

### DIFF
--- a/.ippoan-dev.yaml
+++ b/.ippoan-dev.yaml
@@ -1,5 +1,5 @@
-# dev-proxy metadata. Source of truth for https://<name>-dev.ippoan.org.
-# Changes here propagate to ippoan/dev-proxy via the sync workflow.
+# dev-proxy metadata. Must mirror the entry for ippoan/nuxt-trouble in
+# ippoan/dev-proxy/registry.json. Mismatches fail ci/Dev Proxy Validate.
 name: nuxt-trouble
 port: 3017
 cmd: "PORT=$PORT HOST=0.0.0.0 npm run dev"


### PR DESCRIPTION
## Summary
Comment cleanup: the sync workflow in ippoan/dev-proxy was removed and registry.json is now hand-curated. Update the yaml header to describe the new model so future readers aren't confused.

## Test plan
- [ ] `ci / Dev Proxy Validate` passes with the new validator format: `✓ ippoan/nuxt-trouble name=nuxt-trouble port=3017 subdir=""`