### PR TITLE
feat(tickets): 発生日 → 発生日時 (datetime-local)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 .output/
 dist/
 coverage/
+.wrangler/
 *.log
 .DS_Store
 worker-configuration.d.ts

--- a/app/components/TicketCompactOverview.vue
+++ b/app/components/TicketCompactOverview.vue
@@ -2,6 +2,7 @@
 import type { TroubleTicket, TroubleWorkflowState } from '~/types'
 import { updateTicket } from '~/utils/api'
 import { toHalfWidth } from '~/utils/normalize'
+import { formatOccurredAt } from '~/utils/datetime'
 
 const props = defineProps<{
   ticket: TroubleTicket
@@ -88,7 +89,7 @@ const fields: Array<{ label: string; key: string }> = [
   { label: 'カテゴリ', key: 'category' },
   { label: 'タイトル', key: 'title' },
   { label: '説明', key: 'description' },
-  { label: '発生日', key: 'occurred_date' },
+  { label: '発生日時', key: 'occurred_at' },
   { label: '会社名', key: 'company_name' },
   { label: '営業所名', key: 'office_name' },
   { label: '部署名', key: 'department' },
@@ -104,21 +105,24 @@ const fields: Array<{ label: string; key: string }> = [
 ]
 
 function displayValue(key: string): string {
+  if (key === 'occurred_at') {
+    return formatOccurredAt(props.ticket.occurred_at, props.ticket.occurred_date)
+  }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const val = (props.ticket as any)[key]
   if (val == null || val === '') return '-'
-  if (key === 'due_date' || key === 'occurred_date') return String(val).substring(0, 10)
+  if (key === 'due_date') return String(val).substring(0, 10)
   return String(val)
 }
 </script>
 
 <template>
   <div class="space-y-1">
-    <!-- Line 1: person_name + occurred_date -->
+    <!-- Line 1: person_name + occurred_at -->
     <div class="flex items-center gap-2 text-sm">
       <span v-if="ticket.person_name" class="font-medium">{{ ticket.person_name }}</span>
-      <span v-if="ticket.occurred_date" class="text-gray-500">
-        {{ ticket.occurred_date.substring(0, 10) }}
+      <span v-if="ticket.occurred_at || ticket.occurred_date" class="text-gray-500">
+        {{ formatOccurredAt(ticket.occurred_at, ticket.occurred_date) }}
       </span>
     </div>
 

--- a/app/components/TicketFormFields.vue
+++ b/app/components/TicketFormFields.vue
@@ -104,11 +104,11 @@ function updateEmployee(employeeId: string) {
         />
       </UFormField>
 
-      <UFormField label="発生日">
+      <UFormField label="発生日時">
         <UInput
-          type="date"
-          :model-value="(model.occurred_date as string) || ''"
-          @update:model-value="update('occurred_date', $event)"
+          type="datetime-local"
+          :model-value="(model.occurred_at as string) || ''"
+          @update:model-value="update('occurred_at', $event)"
         />
       </UFormField>
     </fieldset>

--- a/app/composables/useTicketDetail.ts
+++ b/app/composables/useTicketDetail.ts
@@ -1,5 +1,6 @@
 import { getTicket, updateTicket, deleteTicket, getWorkflowStates } from '~/utils/api'
 import type { TroubleTicket, TroubleWorkflowState, UpdateTroubleTicket } from '~/types'
+import { toDatetimeLocalInput, fromDatetimeLocalInput, formatOccurredAt } from '~/utils/datetime'
 
 export function useTicketDetail(ticketId: string) {
   const router = useRouter()
@@ -22,7 +23,7 @@ export function useTicketDetail(ticketId: string) {
     { label: 'カテゴリ', key: 'category' },
     { label: 'タイトル', key: 'title' },
     { label: '説明', key: 'description' },
-    { label: '発生日', key: 'occurred_date' },
+    { label: '発生日時', key: 'occurred_at' },
     { label: '会社名', key: 'company_name' },
     { label: '営業所名', key: 'office_name' },
     { label: '部署名', key: 'department' },
@@ -38,6 +39,9 @@ export function useTicketDetail(ticketId: string) {
 
   function displayValue(key: string): string {
     if (!ticket.value) return '-'
+    if (key === 'occurred_at') {
+      return formatOccurredAt(ticket.value.occurred_at, ticket.value.occurred_date)
+    }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const val = (ticket.value as any)[key]
     if (val == null || val === '') return '-'
@@ -50,7 +54,7 @@ export function useTicketDetail(ticketId: string) {
       category: ticket.value.category,
       title: ticket.value.title,
       description: ticket.value.description,
-      occurred_date: ticket.value.occurred_date || '',
+      occurred_at: toDatetimeLocalInput(ticket.value.occurred_at),
       company_name: ticket.value.company_name,
       office_name: ticket.value.office_name,
       department: ticket.value.department,
@@ -73,9 +77,15 @@ export function useTicketDetail(ticketId: string) {
     try {
       const data: Record<string, unknown> = {}
       for (const [key, value] of Object.entries(form.value)) {
+        if (key === 'occurred_at') continue
         if (value != null && value !== '') {
           data[key] = value
         }
+      }
+      const occurred = fromDatetimeLocalInput(form.value.occurred_at as string | undefined)
+      if (occurred) {
+        data.occurred_at = occurred.occurred_at
+        data.occurred_date = occurred.occurred_date
       }
       ticket.value = await updateTicket(ticketId, data as UpdateTroubleTicket)
       editing.value = false

--- a/app/composables/useTicketDetail.ts
+++ b/app/composables/useTicketDetail.ts
@@ -54,7 +54,7 @@ export function useTicketDetail(ticketId: string) {
       category: ticket.value.category,
       title: ticket.value.title,
       description: ticket.value.description,
-      occurred_at: toDatetimeLocalInput(ticket.value.occurred_at),
+      occurred_at: toDatetimeLocalInput(ticket.value.occurred_at, ticket.value.occurred_date),
       company_name: ticket.value.company_name,
       office_name: ticket.value.office_name,
       department: ticket.value.department,

--- a/app/composables/useTicketList.ts
+++ b/app/composables/useTicketList.ts
@@ -1,6 +1,7 @@
 import { getTickets, getWorkflowStates, deleteTicket, exportTicketsCsv, createTicket, setupDefaultWorkflow, getCategories, getOffices, getProgressStatuses } from '~/utils/api'
 import { TICKET_CATEGORIES } from '~/types'
 import type { TroubleTicket, TroubleWorkflowState, TroubleCategory, TroubleOffice, TroubleProgressStatus, CreateTroubleTicket } from '~/types'
+import { fromDatetimeLocalInput } from '~/utils/datetime'
 
 const STORAGE_KEY = 'trouble_filter_status'
 
@@ -135,7 +136,7 @@ export function useTicketList() {
   const creating = ref(false)
   const newTicket = reactive({
     category: '' as string,
-    occurred_date: '',
+    occurred_at: '',
     company_name: '',
     office_name: '',
     department: '',
@@ -157,7 +158,7 @@ export function useTicketList() {
 
   function resetNewTicket() {
     Object.assign(newTicket, {
-      category: '', occurred_date: '', company_name: '', office_name: '',
+      category: '', occurred_at: '', company_name: '', office_name: '',
       department: '', person_name: '', registration_number: '', location: '',
       description: '', progress_notes: '', allowance: '', damage_amount: '',
       compensation_amount: '', confirmation_notice: '', disciplinary_content: '',
@@ -174,7 +175,7 @@ export function useTicketList() {
       if (states.length === 0) await setupDefaultWorkflow()
       const payload: Record<string, unknown> = { category: newTicket.category }
       const fields = [
-        'occurred_date', 'company_name', 'office_name', 'department',
+        'company_name', 'office_name', 'department',
         'person_name', 'registration_number', 'location', 'description',
         'progress_notes', 'allowance', 'confirmation_notice',
         'disciplinary_content', 'disciplinary_action', 'counterparty',
@@ -185,6 +186,11 @@ export function useTicketList() {
       }
       for (const key of ['damage_amount', 'compensation_amount', 'road_service_cost'] as const) {
         if (newTicket[key]) payload[key] = Number(newTicket[key])
+      }
+      const occurred = fromDatetimeLocalInput(newTicket.occurred_at)
+      if (occurred) {
+        payload.occurred_at = occurred.occurred_at
+        payload.occurred_date = occurred.occurred_date
       }
       await createTicket(payload as unknown as CreateTroubleTicket)
       resetNewTicket()

--- a/app/composables/useTicketNew.ts
+++ b/app/composables/useTicketNew.ts
@@ -1,5 +1,6 @@
 import { createTicket, setupDefaultWorkflow, getWorkflowStates } from '~/utils/api'
 import type { CreateTroubleTicket } from '~/types'
+import { fromDatetimeLocalInput } from '~/utils/datetime'
 
 export function useTicketNew() {
   const router = useRouter()
@@ -10,7 +11,7 @@ export function useTicketNew() {
     category: '',
     title: '',
     description: '',
-    occurred_date: '',
+    occurred_at: '',
     company_name: '',
     office_name: '',
     department: '',
@@ -45,10 +46,15 @@ export function useTicketNew() {
       await ensureWorkflow()
       const payload: Record<string, unknown> = { category: form.value.category }
       for (const [key, value] of Object.entries(form.value)) {
-        if (key === 'category') continue
+        if (key === 'category' || key === 'occurred_at') continue
         if (value != null && value !== '') {
           payload[key] = value
         }
+      }
+      const occurred = fromDatetimeLocalInput(form.value.occurred_at as string | undefined)
+      if (occurred) {
+        payload.occurred_at = occurred.occurred_at
+        payload.occurred_date = occurred.occurred_date
       }
       const ticket = await createTicket(payload as unknown as CreateTroubleTicket)
       router.push(`/tickets/${ticket.id}`)

--- a/app/pages/tickets/index.vue
+++ b/app/pages/tickets/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { updateTicket } from '~/utils/api'
 import { toHalfWidth } from '~/utils/normalize'
+import { formatOccurredAt } from '~/utils/datetime'
 import type { TroubleTicket } from '~/types'
 
 const {
@@ -12,7 +13,7 @@ const {
   resetNewTicket, handleInlineCreate,
   fetchTickets, fetchWorkflowStates, fetchMasterData,
   clearFilter, confirmDelete, handleDelete, handleExportCsv,
-  formatDate, navigateToTicket,
+  navigateToTicket,
 } = useTicketList()
 
 const {
@@ -148,7 +149,7 @@ watch(() => ({ ...filter }), () => { fetchTickets() }, { deep: true })
     <div v-else class="overflow-x-auto p-3 rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50/50 dark:bg-blue-950/30">
       <div class="flex items-end gap-2 whitespace-nowrap min-w-[1600px]">
         <USelect v-model="newTicket.category" :items="createCategoryOptions" placeholder="カテゴリ" size="sm" class="w-28" />
-        <UInput v-model="newTicket.occurred_date" type="date" size="sm" class="w-32" />
+        <UInput v-model="newTicket.occurred_at" type="datetime-local" size="sm" class="w-44" />
         <UInput v-model="newTicket.company_name" placeholder="会社名" size="sm" class="w-24" />
         <USelect v-model="newTicket.office_name" :items="officeOptions" placeholder="営業所" size="sm" class="w-24" :disabled="officeOptions.length === 0" />
         <UInput v-model="newTicket.department" placeholder="運行課" size="sm" class="w-20" />
@@ -189,7 +190,7 @@ watch(() => ({ ...filter }), () => { fetchTickets() }, { deep: true })
           <thead>
             <tr class="border-b border-gray-200 dark:border-gray-700">
               <th class="text-left py-2 px-2 font-medium">No</th>
-              <th class="text-left py-2 px-2 font-medium">発生日</th>
+              <th class="text-left py-2 px-2 font-medium">発生日時</th>
               <th class="text-left py-2 px-2 font-medium">所属会社名</th>
               <th class="text-left py-2 px-2 font-medium">営業所名</th>
               <th class="text-left py-2 px-2 font-medium">運行課</th>
@@ -220,7 +221,7 @@ watch(() => ({ ...filter }), () => { fetchTickets() }, { deep: true })
               @click="navigateToTicket(ticket.id)"
             >
               <td class="py-2 px-2 text-gray-500">{{ ticket.ticket_no }}</td>
-              <td class="py-2 px-2">{{ formatDate(ticket.occurred_date) }}</td>
+              <td class="py-2 px-2">{{ formatOccurredAt(ticket.occurred_at, ticket.occurred_date) }}</td>
               <td class="py-2 px-2">{{ ticket.company_name || '-' }}</td>
               <td class="py-2 px-2">{{ ticket.office_name || '-' }}</td>
               <td class="py-2 px-2">{{ ticket.department || '-' }}</td>

--- a/app/utils/datetime.ts
+++ b/app/utils/datetime.ts
@@ -2,11 +2,21 @@ function pad(n: number): string {
   return String(n).padStart(2, '0')
 }
 
-export function toDatetimeLocalInput(iso: string | null | undefined): string {
-  if (!iso) return ''
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return ''
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+export function toDatetimeLocalInput(
+  iso: string | null | undefined,
+  fallbackDate?: string | null | undefined,
+): string {
+  if (iso) {
+    const d = new Date(iso)
+    if (!Number.isNaN(d.getTime())) {
+      return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+    }
+  }
+  if (fallbackDate) {
+    const ymd = String(fallbackDate).substring(0, 10)
+    if (/^\d{4}-\d{2}-\d{2}$/.test(ymd)) return `${ymd}T00:00`
+  }
+  return ''
 }
 
 export function fromDatetimeLocalInput(

--- a/app/utils/datetime.ts
+++ b/app/utils/datetime.ts
@@ -1,0 +1,36 @@
+function pad(n: number): string {
+  return String(n).padStart(2, '0')
+}
+
+export function toDatetimeLocalInput(iso: string | null | undefined): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+export function fromDatetimeLocalInput(
+  v: string | null | undefined,
+): { occurred_at: string; occurred_date: string } | null {
+  if (!v) return null
+  const d = new Date(v)
+  if (Number.isNaN(d.getTime())) return null
+  return {
+    occurred_at: d.toISOString(),
+    occurred_date: `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`,
+  }
+}
+
+export function formatOccurredAt(
+  occurredAt: string | null | undefined,
+  occurredDate?: string | null | undefined,
+): string {
+  if (occurredAt) {
+    const d = new Date(occurredAt)
+    if (!Number.isNaN(d.getTime())) {
+      return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
+    }
+  }
+  if (occurredDate) return String(occurredDate).substring(0, 10)
+  return '-'
+}

--- a/tests/components/TicketFormFields.test.ts
+++ b/tests/components/TicketFormFields.test.ts
@@ -14,7 +14,7 @@ describe('TicketFormFields', () => {
     category: '',
     title: '',
     description: '',
-    occurred_date: '',
+    occurred_at: '',
     company_name: '',
     office_name: '',
     department: '',

--- a/tests/composables/useTicketList.test.ts
+++ b/tests/composables/useTicketList.test.ts
@@ -318,7 +318,7 @@ describe('useTicketList', () => {
     l.newTicket.category = '貨物事故'
     l.newTicket.company_name = '会社A'
     l.newTicket.office_name = '営業所B'
-    l.newTicket.occurred_date = '2026-01-15'
+    l.newTicket.occurred_at = '2026-01-15T09:30'
     l.newTicket.description = '説明テスト'
     await l.handleInlineCreate()
 
@@ -326,6 +326,8 @@ describe('useTicketList', () => {
     expect(payload.company_name).toBe('会社A')
     expect(payload.office_name).toBe('営業所B')
     expect(payload.occurred_date).toBe('2026-01-15')
+    expect(typeof payload.occurred_at).toBe('string')
+    expect(payload.occurred_at).toMatch(/^2026-01-15T/)
     expect(payload.description).toBe('説明テスト')
   })
 


### PR DESCRIPTION
## Summary
- 単一 datetime-local 入力で 発生日時 (occurred_at) を編集可能に
- occurred_date も client 側で派生し両 DB カラム同期
- legacy (occurred_date のみ) データのフォールバック表示・編集対応
- app/utils/datetime.ts に共通ヘルパー
- 一覧カラム・詳細表示・インライン新規作成・新規作成ページも統一

## Test plan
- [ ] /tickets/<id> で「編集」→ 発生日時 (datetime-local) に既存値が埋まる
- [ ] 保存後リロードで永続化
- [ ] 空欄保存で既存値が維持される (COALESCE)
- [ ] legacy (occurred_date のみ) データは YYYY-MM-DD 00:00 で prefill
- [ ] /tickets 一覧のカラム見出しが「発生日時」、値が時刻付き

🤖 Generated with [Claude Code](https://claude.com/claude-code)