### PR TITLE
fix(settings): renumber full list on up/down so ties no longer block reorder

### DIFF
--- a/app/components/MasterDataManager.vue
+++ b/app/components/MasterDataManager.vue
@@ -34,13 +34,26 @@ const mergedItems = computed(() => {
   return [...dbItems, ...builtins].sort((a, b) => a.sort_order - b.sort_order)
 })
 
+function emitReorderedList(newOrder: typeof mergedItems.value) {
+  // Renumber the entire visible list with sequential indices (10x granularity
+  // so future single-item inserts can fit between). Skip builtins.
+  let dbIndex = 0
+  for (const it of newOrder) {
+    if (it.isBuiltin || !it.id) continue
+    dbIndex += 1
+    emit('reorder', it.id, dbIndex * 10)
+  }
+}
+
 function moveUp(index: number) {
   const item = mergedItems.value[index]
   const prev = mergedItems.value[index - 1]
   if (!item || !prev || index === 0 || item.isBuiltin || !item.id) return
   if (prev.isBuiltin || !prev.id) return
-  emit('reorder', item.id, prev.sort_order)
-  emit('reorder', prev.id, item.sort_order)
+  const newOrder = [...mergedItems.value]
+  newOrder[index - 1] = item
+  newOrder[index] = prev
+  emitReorderedList(newOrder)
 }
 
 function moveDown(index: number) {
@@ -48,8 +61,10 @@ function moveDown(index: number) {
   const next = mergedItems.value[index + 1]
   if (!item || !next || index >= mergedItems.value.length - 1 || item.isBuiltin || !item.id) return
   if (next.isBuiltin || !next.id) return
-  emit('reorder', item.id, next.sort_order)
-  emit('reorder', next.id, item.sort_order)
+  const newOrder = [...mergedItems.value]
+  newOrder[index + 1] = item
+  newOrder[index] = next
+  emitReorderedList(newOrder)
 }
 </script>
 

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -38,7 +38,7 @@ async function fetchCategories() {
 
 async function handleCreateCategory(name: string) {
   try {
-    const created = await createCategory({ name })
+    const created = await createCategory({ name, sort_order: (categories.value.length + 1) * 10 })
     categories.value = [...categories.value, created]
   } catch (e) {
     console.error('カテゴリ作成エラー:', e)
@@ -81,7 +81,7 @@ async function fetchTaskTypes() {
 
 async function handleCreateTaskType(name: string) {
   try {
-    const created = await createTaskType({ name })
+    const created = await createTaskType({ name, sort_order: (taskTypes.value.length + 1) * 10 })
     taskTypes.value = [...taskTypes.value, created]
   } catch (e) {
     console.error('タスクタイプ作成エラー:', e)
@@ -124,7 +124,7 @@ async function fetchOffices() {
 
 async function handleCreateOffice(name: string) {
   try {
-    const created = await createOffice({ name })
+    const created = await createOffice({ name, sort_order: (offices.value.length + 1) * 10 })
     offices.value = [...offices.value, created]
   } catch (e) {
     console.error('営業所作成エラー:', e)
@@ -167,7 +167,7 @@ async function fetchProgressStatuses() {
 
 async function handleCreateProgressStatus(name: string) {
   try {
-    const created = await createProgressStatus({ name })
+    const created = await createProgressStatus({ name, sort_order: (progressStatuses.value.length + 1) * 10 })
     progressStatuses.value = [...progressStatuses.value, created]
   } catch (e) {
     console.error('進捗状況作成エラー:', e)

--- a/tests/components/MasterDataManager.test.ts
+++ b/tests/components/MasterDataManager.test.ts
@@ -7,6 +7,7 @@ const stubs = {
   UButton: {
     template: '<button :disabled="disabled" @click="$emit(\'click\')">{{ label }}</button>',
     props: ['label', 'icon', 'size', 'disabled', 'variant', 'color'],
+    inheritAttrs: false,
   },
   UBadge: {
     template: '<span class="badge"><slot /></span>',
@@ -132,11 +133,11 @@ describe('MasterDataManager', () => {
     await upButton.trigger('click')
     const reorderEvents = wrapper.emitted('reorder')
     expect(reorderEvents).toBeTruthy()
-    expect(reorderEvents!.length).toBeGreaterThanOrEqual(2)
-    // Should contain the swap pair
-    const pairs = reorderEvents!.map(e => e)
-    expect(pairs).toContainEqual(['2', 1])
-    expect(pairs).toContainEqual(['1', 2])
+    // After swap, B is first (sort_order 10), A is second (sort_order 20)
+    expect(reorderEvents).toEqual([
+      ['2', 10],
+      ['1', 20],
+    ])
   })
 
   it('emits reorder events on moveDown', async () => {
@@ -154,10 +155,97 @@ describe('MasterDataManager', () => {
     await downButton.trigger('click')
     const reorderEvents = wrapper.emitted('reorder')
     expect(reorderEvents).toBeTruthy()
-    expect(reorderEvents!.length).toBeGreaterThanOrEqual(2)
-    const pairs = reorderEvents!.map(e => e)
-    expect(pairs).toContainEqual(['1', 2])
-    expect(pairs).toContainEqual(['2', 1])
+    // After swap, B is first (sort_order 10), A is second (sort_order 20)
+    expect(reorderEvents).toEqual([
+      ['2', 10],
+      ['1', 20],
+    ])
+  })
+
+  it('moveUp on index 2 of 5-item list emits 5 sequential reorder events with swap reflected', async () => {
+    // Reproduces issue #106: all items have sort_order 0 (ties).
+    // The component must renumber the entire list to break ties.
+    const sortedItems = [
+      { id: 'a', name: '佐賀', sort_order: 0 },
+      { id: 'b', name: '帯広', sort_order: 0 },
+      { id: 'c', name: '本社', sort_order: 0 },
+      { id: 'd', name: '諸富', sort_order: 0 },
+      { id: 'e', name: '北九州', sort_order: 0 },
+    ]
+    const wrapper = mount(MasterDataManager, {
+      props: { title: '営業所', items: sortedItems, loading: false },
+      global: { stubs },
+    })
+    const listItems = wrapper.findAll('li')
+    // Click "up" on item at index 2 ('本社')
+    const upButton = listItems[2].findAll('button')[0]
+    await upButton.trigger('click')
+    const reorderEvents = wrapper.emitted('reorder')
+    expect(reorderEvents).toBeTruthy()
+    // New order: 佐賀(a), 本社(c), 帯広(b), 諸富(d), 北九州(e)
+    expect(reorderEvents).toEqual([
+      ['a', 10],
+      ['c', 20],
+      ['b', 30],
+      ['d', 40],
+      ['e', 50],
+    ])
+  })
+
+  it('moveDown on index 2 of 5-item list emits 5 sequential reorder events with swap reflected', async () => {
+    const sortedItems = [
+      { id: 'a', name: '佐賀', sort_order: 0 },
+      { id: 'b', name: '帯広', sort_order: 0 },
+      { id: 'c', name: '本社', sort_order: 0 },
+      { id: 'd', name: '諸富', sort_order: 0 },
+      { id: 'e', name: '北九州', sort_order: 0 },
+    ]
+    const wrapper = mount(MasterDataManager, {
+      props: { title: '営業所', items: sortedItems, loading: false },
+      global: { stubs },
+    })
+    const listItems = wrapper.findAll('li')
+    // Click "down" on item at index 2 ('本社')
+    const downButton = listItems[2].findAll('button')[1]
+    await downButton.trigger('click')
+    const reorderEvents = wrapper.emitted('reorder')
+    expect(reorderEvents).toBeTruthy()
+    // New order: 佐賀(a), 帯広(b), 諸富(d), 本社(c), 北九州(e)
+    expect(reorderEvents).toEqual([
+      ['a', 10],
+      ['b', 20],
+      ['d', 30],
+      ['c', 40],
+      ['e', 50],
+    ])
+  })
+
+  it('builtins are skipped when emitting reorder events (only db items get sort_order)', async () => {
+    const sortedItems = [
+      { id: '1', name: 'A', sort_order: 10 },
+      { id: '2', name: 'B', sort_order: 20 },
+    ]
+    const wrapper = mount(MasterDataManager, {
+      props: {
+        title: 'テスト',
+        items: sortedItems,
+        builtinItems: ['X', 'Y'],
+        loading: false,
+      },
+      global: { stubs },
+    })
+    // mergedItems: A(db,10), B(db,20), X(builtin,1000), Y(builtin,1001)
+    const listItems = wrapper.findAll('li')
+    // Move B up — swap A and B; builtins are unchanged
+    const upButton = listItems[1].findAll('button')[0]
+    await upButton.trigger('click')
+    const reorderEvents = wrapper.emitted('reorder')
+    expect(reorderEvents).toBeTruthy()
+    // Only db items emit. New order: B(db), A(db), X(builtin skip), Y(builtin skip)
+    expect(reorderEvents).toEqual([
+      ['2', 10],
+      ['1', 20],
+    ])
   })
 
   it('does not emit reorder for first item moveUp', async () => {


### PR DESCRIPTION
## Summary

- `sort_order` が全件 0 (バックエンド `unwrap_or(0)`) の状態で ↑↓ を押すと 0↔0 の交換になり無反応だった
- `MasterDataManager.vue` の swap を「表示順のまま全件再ナンバリング (sort_order = (dbIndex+1)*10)」に変更
- 新規作成時も `sort_order: (items.length + 1) * 10` を渡してリスト末尾に追加
- Builtin は reorder emit 対象外のまま

## Test plan

- [x] vitest: 27 files / 161 tests pass
- [x] 動作確認: /settings 営業所タブで ↑↓ が効く (ユーザー確認済)

Closes #106