### PR TITLE
fix: rename UToggle to USwitch for Nuxt UI v4 compat

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -54,7 +54,7 @@ function handleLogout() {
       <div class="p-4 border-t border-gray-200 dark:border-gray-800">
         <div class="flex items-center justify-between mb-3">
           <span class="text-xs text-gray-500 dark:text-gray-400">ダークモード</span>
-          <UToggle v-model="isDark" size="xs" />
+          <USwitch v-model="isDark" size="xs" />
         </div>
         <div class="text-sm text-gray-600 dark:text-gray-400 truncate mb-2">
           {{ username }}

--- a/tests/helpers/nuxt-stubs.ts
+++ b/tests/helpers/nuxt-stubs.ts
@@ -13,7 +13,7 @@ export const UFormField = { template: '<div><slot /></div>', props: ['label', 'r
 export const UTextarea = { template: '<textarea />', props: ['modelValue', 'placeholder', 'rows'] }
 export const UModal = { template: '<div v-if="open"><slot name="content" /></div>', props: ['open'] }
 export const UPagination = { template: '<div />', props: ['modelValue', 'total', 'itemsPerPage'] }
-export const UToggle = { template: '<input type="checkbox" />', props: ['modelValue', 'size'] }
+export const USwitch = { template: '<input type="checkbox" />', props: ['modelValue', 'size'] }
 export const NuxtLink = { template: '<a><slot /></a>', props: ['to'] }
 export const NuxtLayout = { template: '<div><slot /></div>' }
 export const NuxtPage = { template: '<div />' }
@@ -29,7 +29,7 @@ export const TicketFilesStub = { template: '<div />', props: ['ticketId'] }
 
 export const allStubs = {
   UApp, UCard, UButton, UIcon, UBadge, UInput, USelect, UFormField,
-  UTextarea, UModal, UPagination, UToggle, NuxtLink, NuxtLayout, NuxtPage,
+  UTextarea, UModal, UPagination, USwitch, NuxtLink, NuxtLayout, NuxtPage,
   StagingFooter,
   TicketCategoryBadge: TicketCategoryBadgeStub,
   TicketFormFields: TicketFormFieldsStub,


### PR DESCRIPTION
## Summary
- Replace `UToggle` with `USwitch` in the sidebar dark-mode toggle.
- Nuxt UI v4 removed `UToggle` (only `Switch.vue` ships in `node_modules/@nuxt/ui/dist/runtime/components/`), so the previous markup triggered `[Vue warn]: Failed to resolve component: UToggle` on every page using the default layout.
- Also rename the test stub in `tests/helpers/nuxt-stubs.ts` so unit tests keep stubbing the component actually rendered.

## Test plan
- [ ] `npm run test` passes
- [ ] staging (`nuxt-trouble-dev.ippoan.org`) — warning disappears from DevTools console, dark-mode switch toggles the theme