### PR TITLE
fix(carins): normalize registration_number to half-width in useCarInspections

### DIFF
--- a/app/composables/useCarInspections.ts
+++ b/app/composables/useCarInspections.ts
@@ -1,4 +1,5 @@
 import { getCarInspectionsCurrent } from '~/utils/api'
+import { toHalfWidth } from '~/utils/normalize'
 import type { CarInspectionSummary } from '~/types'
 
 function normalizeKey(s: string | null | undefined): string {
@@ -10,9 +11,10 @@ function normalizeKey(s: string | null | undefined): string {
 }
 
 function toSummary(raw: Record<string, unknown>): CarInspectionSummary | null {
-  const reg = (raw.EntryNoCarNo as string | undefined)
+  const rawReg = (raw.EntryNoCarNo as string | undefined)
     || (raw.CarNo as string | undefined)
     || ''
+  const reg = toHalfWidth(rawReg)
   if (!reg) return null
   return {
     registrationNumber: reg,

--- a/tests/composables/useCarInspections.test.ts
+++ b/tests/composables/useCarInspections.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { setupApi, teardownApi, restoreNativeApis } from '../helpers/api-test-env'
+import { setupApi, teardownApi, isLive, restoreNativeApis } from '../helpers/api-test-env'
 
 const getCarInspectionsCurrentMock = vi.fn()
 
@@ -11,17 +11,17 @@ vi.mock('~/utils/api', async (importOriginal) => {
   }
 })
 
-import { useCarInspections } from '~/composables/useCarInspections'
-
 describe('useCarInspections', () => {
   beforeEach(async () => {
     restoreNativeApis()
     await setupApi()
     getCarInspectionsCurrentMock.mockReset()
+    // singleton state is module-local; reset modules so each test starts fresh
+    vi.resetModules()
   })
   afterEach(() => teardownApi())
 
-  it('normalizes full-width registration numbers to half-width in options and lookup', async () => {
+  it.skipIf(isLive)('normalizes full-width registration numbers to half-width in options and lookup', async () => {
     getCarInspectionsCurrentMock.mockResolvedValue({
       carInspections: [
         { EntryNoCarNo: '３８８１', OwnerName: 'オーナー1', CarName: '車名1', Model: 'モデル1', ValidPeriodExpirdate: '2027-01-01' },
@@ -29,6 +29,7 @@ describe('useCarInspections', () => {
       ],
     })
 
+    const { useCarInspections } = await import('~/composables/useCarInspections')
     const ci = useCarInspections()
     await ci.load()
 

--- a/tests/composables/useCarInspections.test.ts
+++ b/tests/composables/useCarInspections.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setupApi, teardownApi, restoreNativeApis } from '../helpers/api-test-env'
+
+const getCarInspectionsCurrentMock = vi.fn()
+
+vi.mock('~/utils/api', async (importOriginal) => {
+  if (process.env.API_BASE_URL) return await importOriginal()
+  return {
+    ...(await importOriginal()),
+    getCarInspectionsCurrent: (...args: unknown[]) => getCarInspectionsCurrentMock(...args),
+  }
+})
+
+import { useCarInspections } from '~/composables/useCarInspections'
+
+describe('useCarInspections', () => {
+  beforeEach(async () => {
+    restoreNativeApis()
+    await setupApi()
+    getCarInspectionsCurrentMock.mockReset()
+  })
+  afterEach(() => teardownApi())
+
+  it('normalizes full-width registration numbers to half-width in options and lookup', async () => {
+    getCarInspectionsCurrentMock.mockResolvedValue({
+      carInspections: [
+        { EntryNoCarNo: '３８８１', OwnerName: 'オーナー1', CarName: '車名1', Model: 'モデル1', ValidPeriodExpirdate: '2027-01-01' },
+        { CarNo: '3829', OwnerName: 'オーナー2', CarName: '車名2', Model: 'モデル2', ValidPeriodExpirdate: '2027-02-01' },
+      ],
+    })
+
+    const ci = useCarInspections()
+    await ci.load()
+
+    expect(ci.registrationOptions.value).toEqual(['3881', '3829'])
+    expect(ci.lookupByRegistration('3881')?.ownerName).toBe('オーナー1')
+    expect(ci.lookupByRegistration('３８８１')?.ownerName).toBe('オーナー1')
+    expect(ci.lookupByRegistration('3829')?.ownerName).toBe('オーナー2')
+  })
+})


### PR DESCRIPTION
nuxt-trouble の tickets テーブル行にある登録番号インライン入力 (datalist 由来の autocomplete) で、半角数字を入力しても候補が絞り込めない不具合を修正。

## 原因

`useCarInspections.ts` の `_registrationOptions` (datalist `<option :value>` ソース) は車検証マスタ raw 値 (`EntryNoCarNo` / `CarNo`) をそのまま返しており、マスタ側が全角で格納されているケースで半角入力との literal 比較が一致しなかった。`normalizeKey()` は `_lookupMap` 用にだけ使われていて datalist には未適用。

## 修正

`toSummary()` で `registrationNumber` を `toHalfWidth` 正規化して格納する 1 行の変更。
これで `_registrationOptions` も半角統一され、ブラウザ native datalist の絞り込みが半角入力でヒットする。

## Test plan

- [x] 追加: `tests/composables/useCarInspections.test.ts` — 全角・半角混在の入力で registrationOptions が半角に揃うこと、lookup が両形式で引けることを検証。ローカル vitest pass 済み。
- [ ] HMR 確認: nuxt-trouble-dev.ippoan.org/tickets の空行登録番号セルに半角で入力し autocomplete 候補が絞り込まれることを目視確認。