### PR TITLE
fix(tickets): allow clearing registration_number via empty input

### DIFF
--- a/app/pages/tickets/index.vue
+++ b/app/pages/tickets/index.vue
@@ -38,12 +38,14 @@ const savingRegistrationIds = reactive(new Set<string>())
 async function saveRegistration(ticketId: string, event: Event) {
   const target = event.target as HTMLInputElement
   const value = target.value.trim()
-  if (!value) return
   // 二重発火防止
   if (savingRegistrationIds.has(ticketId)) return
+  // 値が変わっていなければ何もしない（空→空含む）
+  const current = tickets.value.find((t: TroubleTicket) => t.id === ticketId)?.registration_number || ''
+  if (value === current) return
   savingRegistrationIds.add(ticketId)
   try {
-    const updated = await updateTicket(ticketId, { registration_number: value })
+    const updated = await updateTicket(ticketId, { registration_number: value || null })
     // 再フェッチせず該当行のみローカル更新 → フォーカス・スクロール位置を保つ
     const list = tickets.value.slice()
     const idx = list.findIndex((t: TroubleTicket) => t.id === ticketId)
@@ -53,7 +55,7 @@ async function saveRegistration(ticketId: string, event: Event) {
     }
   } catch (e) {
     console.error('登録番号の保存に失敗:', e)
-    target.value = ''
+    target.value = current
   } finally {
     savingRegistrationIds.delete(ticketId)
   }


### PR DESCRIPTION
## Summary
- 登録番号セルで空欄にして Enter/blur すると null に更新できるようにした
- 値変化なしの場合は API を呼ばない (no-op)
- 失敗時は元の値に戻す

## Test plan
- [ ] 既存値ありセル → 空にして Enter で削除される (再フェッチなしで該当行が空表示)
- [ ] 空 → 空 で blur しても PATCH リクエストが飛ばないこと (Network)
- [ ] 同じ値で blur しても PATCH が飛ばないこと
- [ ] PATCH 失敗時に input が元の値に戻ること