### PR TITLE
feat(tickets): show car inspection expiry date on ticket detail

### DIFF
--- a/app/components/TicketCompactOverview.vue
+++ b/app/components/TicketCompactOverview.vue
@@ -3,6 +3,7 @@ import type { TroubleTicket, TroubleWorkflowState } from '~/types'
 import { updateTicket } from '~/utils/api'
 import { toHalfWidth } from '~/utils/normalize'
 import { formatOccurredAt } from '~/utils/datetime'
+import { formatExpiry, getExpiryStatus } from '~/utils/carInspection'
 
 const props = defineProps<{
   ticket: TroubleTicket
@@ -48,10 +49,31 @@ async function saveRegistration(event: Event) {
   }
 }
 
-function formatExpiry(v: string): string {
-  if (!v) return '-'
-  return v.length > 10 ? v.substring(0, 10) : v
-}
+const expiryStatus = computed(() =>
+  getExpiryStatus(carInspectionMatch.value?.validPeriodExpirdate),
+)
+
+const expiryBadgeClass = computed(() => {
+  switch (expiryStatus.value) {
+    case 'expired':
+      return 'bg-red-100 text-red-700 border border-red-300 dark:bg-red-900/40 dark:text-red-200 dark:border-red-800'
+    case 'soon':
+      return 'bg-yellow-100 text-yellow-800 border border-yellow-300 dark:bg-yellow-900/40 dark:text-yellow-200 dark:border-yellow-800'
+    case 'ok':
+      return 'bg-gray-100 text-gray-700 border border-gray-300 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-700'
+    default:
+      return 'bg-gray-100 text-gray-500 border border-gray-300 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-700'
+  }
+})
+
+const expiryStatusLabel = computed(() => {
+  switch (expiryStatus.value) {
+    case 'expired': return '期限切れ'
+    case 'soon': return '残り30日以内'
+    case 'ok': return '有効'
+    default: return ''
+  }
+})
 
 const locationLine = computed(() => {
   const parts = [props.ticket.company_name, props.ticket.office_name].filter(Boolean)
@@ -148,20 +170,38 @@ function displayValue(key: string): string {
       :class="carInspectionMatch
         ? 'border-blue-200 bg-blue-50 dark:border-blue-900 dark:bg-blue-950/40'
         : 'border-gray-200 bg-gray-50 text-gray-500 dark:border-gray-700 dark:bg-gray-900'"
+      data-testid="car-inspection-section"
     >
       <template v-if="carInspectionMatch">
-        <div class="font-semibold text-blue-700 dark:text-blue-300">
-          登録番号 {{ carInspectionMatch.registrationNumber }}
+        <div class="flex items-center gap-3 flex-wrap">
+          <div class="font-semibold text-blue-700 dark:text-blue-300">
+            登録番号 {{ carInspectionMatch.registrationNumber }}
+          </div>
+          <!-- 車検満了日 prominent badge, inline next to registration number -->
+          <div class="flex items-center gap-1.5">
+            <span class="text-gray-500">車検満了日:</span>
+            <span
+              class="inline-flex items-center gap-1 rounded px-2 py-0.5 text-sm font-semibold"
+              :class="expiryBadgeClass"
+              data-testid="car-expiry-badge"
+            >
+              {{ formatExpiry(carInspectionMatch.validPeriodExpirdate) }}
+              <span v-if="expiryStatusLabel" class="text-[10px] font-normal opacity-80">
+                ({{ expiryStatusLabel }})
+              </span>
+            </span>
+          </div>
         </div>
-        <div class="mt-1 flex flex-wrap gap-x-4 gap-y-0.5">
+        <div class="mt-1 flex flex-wrap gap-x-4 gap-y-0.5 text-gray-600 dark:text-gray-400">
           <span><span class="text-gray-500">所有者: </span>{{ carInspectionMatch.ownerName || '-' }}</span>
           <span><span class="text-gray-500">車種: </span>{{ carInspectionMatch.carName || '-' }}</span>
           <span><span class="text-gray-500">型式: </span>{{ carInspectionMatch.model || '-' }}</span>
-          <span><span class="text-gray-500">車検満了日: </span>{{ formatExpiry(carInspectionMatch.validPeriodExpirdate) }}</span>
         </div>
       </template>
       <template v-else>
-        登録番号 {{ ticket.registration_number }} — 車検証マスタに登録なし
+        <span data-testid="car-inspection-missing">
+          登録番号 {{ ticket.registration_number }} — 車検証未登録
+        </span>
       </template>
     </div>
     <!-- 登録番号未入力: インライン入力 -->

--- a/app/composables/useCarInspections.ts
+++ b/app/composables/useCarInspections.ts
@@ -10,6 +10,25 @@ function normalizeKey(s: string | null | undefined): string {
     .toLowerCase()
 }
 
+// DB は ValidPeriodExpirdate を単一フィールドとしては持たず、
+// TwodimensionCodeInfoValidPeriodExpirdate (YYMMDD, 2D barcode 由来) か
+// ValidPeriodExpirdate{E,Y,M,D} (和暦) に分かれている。
+// ここでは YYMMDD を 20YY-MM-DD に変換、無ければ 和暦フィールドを合成する。
+function extractExpiry(raw: Record<string, unknown>): string {
+  const yymmdd = (raw.TwodimensionCodeInfoValidPeriodExpirdate as string | undefined) || ''
+  const m = /^(\d{2})(\d{2})(\d{2})$/.exec(yymmdd.trim())
+  if (m) return `20${m[1]}-${m[2]}-${m[3]}`
+
+  const era = (raw.ValidPeriodExpirdateE as string | undefined) || ''
+  const y = (raw.ValidPeriodExpirdateY as string | undefined) || ''
+  const mm = (raw.ValidPeriodExpirdateM as string | undefined) || ''
+  const dd = (raw.ValidPeriodExpirdateD as string | undefined) || ''
+  if (era && y && mm && dd) {
+    return `${era}${y}年${mm}月${dd}日`
+  }
+  return ''
+}
+
 function toSummary(raw: Record<string, unknown>): CarInspectionSummary | null {
   const rawReg = (raw.EntryNoCarNo as string | undefined)
     || (raw.CarNo as string | undefined)
@@ -23,7 +42,7 @@ function toSummary(raw: Record<string, unknown>): CarInspectionSummary | null {
       || '',
     carName: (raw.CarName as string | undefined) || '',
     model: (raw.Model as string | undefined) || '',
-    validPeriodExpirdate: (raw.ValidPeriodExpirdate as string | undefined) || '',
+    validPeriodExpirdate: extractExpiry(raw),
   }
 }
 

--- a/app/pages/tickets/index.vue
+++ b/app/pages/tickets/index.vue
@@ -2,6 +2,7 @@
 import { updateTicket } from '~/utils/api'
 import { toHalfWidth } from '~/utils/normalize'
 import { formatOccurredAt } from '~/utils/datetime'
+import { formatExpiry } from '~/utils/carInspection'
 import type { TroubleTicket } from '~/types'
 
 const {
@@ -26,11 +27,6 @@ const showBulkImport = ref(false)
 
 function handleBulkImportDone() {
   fetchTickets()
-}
-
-function formatExpiry(v: string): string {
-  if (!v) return '-'
-  return v.length > 10 ? v.substring(0, 10) : v
 }
 
 // 保存中チケットID set（Enter + blur 重複発火を防ぐため in-flight 判定も兼ねる）

--- a/app/utils/carInspection.ts
+++ b/app/utils/carInspection.ts
@@ -1,0 +1,41 @@
+// 車検証関連の表示ヘルパー。
+// rust-alc-api が返す ValidPeriodExpirdate (例: "2026-05-01" または "2026-05-01T00:00:00Z")
+// を画面表示用に整形・分類する。
+
+export type ExpiryStatus = 'expired' | 'soon' | 'ok' | 'unknown'
+
+const SOON_DAYS = 30
+
+/**
+ * Format a car-inspection expiry value for display.
+ * Returns "-" when value is empty. Truncates ISO datetime to YYYY-MM-DD.
+ */
+export function formatExpiry(v: string | null | undefined): string {
+  if (!v) return '-'
+  return v.length > 10 ? v.substring(0, 10) : v
+}
+
+/**
+ * Classify a car-inspection expiry value.
+ * - 'expired' : already past today
+ * - 'soon'    : within SOON_DAYS days from today (inclusive of today)
+ * - 'ok'      : valid for more than SOON_DAYS days
+ * - 'unknown' : empty / unparseable
+ *
+ * `now` is injectable for tests.
+ */
+export function getExpiryStatus(
+  v: string | null | undefined,
+  now: Date = new Date(),
+): ExpiryStatus {
+  if (!v) return 'unknown'
+  const ymd = v.length > 10 ? v.substring(0, 10) : v
+  const expiry = new Date(`${ymd}T00:00:00`)
+  if (Number.isNaN(expiry.getTime())) return 'unknown'
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const diffMs = expiry.getTime() - today.getTime()
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+  if (diffDays < 0) return 'expired'
+  if (diffDays <= SOON_DAYS) return 'soon'
+  return 'ok'
+}

--- a/tests/components/TicketCompactOverview.test.ts
+++ b/tests/components/TicketCompactOverview.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { allStubs } from '../helpers/nuxt-stubs'
+
+// ----- Mocks -------------------------------------------------------------
+const lookupMock = vi.fn()
+const loadMock = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('~/composables/useCarInspections', () => ({
+  useCarInspections: () => ({
+    load: loadMock,
+    lookupByRegistration: lookupMock,
+    registrationOptions: { value: [] },
+  }),
+}))
+
+vi.mock('~/utils/api', () => ({
+  updateTicket: vi.fn(),
+}))
+
+import TicketCompactOverview from '~/components/TicketCompactOverview.vue'
+import type { TroubleTicket } from '~/types'
+
+function makeTicket(overrides: Partial<TroubleTicket> = {}): TroubleTicket {
+  return {
+    id: 't1',
+    ticket_no: 1,
+    category: '貨物事故',
+    title: '',
+    description: '',
+    occurred_at: null,
+    occurred_date: null,
+    company_name: null,
+    office_name: null,
+    department: null,
+    person_name: null,
+    registration_number: '3881',
+    location: null,
+    progress_notes: null,
+    allowance: null,
+    damage_amount: null,
+    compensation_amount: null,
+    confirmation_notice: null,
+    disciplinary_content: null,
+    disciplinary_action: null,
+    road_service_cost: null,
+    counterparty: null,
+    counterparty_insurance: null,
+    status_id: null,
+    due_date: null,
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+    ...overrides,
+  } as TroubleTicket
+}
+
+function mountOverview(opts: { ticket?: Partial<TroubleTicket> } = {}) {
+  return mount(TicketCompactOverview, {
+    props: {
+      ticket: makeTicket(opts.ticket),
+      workflowStates: [],
+    },
+    global: { stubs: allStubs },
+  })
+}
+
+describe('TicketCompactOverview - 車検満了日 display', () => {
+  beforeEach(() => {
+    lookupMock.mockReset()
+    loadMock.mockClear()
+    vi.useFakeTimers()
+    // Fixed today for deterministic expiry-status tests
+    vi.setSystemTime(new Date(2026, 3, 21)) // 2026-04-21
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders 車検満了日 when lookupCarInspection returns a record', async () => {
+    lookupMock.mockReturnValue({
+      registrationNumber: '3881',
+      ownerName: 'オーナー1',
+      carName: '車名1',
+      model: 'モデル1',
+      validPeriodExpirdate: '2027-01-01',
+    })
+
+    const wrapper = mountOverview()
+    await flushPromises()
+
+    const badge = wrapper.find('[data-testid="car-expiry-badge"]')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toContain('2027-01-01')
+    expect(wrapper.text()).toContain('車検満了日')
+    expect(wrapper.text()).toContain('オーナー1')
+    expect(wrapper.text()).toContain('車名1')
+    expect(wrapper.text()).toContain('モデル1')
+  })
+
+  it('renders "車検証未登録" when lookup returns null/undefined', async () => {
+    lookupMock.mockReturnValue(undefined)
+
+    const wrapper = mountOverview()
+    await flushPromises()
+
+    const missing = wrapper.find('[data-testid="car-inspection-missing"]')
+    expect(missing.exists()).toBe(true)
+    expect(missing.text()).toContain('車検証未登録')
+    expect(wrapper.find('[data-testid="car-expiry-badge"]').exists()).toBe(false)
+  })
+
+  it('shows red badge when expiry < today (expired)', async () => {
+    lookupMock.mockReturnValue({
+      registrationNumber: '3881',
+      ownerName: '', carName: '', model: '',
+      validPeriodExpirdate: '2026-04-20', // yesterday
+    })
+
+    const wrapper = mountOverview()
+    await flushPromises()
+
+    const badge = wrapper.find('[data-testid="car-expiry-badge"]')
+    expect(badge.classes().some(c => c.includes('red'))).toBe(true)
+    expect(badge.text()).toContain('期限切れ')
+  })
+
+  it('shows yellow badge when expiry within 30 days (soon)', async () => {
+    lookupMock.mockReturnValue({
+      registrationNumber: '3881',
+      ownerName: '', carName: '', model: '',
+      validPeriodExpirdate: '2026-05-01', // +10 days
+    })
+
+    const wrapper = mountOverview()
+    await flushPromises()
+
+    const badge = wrapper.find('[data-testid="car-expiry-badge"]')
+    expect(badge.classes().some(c => c.includes('yellow'))).toBe(true)
+    expect(badge.text()).toContain('残り30日以内')
+  })
+
+  it('shows neutral badge when expiry far in the future (ok)', async () => {
+    lookupMock.mockReturnValue({
+      registrationNumber: '3881',
+      ownerName: '', carName: '', model: '',
+      validPeriodExpirdate: '2027-01-01',
+    })
+
+    const wrapper = mountOverview()
+    await flushPromises()
+
+    const badge = wrapper.find('[data-testid="car-expiry-badge"]')
+    // neutral = gray, not red/yellow
+    expect(badge.classes().some(c => c.includes('red'))).toBe(false)
+    expect(badge.classes().some(c => c.includes('yellow'))).toBe(false)
+    expect(badge.classes().some(c => c.includes('gray'))).toBe(true)
+    expect(badge.text()).toContain('有効')
+  })
+
+  it('does not render car-inspection section when ticket has no registration_number', async () => {
+    const wrapper = mountOverview({ ticket: { registration_number: null } })
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="car-inspection-section"]').exists()).toBe(false)
+  })
+})

--- a/tests/composables/useCarInspections.test.ts
+++ b/tests/composables/useCarInspections.test.ts
@@ -24,8 +24,8 @@ describe('useCarInspections', () => {
   it.skipIf(isLive)('normalizes full-width registration numbers to half-width in options and lookup', async () => {
     getCarInspectionsCurrentMock.mockResolvedValue({
       carInspections: [
-        { EntryNoCarNo: '３８８１', OwnerName: 'オーナー1', CarName: '車名1', Model: 'モデル1', ValidPeriodExpirdate: '2027-01-01' },
-        { CarNo: '3829', OwnerName: 'オーナー2', CarName: '車名2', Model: 'モデル2', ValidPeriodExpirdate: '2027-02-01' },
+        { EntryNoCarNo: '３８８１', OwnerName: 'オーナー1', CarName: '車名1', Model: 'モデル1' },
+        { CarNo: '3829', OwnerName: 'オーナー2', CarName: '車名2', Model: 'モデル2' },
       ],
     })
 
@@ -37,5 +37,41 @@ describe('useCarInspections', () => {
     expect(ci.lookupByRegistration('3881')?.ownerName).toBe('オーナー1')
     expect(ci.lookupByRegistration('３８８１')?.ownerName).toBe('オーナー1')
     expect(ci.lookupByRegistration('3829')?.ownerName).toBe('オーナー2')
+  })
+
+  it.skipIf(isLive)('extracts expiry from TwodimensionCodeInfoValidPeriodExpirdate (YYMMDD)', async () => {
+    getCarInspectionsCurrentMock.mockResolvedValue({
+      carInspections: [
+        { CarNo: '1111', TwodimensionCodeInfoValidPeriodExpirdate: '270430' },
+      ],
+    })
+    const { useCarInspections } = await import('~/composables/useCarInspections')
+    const ci = useCarInspections()
+    await ci.load()
+    expect(ci.lookupByRegistration('1111')?.validPeriodExpirdate).toBe('2027-04-30')
+  })
+
+  it.skipIf(isLive)('falls back to wareki Y/M/D fields when TwodimensionCodeInfo is absent', async () => {
+    getCarInspectionsCurrentMock.mockResolvedValue({
+      carInspections: [
+        { CarNo: '2222', ValidPeriodExpirdateE: '令和', ValidPeriodExpirdateY: '7', ValidPeriodExpirdateM: '4', ValidPeriodExpirdateD: '30' },
+      ],
+    })
+    const { useCarInspections } = await import('~/composables/useCarInspections')
+    const ci = useCarInspections()
+    await ci.load()
+    expect(ci.lookupByRegistration('2222')?.validPeriodExpirdate).toBe('令和7年4月30日')
+  })
+
+  it.skipIf(isLive)('returns empty string when no expiry fields are present', async () => {
+    getCarInspectionsCurrentMock.mockResolvedValue({
+      carInspections: [
+        { CarNo: '3333', OwnerName: '社長' },
+      ],
+    })
+    const { useCarInspections } = await import('~/composables/useCarInspections')
+    const ci = useCarInspections()
+    await ci.load()
+    expect(ci.lookupByRegistration('3333')?.validPeriodExpirdate).toBe('')
   })
 })

--- a/tests/utils/carInspection.test.ts
+++ b/tests/utils/carInspection.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { formatExpiry, getExpiryStatus } from '~/utils/carInspection'
+
+describe('formatExpiry', () => {
+  it('returns "-" for empty / null / undefined', () => {
+    expect(formatExpiry('')).toBe('-')
+    expect(formatExpiry(null)).toBe('-')
+    expect(formatExpiry(undefined)).toBe('-')
+  })
+
+  it('returns YYYY-MM-DD as-is when length <= 10', () => {
+    expect(formatExpiry('2026-05-01')).toBe('2026-05-01')
+  })
+
+  it('truncates ISO datetime to YYYY-MM-DD', () => {
+    expect(formatExpiry('2026-05-01T00:00:00Z')).toBe('2026-05-01')
+  })
+})
+
+describe('getExpiryStatus', () => {
+  const today = new Date(2026, 3, 21) // 2026-04-21
+
+  it('returns "unknown" for empty value', () => {
+    expect(getExpiryStatus('', today)).toBe('unknown')
+    expect(getExpiryStatus(null, today)).toBe('unknown')
+    expect(getExpiryStatus(undefined, today)).toBe('unknown')
+  })
+
+  it('returns "unknown" for unparseable value', () => {
+    expect(getExpiryStatus('not-a-date', today)).toBe('unknown')
+  })
+
+  it('returns "expired" for date before today', () => {
+    expect(getExpiryStatus('2026-04-20', today)).toBe('expired')
+    expect(getExpiryStatus('2025-12-31', today)).toBe('expired')
+  })
+
+  it('returns "soon" for today (0 days)', () => {
+    expect(getExpiryStatus('2026-04-21', today)).toBe('soon')
+  })
+
+  it('returns "soon" for date within 30 days', () => {
+    expect(getExpiryStatus('2026-05-01', today)).toBe('soon') // +10 days
+    expect(getExpiryStatus('2026-05-21', today)).toBe('soon') // +30 days (boundary)
+  })
+
+  it('returns "ok" for date more than 30 days away', () => {
+    expect(getExpiryStatus('2026-05-22', today)).toBe('ok') // +31 days
+    expect(getExpiryStatus('2027-01-01', today)).toBe('ok')
+  })
+
+  it('handles ISO datetime input', () => {
+    expect(getExpiryStatus('2027-01-01T00:00:00Z', today)).toBe('ok')
+    expect(getExpiryStatus('2026-04-20T12:00:00Z', today)).toBe('expired')
+  })
+
+  it('uses current Date by default when now omitted', () => {
+    // far future is always "ok"
+    expect(getExpiryStatus('2099-12-31')).toBe('ok')
+    // far past is always "expired"
+    expect(getExpiryStatus('2000-01-01')).toBe('expired')
+  })
+})


### PR DESCRIPTION
## Summary

- DB に `ValidPeriodExpirdate` 単一フィールドは存在しない (Y/M/D 分割 + 2D barcode YYMMDD のみ) ため、composable が常に空を返していた
- `TwodimensionCodeInfoValidPeriodExpirdate` (YYMMDD) を 20YY-MM-DD に変換、フォールバックで和暦合成
- チケット詳細の車検証情報ブロックに色分けバッジ表示 (期限切れ=赤 / 30日以内=黄 / 有効=グレー)
- `justify-between` を外して登録番号の右隣にインライン表示
- `formatExpiry` / `getExpiryStatus` を `app/utils/carInspection.ts` に集約

## Test plan

- [x] vitest: 27 files / 178 tests pass
- [x] 動作確認: チケット詳細で車検満了日が日付表示 (ユーザー確認済)

Closes #107