### PR TITLE
fix(tickets): always show editable input for registration_number

### DIFF
--- a/app/pages/tickets/index.vue
+++ b/app/pages/tickets/index.vue
@@ -224,26 +224,23 @@ watch(() => ({ ...filter }), () => { fetchTickets() }, { deep: true })
               <td class="py-2 px-2">{{ ticket.department || '-' }}</td>
               <td class="py-2 px-2">{{ ticket.person_name || '-' }}</td>
               <td class="py-2 px-2" @click.stop>
-                <template v-if="ticket.registration_number">
-                  <span>{{ ticket.registration_number }}</span>
-                  <UIcon
-                    v-if="lookupCarInspection(ticket.registration_number)"
-                    name="i-lucide-info"
-                    class="ml-1 inline size-3.5 text-blue-500 align-middle"
-                    :title="(() => { const s = lookupCarInspection(ticket.registration_number)!; return `所有者: ${s.ownerName || '-'}\n車種: ${s.carName || '-'}\n型式: ${s.model || '-'}\n車検満了日: ${formatExpiry(s.validPeriodExpirdate)}` })()"
-                  />
-                </template>
                 <input
-                  v-else
                   type="text"
                   list="car-inspection-registrations"
                   placeholder="登録番号を入力"
                   class="w-28 rounded border border-dashed border-gray-300 dark:border-gray-600 bg-transparent px-1.5 py-0.5 text-xs focus:border-solid focus:border-blue-500 focus:outline-none"
+                  :value="ticket.registration_number || ''"
                   :disabled="savingRegistrationIds.has(ticket.id)"
                   @input="(e: Event) => { const el = e.target as HTMLInputElement; const v = toHalfWidth(el.value); if (el.value !== v) el.value = v }"
                   @keydown.enter.prevent="saveRegistration(ticket.id, $event)"
                   @change="saveRegistration(ticket.id, $event)"
                 >
+                <UIcon
+                  v-if="ticket.registration_number && lookupCarInspection(ticket.registration_number)"
+                  name="i-lucide-info"
+                  class="ml-1 inline size-3.5 text-blue-500 align-middle"
+                  :title="(() => { const s = lookupCarInspection(ticket.registration_number)!; return `所有者: ${s.ownerName || '-'}\n車種: ${s.carName || '-'}\n型式: ${s.model || '-'}\n車検満了日: ${formatExpiry(s.validPeriodExpirdate)}` })()"
+                />
               </td>
               <td class="py-2 px-2"><TicketCategoryBadge :category="ticket.category" /></td>
               <td class="py-2 px-2 max-w-[120px] truncate">{{ ticket.location || '-' }}</td>


### PR DESCRIPTION
## Summary
- 一覧の登録番号セルで、既に値が入っている行も上書き編集できるようにした
- PR #92 以降「空の時だけ input、値があると static span」だったため編集不可だったのを修正
- 常に input を表示し、車検証情報アイコンは入力欄の隣に出す

## Test plan
- [ ] /tickets 一覧で登録番号入力済の行をクリックして編集 → Enter で保存される
- [ ] 空欄行も従来通り placeholder 表示で入力できる
- [ ] 全角数字入力が半角に正規化される
- [ ] 車検証情報あり行で UIcon ツールチップが表示される
- [ ] 行クリックで詳細ページに遷移しない (@click.stop)