### PR TITLE
feat(tickets): add ステータス管理 + 待機一覧 + 状況管理 cross-ticket list

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -16,8 +16,11 @@ const isDark = computed({
   },
 })
 
-const navigation = [
+const navigation: { label: string; icon: string; to: string; target?: string }[] = [
   { label: 'チケット一覧', icon: 'i-lucide-list', to: '/tickets' },
+  { label: 'ステータス管理', icon: 'i-lucide-kanban', to: '/tickets/situations', target: '_blank' },
+  { label: '待機一覧', icon: 'i-lucide-clock', to: '/tickets/waiting', target: '_blank' },
+  { label: '状況管理', icon: 'i-lucide-list-checks', to: '/tasks', target: '_blank' },
   { label: '設定', icon: 'i-lucide-settings', to: '/settings' },
 ]
 
@@ -40,8 +43,10 @@ function handleLogout() {
           v-for="item in navigation"
           :key="item.to"
           :to="item.to"
+          :target="item.target"
+          :rel="item.target ? 'noopener' : undefined"
           class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors"
-          :class="route.path.startsWith(item.to)
+          :class="!item.target && route.path.startsWith(item.to)
             ? 'bg-blue-50 dark:bg-blue-950 text-blue-700 dark:text-blue-300 font-medium'
             : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'"
         >

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -1,0 +1,289 @@
+<script setup lang="ts">
+import type { TroubleTask, TroubleTaskType, Employee } from '~/types'
+import { TASK_STATUS_LABELS, DEFAULT_TASK_TYPES } from '~/types'
+import { listAllTasks, getTaskTypes, getEmployees } from '~/utils/api'
+import type { ListTasksQuery } from '~/utils/api'
+
+const items = ref<TroubleTask[]>([])
+const total = ref(0)
+const page = ref(1)
+const perPage = ref(50)
+const loading = ref(false)
+const errorMessage = ref<string | null>(null)
+
+const taskTypes = ref<TroubleTaskType[]>([])
+const employees = ref<Employee[]>([])
+
+// Filters
+const statusFilter = ref<'open' | 'in_progress' | 'done' | ''>('')
+const taskTypeFilter = ref<string>('')
+const assignedToFilter = ref<string>('')
+const qFilter = ref<string>('')
+const dueFrom = ref<string>('')
+const dueTo = ref<string>('')
+const occurredFrom = ref<string>('')
+const occurredTo = ref<string>('')
+
+// Sort
+const sortBy = ref<'created_at' | 'occurred_at' | 'due_date' | 'next_action_due' | 'status'>('created_at')
+const sortDesc = ref<boolean>(true)
+
+const STATUS_OPTIONS = [
+  { label: 'すべて', value: '' },
+  { label: '未着手', value: 'open' },
+  { label: '進行中', value: 'in_progress' },
+  { label: '完了', value: 'done' },
+]
+
+const SORT_OPTIONS = [
+  { label: '作成日', value: 'created_at' },
+  { label: '発生日', value: 'occurred_at' },
+  { label: '期限', value: 'due_date' },
+  { label: '次回', value: 'next_action_due' },
+  { label: 'ステータス', value: 'status' },
+]
+
+const taskTypeOptions = computed(() => {
+  const names = new Set<string>()
+  for (const t of taskTypes.value) names.add(t.name)
+  for (const n of DEFAULT_TASK_TYPES) names.add(n)
+  return [{ label: 'すべて', value: '' }, ...Array.from(names).map(name => ({ label: name, value: name }))]
+})
+
+const employeeOptions = computed(() => [
+  { label: 'すべて', value: '' },
+  ...employees.value.map(e => ({ label: e.name, value: e.id })),
+])
+
+const employeeMap = computed(() => {
+  const m: Record<string, Employee> = {}
+  for (const e of employees.value) m[e.id] = e
+  return m
+})
+
+function employeeName(id: string | null | undefined): string {
+  if (!id) return '-'
+  return employeeMap.value[id]?.name || id
+}
+
+function formatYmd(v: string | null | undefined): string {
+  if (!v) return '-'
+  const d = new Date(v)
+  if (Number.isNaN(d.getTime())) return String(v).substring(0, 10)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+}
+
+async function load() {
+  loading.value = true
+  errorMessage.value = null
+  try {
+    const query: ListTasksQuery = {
+      page: page.value,
+      per_page: perPage.value,
+      sort_by: sortBy.value,
+      sort_desc: sortDesc.value,
+    }
+    if (statusFilter.value) query.status = statusFilter.value
+    if (taskTypeFilter.value) query.task_type = taskTypeFilter.value
+    if (assignedToFilter.value) query.assigned_to = assignedToFilter.value
+    if (qFilter.value) query.q = qFilter.value
+    if (dueFrom.value) query.due_from = dueFrom.value
+    if (dueTo.value) query.due_to = dueTo.value
+    if (occurredFrom.value) query.occurred_from = occurredFrom.value
+    if (occurredTo.value) query.occurred_to = occurredTo.value
+
+    const res = await listAllTasks(query)
+    items.value = res.items
+    total.value = res.total
+    page.value = res.page
+    perPage.value = res.per_page
+  } catch (e) {
+    errorMessage.value = e instanceof Error ? e.message : String(e)
+    items.value = []
+    total.value = 0
+    console.error('Failed to load tasks:', e)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function loadMasters() {
+  try {
+    const [tt, emps] = await Promise.all([
+      getTaskTypes().catch(() => [] as TroubleTaskType[]),
+      getEmployees().catch(() => [] as Employee[]),
+    ])
+    taskTypes.value = tt
+    employees.value = emps
+  } catch (e) {
+    console.error('Failed to load masters:', e)
+  }
+}
+
+// Debounced search
+let searchTimer: ReturnType<typeof setTimeout> | null = null
+watch(qFilter, () => {
+  if (searchTimer) clearTimeout(searchTimer)
+  searchTimer = setTimeout(() => {
+    page.value = 1
+    load()
+  }, 300)
+})
+
+watch([statusFilter, taskTypeFilter, assignedToFilter, dueFrom, dueTo, occurredFrom, occurredTo], () => {
+  page.value = 1
+  load()
+})
+
+watch([sortBy, sortDesc], () => {
+  load()
+})
+
+watch(page, () => {
+  load()
+})
+
+function toggleSortDir() {
+  sortDesc.value = !sortDesc.value
+}
+
+function ticketHref(taskTicketId: string): string {
+  return `/tickets/${taskTicketId}`
+}
+
+onMounted(async () => {
+  await loadMasters()
+  await load()
+})
+</script>
+
+<template>
+  <div class="space-y-4">
+    <div class="flex items-center justify-between">
+      <h2 class="text-xl font-bold">状況管理 一覧</h2>
+      <UButton label="再読み込み" icon="i-lucide-refresh-cw" variant="outline" size="sm" :loading="loading" @click="load" />
+    </div>
+
+    <!-- Filter bar -->
+    <UCard>
+      <div class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-3">
+        <UFormField label="ステータス">
+          <USelect v-model="statusFilter" :items="STATUS_OPTIONS" size="sm" />
+        </UFormField>
+        <UFormField label="状況タイプ">
+          <USelect v-model="taskTypeFilter" :items="taskTypeOptions" size="sm" />
+        </UFormField>
+        <UFormField label="担当者">
+          <USelect v-model="assignedToFilter" :items="employeeOptions" size="sm" />
+        </UFormField>
+        <UFormField label="検索 (題名/詳細)">
+          <UInput v-model="qFilter" placeholder="キーワード" size="sm" />
+        </UFormField>
+        <UFormField label="期限 (から)">
+          <UInput v-model="dueFrom" type="date" size="sm" />
+        </UFormField>
+        <UFormField label="期限 (まで)">
+          <UInput v-model="dueTo" type="date" size="sm" />
+        </UFormField>
+        <UFormField label="発生日 (から)">
+          <UInput v-model="occurredFrom" type="date" size="sm" />
+        </UFormField>
+        <UFormField label="発生日 (まで)">
+          <UInput v-model="occurredTo" type="date" size="sm" />
+        </UFormField>
+        <UFormField label="並び">
+          <div class="flex gap-2">
+            <USelect v-model="sortBy" :items="SORT_OPTIONS" size="sm" class="flex-1" />
+            <UButton
+              :icon="sortDesc ? 'i-lucide-arrow-down' : 'i-lucide-arrow-up'"
+              :label="sortDesc ? '降順' : '昇順'"
+              variant="outline"
+              size="sm"
+              @click="toggleSortDir"
+            />
+          </div>
+        </UFormField>
+      </div>
+    </UCard>
+
+    <!-- Table -->
+    <UCard>
+      <div v-if="loading" class="flex justify-center py-8">
+        <UIcon name="i-lucide-loader-circle" class="animate-spin size-6 text-gray-400" />
+      </div>
+
+      <div v-else-if="errorMessage" class="py-8 text-center text-red-500">
+        {{ errorMessage }}
+      </div>
+
+      <div v-else-if="items.length === 0" class="py-8 text-center text-gray-400">
+        該当する状況がありません
+      </div>
+
+      <div v-else class="overflow-x-auto">
+        <table class="text-sm w-full whitespace-nowrap">
+          <thead>
+            <tr class="border-b border-gray-200 dark:border-gray-700">
+              <th class="text-left py-2 px-2 font-medium">チケット</th>
+              <th class="text-left py-2 px-2 font-medium">種類</th>
+              <th class="text-left py-2 px-2 font-medium">題名</th>
+              <th class="text-left py-2 px-2 font-medium">内容</th>
+              <th class="text-left py-2 px-2 font-medium">担当</th>
+              <th class="text-left py-2 px-2 font-medium">発生日</th>
+              <th class="text-left py-2 px-2 font-medium">期限</th>
+              <th class="text-left py-2 px-2 font-medium">次のアクション</th>
+              <th class="text-left py-2 px-2 font-medium">次の対応者</th>
+              <th class="text-left py-2 px-2 font-medium">次回</th>
+              <th class="text-left py-2 px-2 font-medium">ステータス</th>
+              <th class="text-left py-2 px-2 font-medium">作成日</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="task in items"
+              :key="task.id"
+              class="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900"
+            >
+              <td class="py-2 px-2">
+                <NuxtLink
+                  :to="ticketHref(task.ticket_id)"
+                  target="_blank"
+                  rel="noopener"
+                  class="text-blue-600 dark:text-blue-400 underline"
+                >
+                  {{ task.ticket_id.substring(0, 8) }}
+                </NuxtLink>
+              </td>
+              <td class="py-2 px-2">{{ task.task_type }}</td>
+              <td class="py-2 px-2 max-w-[200px] truncate">{{ task.title }}</td>
+              <td class="py-2 px-2 max-w-[300px] truncate">{{ task.description || '-' }}</td>
+              <td class="py-2 px-2">{{ employeeName(task.assigned_to) }}</td>
+              <td class="py-2 px-2">{{ formatYmd(task.occurred_at) }}</td>
+              <td class="py-2 px-2">{{ formatYmd(task.due_date) }}</td>
+              <td class="py-2 px-2 max-w-[200px] truncate">{{ task.next_action || '-' }}</td>
+              <td class="py-2 px-2">{{ employeeName(task.next_action_by) }}</td>
+              <td class="py-2 px-2">{{ formatYmd(task.next_action_due) }}</td>
+              <td class="py-2 px-2">
+                <UBadge
+                  v-if="TASK_STATUS_LABELS[task.status]"
+                  :style="{ backgroundColor: TASK_STATUS_LABELS[task.status]!.color + '20', color: TASK_STATUS_LABELS[task.status]!.color }"
+                  variant="subtle"
+                >
+                  {{ TASK_STATUS_LABELS[task.status]!.label }}
+                </UBadge>
+                <span v-else class="text-gray-400">{{ task.status }}</span>
+              </td>
+              <td class="py-2 px-2">{{ formatYmd(task.created_at) }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </UCard>
+
+    <!-- Pagination -->
+    <div v-if="total > perPage" class="flex justify-center">
+      <UPagination v-model="page" :total="total" :items-per-page="perPage" />
+    </div>
+  </div>
+</template>

--- a/app/pages/tickets/situations.vue
+++ b/app/pages/tickets/situations.vue
@@ -23,26 +23,29 @@ async function load() {
   }
 }
 
-const ticketsByState = computed(() => {
-  const map: Record<string, TroubleTicket[]> = {}
+// vue-tsc TS2589 (deep instantiation) fires on `.push(TroubleTicket)` because
+// ts-rs generated TroubleTicket has JsonValue (recursive). Grouping via plain
+// `unknown[]` sidesteps the deep inference, then we cast back at the boundary.
+const ticketsByState = computed<Record<string, TroubleTicket[]>>(() => {
+  const raw: Record<string, unknown[]> = {}
   for (const state of workflowStates.value) {
-    map[state.id] = []
+    raw[state.id] = []
   }
   for (const t of tickets.value) {
-    if (!t.status_id) continue
-    const bucket = map[t.status_id]
-    if (bucket) bucket.push(t)
+    const sid = t.status_id
+    if (!sid) continue
+    raw[sid]?.push(t)
   }
-  return map
+  return raw as Record<string, TroubleTicket[]>
 })
 
 const unassignedTickets = computed<TroubleTicket[]>(() => {
   const validIds = new Set<string>(workflowStates.value.map(s => s.id))
-  const list: TroubleTicket[] = []
+  const list: unknown[] = []
   for (const t of tickets.value) {
     if (!t.status_id || !validIds.has(t.status_id)) list.push(t)
   }
-  return list
+  return list as TroubleTicket[]
 })
 
 function navigateToTicket(id: string) {

--- a/app/pages/tickets/situations.vue
+++ b/app/pages/tickets/situations.vue
@@ -37,8 +37,12 @@ const ticketsByState = computed(() => {
 })
 
 const unassignedTickets = computed<TroubleTicket[]>(() => {
-  const validIds = new Set(workflowStates.value.map(s => s.id))
-  return tickets.value.filter(t => !t.status_id || !validIds.has(t.status_id))
+  const validIds = new Set<string>(workflowStates.value.map(s => s.id))
+  const list: TroubleTicket[] = []
+  for (const t of tickets.value) {
+    if (!t.status_id || !validIds.has(t.status_id)) list.push(t)
+  }
+  return list
 })
 
 function navigateToTicket(id: string) {

--- a/app/pages/tickets/situations.vue
+++ b/app/pages/tickets/situations.vue
@@ -29,16 +29,17 @@ const ticketsByState = computed(() => {
     map[state.id] = []
   }
   for (const t of tickets.value) {
-    if (t.status_id && map[t.status_id]) {
-      map[t.status_id].push(t)
-    }
+    if (!t.status_id) continue
+    const bucket = map[t.status_id]
+    if (bucket) bucket.push(t)
   }
   return map
 })
 
-const unassignedTickets = computed(() =>
-  tickets.value.filter(t => !t.status_id || !workflowStates.value.some(s => s.id === t.status_id)),
-)
+const unassignedTickets = computed<TroubleTicket[]>(() => {
+  const validIds = new Set(workflowStates.value.map(s => s.id))
+  return tickets.value.filter(t => !t.status_id || !validIds.has(t.status_id))
+})
 
 function navigateToTicket(id: string) {
   router.push(`/tickets/${id}`)

--- a/app/pages/tickets/situations.vue
+++ b/app/pages/tickets/situations.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+import type { TroubleTicket, TroubleWorkflowState } from '~/types'
+import { getTickets, getWorkflowStates } from '~/utils/api'
+
+const router = useRouter()
+const tickets = ref<TroubleTicket[]>([])
+const workflowStates = ref<TroubleWorkflowState[]>([])
+const loading = ref(false)
+
+async function load() {
+  loading.value = true
+  try {
+    const [ticketsRes, statesRes] = await Promise.all([
+      getTickets({ per_page: 1000 }),
+      getWorkflowStates().catch(() => [] as TroubleWorkflowState[]),
+    ])
+    tickets.value = ticketsRes.tickets
+    workflowStates.value = statesRes
+  } catch (e) {
+    console.error('Failed to load situations:', e)
+  } finally {
+    loading.value = false
+  }
+}
+
+const ticketsByState = computed(() => {
+  const map: Record<string, TroubleTicket[]> = {}
+  for (const state of workflowStates.value) {
+    map[state.id] = []
+  }
+  for (const t of tickets.value) {
+    if (t.status_id && map[t.status_id]) {
+      map[t.status_id].push(t)
+    }
+  }
+  return map
+})
+
+const unassignedTickets = computed(() =>
+  tickets.value.filter(t => !t.status_id || !workflowStates.value.some(s => s.id === t.status_id)),
+)
+
+function navigateToTicket(id: string) {
+  router.push(`/tickets/${id}`)
+}
+
+function ticketTitle(t: TroubleTicket): string {
+  const txt = t.title || t.description || t.category || ''
+  return txt.length > 40 ? txt.substring(0, 40) + '...' : txt
+}
+
+onMounted(() => { load() })
+</script>
+
+<template>
+  <div class="space-y-4">
+    <div class="flex items-center justify-between">
+      <h2 class="text-xl font-bold">状況一覧</h2>
+      <UButton label="再読み込み" icon="i-lucide-refresh-cw" variant="outline" size="sm" :loading="loading" @click="load" />
+    </div>
+
+    <div v-if="loading" class="flex justify-center py-8">
+      <UIcon name="i-lucide-loader-circle" class="animate-spin size-6 text-gray-400" />
+    </div>
+
+    <div v-else-if="workflowStates.length === 0" class="text-center text-gray-400 py-8">
+      ワークフローが未設定です。<NuxtLink to="/settings" class="text-blue-500 underline">設定</NuxtLink>から作成してください。
+    </div>
+
+    <div v-else class="flex gap-4 overflow-x-auto pb-4">
+      <div
+        v-for="state in workflowStates"
+        :key="state.id"
+        class="min-w-[280px] w-[280px] flex-shrink-0"
+      >
+        <div
+          class="rounded-t-lg px-3 py-2 font-medium text-sm"
+          :style="{ backgroundColor: state.color + '20', color: state.color }"
+        >
+          {{ state.label }}
+          <span class="ml-1 text-xs opacity-70">({{ ticketsByState[state.id]?.length ?? 0 }})</span>
+        </div>
+        <div class="bg-gray-50 dark:bg-gray-900 rounded-b-lg p-2 space-y-2 min-h-[200px]">
+          <UCard
+            v-for="ticket in ticketsByState[state.id]"
+            :key="ticket.id"
+            class="cursor-pointer hover:shadow-md transition-shadow"
+            @click="navigateToTicket(ticket.id)"
+          >
+            <div class="space-y-1">
+              <div class="text-xs text-gray-500">No.{{ ticket.ticket_no }}</div>
+              <div class="text-sm font-medium">{{ ticketTitle(ticket) }}</div>
+              <div v-if="ticket.assigned_to" class="text-xs text-gray-600 dark:text-gray-400">
+                <UIcon name="i-lucide-user" class="inline size-3" /> {{ ticket.assigned_to }}
+              </div>
+              <div v-if="ticket.registration_number" class="text-xs text-gray-600 dark:text-gray-400">
+                <UIcon name="i-lucide-car" class="inline size-3" /> {{ ticket.registration_number }}
+              </div>
+            </div>
+          </UCard>
+          <div v-if="(ticketsByState[state.id]?.length ?? 0) === 0" class="text-xs text-gray-400 text-center py-4">
+            -
+          </div>
+        </div>
+      </div>
+
+      <div v-if="unassignedTickets.length > 0" class="min-w-[280px] w-[280px] flex-shrink-0">
+        <div class="rounded-t-lg px-3 py-2 font-medium text-sm bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300">
+          未設定 <span class="ml-1 text-xs opacity-70">({{ unassignedTickets.length }})</span>
+        </div>
+        <div class="bg-gray-50 dark:bg-gray-900 rounded-b-lg p-2 space-y-2 min-h-[200px]">
+          <UCard
+            v-for="ticket in unassignedTickets"
+            :key="ticket.id"
+            class="cursor-pointer hover:shadow-md transition-shadow"
+            @click="navigateToTicket(ticket.id)"
+          >
+            <div class="space-y-1">
+              <div class="text-xs text-gray-500">No.{{ ticket.ticket_no }}</div>
+              <div class="text-sm font-medium">{{ ticketTitle(ticket) }}</div>
+            </div>
+          </UCard>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/pages/tickets/waiting.vue
+++ b/app/pages/tickets/waiting.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+import type { TroubleTicket, TroubleProgressStatus, TroubleWorkflowState } from '~/types'
+import { getTickets, getProgressStatuses, getWorkflowStates } from '~/utils/api'
+import { formatOccurredAt } from '~/utils/datetime'
+
+const router = useRouter()
+const tickets = ref<TroubleTicket[]>([])
+const progressStatuses = ref<TroubleProgressStatus[]>([])
+const workflowStates = ref<TroubleWorkflowState[]>([])
+const loading = ref(false)
+
+async function load() {
+  loading.value = true
+  try {
+    const [ticketsRes, progs, states] = await Promise.all([
+      getTickets({ per_page: 1000 }),
+      getProgressStatuses().catch(() => [] as TroubleProgressStatus[]),
+      getWorkflowStates().catch(() => [] as TroubleWorkflowState[]),
+    ])
+    tickets.value = ticketsRes.tickets
+    progressStatuses.value = progs
+    workflowStates.value = states
+  } catch (e) {
+    console.error('Failed to load waiting tickets:', e)
+  } finally {
+    loading.value = false
+  }
+}
+
+const waitingStatus = computed(() =>
+  progressStatuses.value.find(s => s.name === '待機') ?? null,
+)
+
+const waitingTickets = computed(() => {
+  if (!waitingStatus.value) return []
+  return tickets.value.filter(t => t.progress_notes === waitingStatus.value!.name)
+})
+
+const stateMap = computed(() => {
+  const map: Record<string, TroubleWorkflowState> = {}
+  for (const s of workflowStates.value) map[s.id] = s
+  return map
+})
+
+function navigateToTicket(id: string) {
+  router.push(`/tickets/${id}`)
+}
+
+onMounted(() => { load() })
+</script>
+
+<template>
+  <div class="space-y-4">
+    <div class="flex items-center justify-between">
+      <h2 class="text-xl font-bold">待機一覧</h2>
+      <UButton label="再読み込み" icon="i-lucide-refresh-cw" variant="outline" size="sm" :loading="loading" @click="load" />
+    </div>
+
+    <UCard>
+      <div v-if="loading" class="flex justify-center py-8">
+        <UIcon name="i-lucide-loader-circle" class="animate-spin size-6 text-gray-400" />
+      </div>
+
+      <div v-else-if="!waitingStatus" class="py-8 text-center text-gray-500 space-y-2">
+        <p>進捗状況に「待機」が登録されていません。</p>
+        <p class="text-sm">
+          <NuxtLink to="/settings" class="text-blue-500 underline">設定</NuxtLink>
+          から「待機」を進捗状況として登録してください。
+        </p>
+      </div>
+
+      <div v-else-if="waitingTickets.length === 0" class="py-8 text-center text-gray-400">
+        待機中のチケットはありません。
+      </div>
+
+      <div v-else class="overflow-x-auto">
+        <table class="text-sm w-full whitespace-nowrap">
+          <thead>
+            <tr class="border-b border-gray-200 dark:border-gray-700">
+              <th class="text-left py-2 px-2 font-medium">No</th>
+              <th class="text-left py-2 px-2 font-medium">発生日時</th>
+              <th class="text-left py-2 px-2 font-medium">所属会社名</th>
+              <th class="text-left py-2 px-2 font-medium">営業所名</th>
+              <th class="text-left py-2 px-2 font-medium">当事者名</th>
+              <th class="text-left py-2 px-2 font-medium">登録番号</th>
+              <th class="text-left py-2 px-2 font-medium">事故等分類</th>
+              <th class="text-left py-2 px-2 font-medium">内容</th>
+              <th class="text-left py-2 px-2 font-medium">ステータス</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="ticket in waitingTickets"
+              :key="ticket.id"
+              class="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900 cursor-pointer"
+              @click="navigateToTicket(ticket.id)"
+            >
+              <td class="py-2 px-2 text-gray-500">{{ ticket.ticket_no }}</td>
+              <td class="py-2 px-2">{{ formatOccurredAt(ticket.occurred_at, ticket.occurred_date) }}</td>
+              <td class="py-2 px-2">{{ ticket.company_name || '-' }}</td>
+              <td class="py-2 px-2">{{ ticket.office_name || '-' }}</td>
+              <td class="py-2 px-2">{{ ticket.person_name || '-' }}</td>
+              <td class="py-2 px-2">{{ ticket.registration_number || '-' }}</td>
+              <td class="py-2 px-2"><TicketCategoryBadge :category="ticket.category" /></td>
+              <td class="py-2 px-2 max-w-[300px] truncate">{{ ticket.description || '-' }}</td>
+              <td class="py-2 px-2">
+                <UBadge
+                  v-if="ticket.status_id && stateMap[ticket.status_id]"
+                  :style="{ backgroundColor: stateMap[ticket.status_id]!.color + '20', color: stateMap[ticket.status_id]!.color }"
+                  variant="subtle"
+                >
+                  {{ stateMap[ticket.status_id]!.label }}
+                </UBadge>
+                <span v-else class="text-gray-400">-</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </UCard>
+  </div>
+</template>

--- a/app/pages/tickets/waiting.vue
+++ b/app/pages/tickets/waiting.vue
@@ -31,9 +31,14 @@ const waitingStatus = computed(() =>
   progressStatuses.value.find(s => s.name === '待機') ?? null,
 )
 
-const waitingTickets = computed(() => {
+const waitingTickets = computed<TroubleTicket[]>(() => {
   if (!waitingStatus.value) return []
-  return tickets.value.filter(t => t.progress_notes === waitingStatus.value!.name)
+  const target = waitingStatus.value.name
+  const out: unknown[] = []
+  for (const t of tickets.value) {
+    if (t.progress_notes === target) out.push(t)
+  }
+  return out as TroubleTicket[]
 })
 
 const stateMap = computed(() => {

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -415,6 +415,40 @@ export async function deleteTask(taskId: string): Promise<void> {
   await request<void>(`/api/trouble/tasks/${encodeURIComponent(taskId)}`, { method: 'DELETE' })
 }
 
+// --- Cross-ticket Tasks (状況管理) ---
+
+export interface ListTasksQuery {
+  ticket_id?: string
+  status?: 'open' | 'in_progress' | 'done'
+  task_type?: string
+  assigned_to?: string
+  q?: string
+  due_from?: string
+  due_to?: string
+  occurred_from?: string
+  occurred_to?: string
+  sort_by?: 'created_at' | 'occurred_at' | 'due_date' | 'next_action_due' | 'status'
+  sort_desc?: boolean
+  page?: number
+  per_page?: number
+}
+
+export interface ListTasksResponse {
+  items: TroubleTask[]
+  total: number
+  page: number
+  per_page: number
+}
+
+export async function listAllTasks(q: ListTasksQuery = {}): Promise<ListTasksResponse> {
+  const params = new URLSearchParams()
+  for (const [k, v] of Object.entries(q)) {
+    if (v !== undefined && v !== null && v !== '') params.set(k, String(v))
+  }
+  const qs = params.toString()
+  return request<ListTasksResponse>(`/api/trouble/tasks${qs ? `?${qs}` : ''}`)
+}
+
 // --- Task Files ---
 
 export async function getTaskFiles(taskId: string): Promise<TroubleFile[]> {

--- a/tests/layouts/default.test.ts
+++ b/tests/layouts/default.test.ts
@@ -27,8 +27,36 @@ describe('default layout', () => {
   it('renders navigation and user name', () => {
     const wrapper = mount(DefaultLayout, { global: { stubs: allStubs }, slots: { default: '<p>content</p>' } })
     expect(wrapper.text()).toContain('チケット一覧')
+    expect(wrapper.text()).toContain('ステータス管理')
+    expect(wrapper.text()).toContain('待機一覧')
+    expect(wrapper.text()).toContain('状況管理')
+    expect(wrapper.text()).toContain('設定')
     expect(wrapper.text()).toContain('テストユーザー')
     expect(wrapper.text()).toContain('content')
+  })
+
+  it('renders 5 nav items, situations/waiting/tasks open in new tab', () => {
+    const NuxtLinkSpy = {
+      template: '<a :data-to="to" :data-target="target" :data-rel="rel"><slot /></a>',
+      props: ['to', 'target', 'rel'],
+    }
+    const wrapper = mount(DefaultLayout, {
+      global: { stubs: { ...allStubs, NuxtLink: NuxtLinkSpy } },
+    })
+    const links = wrapper.findAll('a')
+    expect(links).toHaveLength(5)
+    const situations = links.find(l => l.attributes('data-to') === '/tickets/situations')
+    const waiting = links.find(l => l.attributes('data-to') === '/tickets/waiting')
+    const tasks = links.find(l => l.attributes('data-to') === '/tasks')
+    const list = links.find(l => l.attributes('data-to') === '/tickets')
+    expect(situations?.attributes('data-target')).toBe('_blank')
+    expect(situations?.attributes('data-rel')).toBe('noopener')
+    expect(waiting?.attributes('data-target')).toBe('_blank')
+    expect(waiting?.attributes('data-rel')).toBe('noopener')
+    expect(tasks?.attributes('data-target')).toBe('_blank')
+    expect(tasks?.attributes('data-rel')).toBe('noopener')
+    // /tickets has no target → undefined attribute
+    expect(list?.attributes('data-target')).toBeUndefined()
   })
 
   it('handles logout', async () => {

--- a/tests/pages/tasks.test.ts
+++ b/tests/pages/tasks.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { allStubs } from '../helpers/nuxt-stubs'
+import type { TroubleTask } from '~/types'
+
+const pushMock = vi.fn()
+vi.mock('#app/composables/router', () => ({
+  useRouter: () => ({ push: pushMock }),
+}))
+
+const listAllTasksMock = vi.fn()
+const getTaskTypesMock = vi.fn()
+const getEmployeesMock = vi.fn()
+vi.mock('~/utils/api', () => ({
+  listAllTasks: (...args: unknown[]) => listAllTasksMock(...args),
+  getTaskTypes: (...args: unknown[]) => getTaskTypesMock(...args),
+  getEmployees: (...args: unknown[]) => getEmployeesMock(...args),
+}))
+
+import TasksPage from '~/pages/tasks.vue'
+
+function makeTask(overrides: Partial<TroubleTask> = {}): TroubleTask {
+  return {
+    id: 'task-1', tenant_id: 'tenant-1', ticket_id: 'ticket-1234567890abcdef',
+    task_type: 'レッカー対応', title: '題名', description: '詳細',
+    status: 'open', assigned_to: 'emp-1', due_date: '2026-05-01',
+    completed_at: null, sort_order: 0,
+    next_action: '電話する', next_action_detail: '',
+    next_action_by: 'emp-2', next_action_due: '2026-05-02',
+    occurred_at: '2026-04-01', created_by: null,
+    created_at: '2026-04-10T00:00:00', updated_at: '2026-04-10T00:00:00',
+    ...overrides,
+  }
+}
+
+describe('tasks page', () => {
+  beforeEach(() => {
+    pushMock.mockReset()
+    listAllTasksMock.mockReset()
+    getTaskTypesMock.mockReset()
+    getEmployeesMock.mockReset()
+    listAllTasksMock.mockResolvedValue({ items: [], total: 0, page: 1, per_page: 50 })
+    getTaskTypesMock.mockResolvedValue([])
+    getEmployeesMock.mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('loads and renders list on mount', async () => {
+    const tasks = [
+      makeTask({ id: 'task-1', title: 'タスクA' }),
+      makeTask({ id: 'task-2', title: 'タスクB', status: 'in_progress' }),
+    ]
+    listAllTasksMock.mockResolvedValue({ items: tasks, total: 2, page: 1, per_page: 50 })
+    getTaskTypesMock.mockResolvedValue([
+      { id: 'tt-1', tenant_id: 'tenant-1', name: 'カスタムタイプ', sort_order: 0, created_at: '2026-01-01' },
+    ])
+    getEmployeesMock.mockResolvedValue([
+      { id: 'emp-1', tenant_id: 'tenant-1', name: '山田太郎', code: 'E001' },
+      { id: 'emp-2', tenant_id: 'tenant-1', name: '佐藤花子', code: 'E002' },
+    ])
+
+    const wrapper = mount(TasksPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(listAllTasksMock).toHaveBeenCalled()
+    expect(wrapper.text()).toContain('タスクA')
+    expect(wrapper.text()).toContain('タスクB')
+    expect(wrapper.text()).toContain('山田太郎')
+    expect(wrapper.text()).toContain('未着手')
+    expect(wrapper.text()).toContain('進行中')
+  })
+
+  it('shows empty state when items is empty', async () => {
+    listAllTasksMock.mockResolvedValue({ items: [], total: 0, page: 1, per_page: 50 })
+
+    const wrapper = mount(TasksPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('該当する状況がありません')
+  })
+
+  it('shows error state when API throws', async () => {
+    listAllTasksMock.mockRejectedValue(new Error('API down'))
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const wrapper = mount(TasksPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('API down')
+    errSpy.mockRestore()
+  })
+
+  it('filter by status triggers re-fetch with query param', async () => {
+    const wrapper = mount(TasksPage, { global: { stubs: allStubs } })
+    await flushPromises()
+    const initialCallCount = listAllTasksMock.mock.calls.length
+
+    const vm = wrapper.vm as unknown as { statusFilter: string }
+    vm.statusFilter = 'in_progress'
+    await flushPromises()
+
+    expect(listAllTasksMock.mock.calls.length).toBeGreaterThan(initialCallCount)
+    const lastCall = listAllTasksMock.mock.calls[listAllTasksMock.mock.calls.length - 1]
+    expect(lastCall[0]).toMatchObject({ status: 'in_progress' })
+  })
+
+  it('search input debounces 300ms before fetching', async () => {
+    vi.useFakeTimers()
+    const wrapper = mount(TasksPage, { global: { stubs: allStubs } })
+    await vi.runAllTimersAsync()
+    const initialCallCount = listAllTasksMock.mock.calls.length
+
+    const vm = wrapper.vm as unknown as { qFilter: string }
+    vm.qFilter = 'キーワード'
+    await Promise.resolve()
+    // Not yet fetched
+    expect(listAllTasksMock.mock.calls.length).toBe(initialCallCount)
+
+    // Advance 250ms: still not fetched
+    await vi.advanceTimersByTimeAsync(250)
+    expect(listAllTasksMock.mock.calls.length).toBe(initialCallCount)
+
+    // Advance past 300ms
+    await vi.advanceTimersByTimeAsync(60)
+    expect(listAllTasksMock.mock.calls.length).toBeGreaterThan(initialCallCount)
+    const lastCall = listAllTasksMock.mock.calls[listAllTasksMock.mock.calls.length - 1]
+    expect(lastCall[0]).toMatchObject({ q: 'キーワード' })
+  })
+
+  it('sort dropdown changes sort_by and re-fetches', async () => {
+    const wrapper = mount(TasksPage, { global: { stubs: allStubs } })
+    await flushPromises()
+    const initialCallCount = listAllTasksMock.mock.calls.length
+
+    const vm = wrapper.vm as unknown as { sortBy: string }
+    vm.sortBy = 'due_date'
+    await flushPromises()
+
+    expect(listAllTasksMock.mock.calls.length).toBeGreaterThan(initialCallCount)
+    const lastCall = listAllTasksMock.mock.calls[listAllTasksMock.mock.calls.length - 1]
+    expect(lastCall[0]).toMatchObject({ sort_by: 'due_date' })
+  })
+
+  it('sort_desc toggle flips direction', async () => {
+    const wrapper = mount(TasksPage, { global: { stubs: allStubs } })
+    await flushPromises()
+    const initialCallCount = listAllTasksMock.mock.calls.length
+
+    const vm = wrapper.vm as unknown as { sortDesc: boolean; toggleSortDir: () => void }
+    expect(vm.sortDesc).toBe(true)
+    vm.toggleSortDir()
+    await flushPromises()
+    expect(vm.sortDesc).toBe(false)
+    expect(listAllTasksMock.mock.calls.length).toBeGreaterThan(initialCallCount)
+    const lastCall = listAllTasksMock.mock.calls[listAllTasksMock.mock.calls.length - 1]
+    expect(lastCall[0]).toMatchObject({ sort_desc: false })
+  })
+
+  it('pagination change triggers fetch with new page', async () => {
+    // Mock returns echo of requested page so it doesn't snap back to 1
+    listAllTasksMock.mockImplementation((q: { page?: number }) => Promise.resolve({
+      items: [], total: 200, page: q?.page ?? 1, per_page: 50,
+    }))
+    const wrapper = mount(TasksPage, { global: { stubs: allStubs } })
+    await flushPromises()
+    const initialCallCount = listAllTasksMock.mock.calls.length
+
+    const vm = wrapper.vm as unknown as { page: number }
+    vm.page = 2
+    await flushPromises()
+
+    expect(listAllTasksMock.mock.calls.length).toBeGreaterThan(initialCallCount)
+    const page2Call = listAllTasksMock.mock.calls.find(c => c[0]?.page === 2)
+    expect(page2Call).toBeDefined()
+  })
+
+  it('row renders NuxtLink to /tickets/{id} with target=_blank', async () => {
+    const tasks = [makeTask({ id: 'task-1', ticket_id: 'ticket-abc-123', title: 'T' })]
+    listAllTasksMock.mockResolvedValue({ items: tasks, total: 1, page: 1, per_page: 50 })
+    const NuxtLinkSpy = {
+      template: '<a :data-to="to" :data-target="target" :data-rel="rel"><slot /></a>',
+      props: ['to', 'target', 'rel'],
+    }
+
+    const wrapper = mount(TasksPage, {
+      global: { stubs: { ...allStubs, NuxtLink: NuxtLinkSpy } },
+    })
+    await flushPromises()
+
+    const links = wrapper.findAll('a')
+    const ticketLink = links.find(l => l.attributes('data-to') === '/tickets/ticket-abc-123')
+    expect(ticketLink).toBeDefined()
+    expect(ticketLink!.attributes('data-target')).toBe('_blank')
+    expect(ticketLink!.attributes('data-rel')).toBe('noopener')
+  })
+
+  it('reload button triggers refetch', async () => {
+    const wrapper = mount(TasksPage, { global: { stubs: allStubs } })
+    await flushPromises()
+    const initialCount = listAllTasksMock.mock.calls.length
+
+    const buttons = wrapper.findAll('button')
+    // first button is 再読み込み
+    await buttons[0].trigger('click')
+    await flushPromises()
+
+    expect(listAllTasksMock.mock.calls.length).toBeGreaterThan(initialCount)
+  })
+
+  it('handles master fetch error gracefully', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    getTaskTypesMock.mockRejectedValue(new Error('boom'))
+    getEmployeesMock.mockRejectedValue(new Error('boom'))
+
+    const wrapper = mount(TasksPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    // Page still renders even if masters fail
+    expect(wrapper.text()).toContain('状況管理 一覧')
+    errSpy.mockRestore()
+  })
+
+  it('formats dates and shows dash for null', async () => {
+    const tasks = [
+      makeTask({
+        id: 'task-1', title: 'A',
+        occurred_at: null, due_date: null, next_action_due: null,
+        description: null, next_action: '',
+        assigned_to: null, next_action_by: null,
+      }),
+    ]
+    listAllTasksMock.mockResolvedValue({ items: tasks, total: 1, page: 1, per_page: 50 })
+
+    const wrapper = mount(TasksPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    // Multiple "-" cells exist
+    expect(wrapper.text()).toContain('-')
+  })
+
+  it('renders unknown status as-is (fallback branch)', async () => {
+    const tasks = [makeTask({ id: 'task-1', status: 'weird-status' })]
+    listAllTasksMock.mockResolvedValue({ items: tasks, total: 1, page: 1, per_page: 50 })
+
+    const wrapper = mount(TasksPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('weird-status')
+  })
+
+  it('resolves employee name from id, falls back to id if unknown', async () => {
+    const tasks = [
+      makeTask({ id: 'task-1', assigned_to: 'emp-unknown', next_action_by: 'emp-1' }),
+    ]
+    listAllTasksMock.mockResolvedValue({ items: tasks, total: 1, page: 1, per_page: 50 })
+    getEmployeesMock.mockResolvedValue([
+      { id: 'emp-1', tenant_id: 'tenant-1', name: '山田太郎', code: null },
+    ])
+
+    const wrapper = mount(TasksPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('emp-unknown')
+    expect(wrapper.text()).toContain('山田太郎')
+  })
+
+  it('error message falls back to string when thrown value is not Error', async () => {
+    listAllTasksMock.mockRejectedValue('string error')
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const wrapper = mount(TasksPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('string error')
+    errSpy.mockRestore()
+  })
+})

--- a/tests/pages/tickets/situations.test.ts
+++ b/tests/pages/tickets/situations.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { allStubs } from '../../helpers/nuxt-stubs'
+import { makeTroubleTicket, makeWorkflowState } from '../../helpers/test-data'
+
+const pushMock = vi.fn()
+vi.mock('#app/composables/router', () => ({
+  useRouter: () => ({ push: pushMock }),
+}))
+
+const getTicketsMock = vi.fn()
+const getWorkflowStatesMock = vi.fn()
+vi.mock('~/utils/api', () => ({
+  getTickets: (...args: unknown[]) => getTicketsMock(...args),
+  getWorkflowStates: (...args: unknown[]) => getWorkflowStatesMock(...args),
+}))
+
+import SituationsPage from '~/pages/tickets/situations.vue'
+
+describe('situations page', () => {
+  beforeEach(() => {
+    pushMock.mockReset()
+    getTicketsMock.mockReset()
+    getWorkflowStatesMock.mockReset()
+  })
+
+  it('groups tickets by workflow_state_id, shows headers, navigates on click', async () => {
+    const stateA = makeWorkflowState({ id: 'state-a', label: '対応中', color: '#3b82f6' })
+    const stateB = makeWorkflowState({ id: 'state-b', label: '完了', color: '#10b981' })
+    const tickets = [
+      makeTroubleTicket({ id: 't1', ticket_no: 1, status_id: 'state-a', title: 'チケットA1' }),
+      makeTroubleTicket({ id: 't2', ticket_no: 2, status_id: 'state-a', title: 'チケットA2' }),
+      makeTroubleTicket({ id: 't3', ticket_no: 3, status_id: 'state-b', title: 'チケットB1' }),
+    ]
+    getTicketsMock.mockResolvedValue({ tickets, total: 3, page: 1, per_page: 1000 })
+    getWorkflowStatesMock.mockResolvedValue([stateA, stateB])
+
+    const wrapper = mount(SituationsPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('対応中')
+    expect(wrapper.text()).toContain('完了')
+    expect(wrapper.text()).toContain('チケットA1')
+    expect(wrapper.text()).toContain('チケットA2')
+    expect(wrapper.text()).toContain('チケットB1')
+    expect(wrapper.text()).toContain('(2)')
+    expect(wrapper.text()).toContain('(1)')
+
+    const cards = wrapper.findAll('.cursor-pointer')
+    await cards[0].trigger('click')
+    expect(pushMock).toHaveBeenCalledWith('/tickets/t1')
+  })
+
+  it('renders empty column header even with no tickets', async () => {
+    const stateA = makeWorkflowState({ id: 'state-a', label: '対応中' })
+    getTicketsMock.mockResolvedValue({ tickets: [], total: 0, page: 1, per_page: 1000 })
+    getWorkflowStatesMock.mockResolvedValue([stateA])
+
+    const wrapper = mount(SituationsPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('対応中')
+    expect(wrapper.text()).toContain('(0)')
+  })
+
+  it('shows message when no workflow states defined', async () => {
+    getTicketsMock.mockResolvedValue({ tickets: [], total: 0, page: 1, per_page: 1000 })
+    getWorkflowStatesMock.mockResolvedValue([])
+
+    const wrapper = mount(SituationsPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('ワークフローが未設定')
+  })
+
+  it('groups tickets with unknown status into 未設定 column', async () => {
+    const stateA = makeWorkflowState({ id: 'state-a', label: '対応中' })
+    const tickets = [
+      makeTroubleTicket({ id: 't1', ticket_no: 1, status_id: null, title: 'No status' }),
+      makeTroubleTicket({ id: 't2', ticket_no: 2, status_id: 'unknown-state', title: 'Unknown' }),
+    ]
+    getTicketsMock.mockResolvedValue({ tickets, total: 2, page: 1, per_page: 1000 })
+    getWorkflowStatesMock.mockResolvedValue([stateA])
+
+    const wrapper = mount(SituationsPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('未設定')
+    expect(wrapper.text()).toContain('No status')
+    expect(wrapper.text()).toContain('Unknown')
+  })
+
+  it('handles getWorkflowStates error gracefully (catch returns [])', async () => {
+    getTicketsMock.mockResolvedValue({ tickets: [], total: 0, page: 1, per_page: 1000 })
+    getWorkflowStatesMock.mockRejectedValue(new Error('boom'))
+
+    const wrapper = mount(SituationsPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('ワークフローが未設定')
+  })
+
+  it('logs and recovers when load fails', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    getTicketsMock.mockRejectedValue(new Error('boom'))
+    getWorkflowStatesMock.mockResolvedValue([])
+
+    const wrapper = mount(SituationsPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(errSpy).toHaveBeenCalled()
+    expect(wrapper.text()).toContain('ワークフローが未設定')
+    errSpy.mockRestore()
+  })
+
+  it('truncates long ticket titles', async () => {
+    const stateA = makeWorkflowState({ id: 'state-a', label: '対応中' })
+    const longTitle = 'あ'.repeat(60)
+    const tickets = [
+      makeTroubleTicket({ id: 't1', ticket_no: 1, status_id: 'state-a', title: longTitle }),
+      // No title → falls back to description
+      makeTroubleTicket({ id: 't2', ticket_no: 2, status_id: 'state-a', title: '', description: '短い説明' }),
+      // No title and no description → falls back to category
+      makeTroubleTicket({ id: 't3', ticket_no: 3, status_id: 'state-a', title: '', description: '', category: 'カテゴリのみ' }),
+    ]
+    getTicketsMock.mockResolvedValue({ tickets, total: 3, page: 1, per_page: 1000 })
+    getWorkflowStatesMock.mockResolvedValue([stateA])
+
+    const wrapper = mount(SituationsPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('...')
+    expect(wrapper.text()).toContain('短い説明')
+    expect(wrapper.text()).toContain('カテゴリのみ')
+  })
+
+  it('reload button refetches', async () => {
+    getTicketsMock.mockResolvedValue({ tickets: [], total: 0, page: 1, per_page: 1000 })
+    getWorkflowStatesMock.mockResolvedValue([])
+
+    const wrapper = mount(SituationsPage, { global: { stubs: allStubs } })
+    await flushPromises()
+    expect(getTicketsMock).toHaveBeenCalledTimes(1)
+
+    const buttons = wrapper.findAll('button')
+    const beforeCount = getTicketsMock.mock.calls.length
+    await buttons[0].trigger('click')
+    await flushPromises()
+    expect(getTicketsMock.mock.calls.length).toBeGreaterThan(beforeCount)
+  })
+
+  it('shows assignee and registration on cards', async () => {
+    const stateA = makeWorkflowState({ id: 'state-a', label: '対応中' })
+    const tickets = [
+      makeTroubleTicket({
+        id: 't1', ticket_no: 1, status_id: 'state-a', title: 'A',
+        assigned_to: '田中太郎', registration_number: '品川 100 あ 1234',
+      }),
+    ]
+    getTicketsMock.mockResolvedValue({ tickets, total: 1, page: 1, per_page: 1000 })
+    getWorkflowStatesMock.mockResolvedValue([stateA])
+
+    const wrapper = mount(SituationsPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('田中太郎')
+    expect(wrapper.text()).toContain('品川 100 あ 1234')
+  })
+})

--- a/tests/pages/tickets/waiting.test.ts
+++ b/tests/pages/tickets/waiting.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { allStubs } from '../../helpers/nuxt-stubs'
+import { makeTroubleTicket, makeWorkflowState } from '../../helpers/test-data'
+
+const pushMock = vi.fn()
+vi.mock('#app/composables/router', () => ({
+  useRouter: () => ({ push: pushMock }),
+}))
+
+const getTicketsMock = vi.fn()
+const getProgressStatusesMock = vi.fn()
+const getWorkflowStatesMock = vi.fn()
+vi.mock('~/utils/api', () => ({
+  getTickets: (...args: unknown[]) => getTicketsMock(...args),
+  getProgressStatuses: (...args: unknown[]) => getProgressStatusesMock(...args),
+  getWorkflowStates: (...args: unknown[]) => getWorkflowStatesMock(...args),
+}))
+
+import WaitingPage from '~/pages/tickets/waiting.vue'
+
+const waitingProgress = {
+  id: 'prog-w', tenant_id: 'tenant-1', name: '待機', sort_order: 1, created_at: '2026-01-01',
+}
+const otherProgress = {
+  id: 'prog-o', tenant_id: 'tenant-1', name: '対応中', sort_order: 2, created_at: '2026-01-01',
+}
+
+describe('waiting page', () => {
+  beforeEach(() => {
+    pushMock.mockReset()
+    getTicketsMock.mockReset()
+    getProgressStatusesMock.mockReset()
+    getWorkflowStatesMock.mockReset()
+  })
+
+  it('shows only tickets matching 待機', async () => {
+    const tickets = [
+      makeTroubleTicket({ id: 't1', ticket_no: 1, progress_notes: '待機', description: '待機チケット' }),
+      makeTroubleTicket({ id: 't2', ticket_no: 2, progress_notes: '対応中', description: '対応中チケット' }),
+      makeTroubleTicket({ id: 't3', ticket_no: 3, progress_notes: '', description: '空' }),
+    ]
+    getTicketsMock.mockResolvedValue({ tickets, total: 3, page: 1, per_page: 1000 })
+    getProgressStatusesMock.mockResolvedValue([waitingProgress, otherProgress])
+    getWorkflowStatesMock.mockResolvedValue([makeWorkflowState({ id: 'state-1', label: '新規' })])
+
+    const wrapper = mount(WaitingPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('待機チケット')
+    expect(wrapper.text()).not.toContain('対応中チケット')
+    expect(wrapper.text()).not.toContain('空')
+  })
+
+  it('shows empty state when no 待機 status defined', async () => {
+    getTicketsMock.mockResolvedValue({ tickets: [], total: 0, page: 1, per_page: 1000 })
+    getProgressStatusesMock.mockResolvedValue([otherProgress])
+    getWorkflowStatesMock.mockResolvedValue([])
+
+    const wrapper = mount(WaitingPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('「待機」が登録されていません')
+  })
+
+  it('shows empty list when 待機 status exists but no matching tickets', async () => {
+    const tickets = [
+      makeTroubleTicket({ id: 't1', progress_notes: '対応中' }),
+    ]
+    getTicketsMock.mockResolvedValue({ tickets, total: 1, page: 1, per_page: 1000 })
+    getProgressStatusesMock.mockResolvedValue([waitingProgress])
+    getWorkflowStatesMock.mockResolvedValue([])
+
+    const wrapper = mount(WaitingPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('待機中のチケットはありません')
+  })
+
+  it('navigates on row click', async () => {
+    const tickets = [
+      makeTroubleTicket({ id: 't1', ticket_no: 1, progress_notes: '待機', description: 'X' }),
+    ]
+    getTicketsMock.mockResolvedValue({ tickets, total: 1, page: 1, per_page: 1000 })
+    getProgressStatusesMock.mockResolvedValue([waitingProgress])
+    getWorkflowStatesMock.mockResolvedValue([])
+
+    const wrapper = mount(WaitingPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    const row = wrapper.find('tbody tr')
+    await row.trigger('click')
+    expect(pushMock).toHaveBeenCalledWith('/tickets/t1')
+  })
+
+  it('renders status badge with workflow state color', async () => {
+    const state = makeWorkflowState({ id: 'state-1', label: '対応中', color: '#3b82f6' })
+    const tickets = [
+      makeTroubleTicket({ id: 't1', progress_notes: '待機', status_id: 'state-1' }),
+      makeTroubleTicket({ id: 't2', progress_notes: '待機', status_id: null }),
+    ]
+    getTicketsMock.mockResolvedValue({ tickets, total: 2, page: 1, per_page: 1000 })
+    getProgressStatusesMock.mockResolvedValue([waitingProgress])
+    getWorkflowStatesMock.mockResolvedValue([state])
+
+    const wrapper = mount(WaitingPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('対応中')
+  })
+
+  it('reloads when 再読み込み clicked', async () => {
+    getTicketsMock.mockResolvedValue({ tickets: [], total: 0, page: 1, per_page: 1000 })
+    getProgressStatusesMock.mockResolvedValue([])
+    getWorkflowStatesMock.mockResolvedValue([])
+
+    const wrapper = mount(WaitingPage, { global: { stubs: allStubs } })
+    await flushPromises()
+    expect(getTicketsMock).toHaveBeenCalledTimes(1)
+
+    const buttons = wrapper.findAll('button')
+    const beforeCount = getTicketsMock.mock.calls.length
+    await buttons[0].trigger('click')
+    await flushPromises()
+    expect(getTicketsMock.mock.calls.length).toBeGreaterThan(beforeCount)
+  })
+
+  it('handles getProgressStatuses error gracefully', async () => {
+    getTicketsMock.mockResolvedValue({ tickets: [], total: 0, page: 1, per_page: 1000 })
+    getProgressStatusesMock.mockRejectedValue(new Error('boom'))
+    getWorkflowStatesMock.mockResolvedValue([])
+
+    const wrapper = mount(WaitingPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('「待機」が登録されていません')
+  })
+
+  it('handles getWorkflowStates error gracefully', async () => {
+    const tickets = [makeTroubleTicket({ id: 't1', progress_notes: '待機' })]
+    getTicketsMock.mockResolvedValue({ tickets, total: 1, page: 1, per_page: 1000 })
+    getProgressStatusesMock.mockResolvedValue([waitingProgress])
+    getWorkflowStatesMock.mockRejectedValue(new Error('boom'))
+
+    const wrapper = mount(WaitingPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('待機')
+  })
+
+  it('logs and recovers when load fails', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    getTicketsMock.mockRejectedValue(new Error('boom'))
+    getProgressStatusesMock.mockResolvedValue([])
+    getWorkflowStatesMock.mockResolvedValue([])
+
+    const wrapper = mount(WaitingPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(errSpy).toHaveBeenCalled()
+    errSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary

Sidebar nav に 3 件の新ページを追加 (いずれも target=_blank で別タブ):

- **ステータス管理** (/tickets/situations) — workflow_state_id 別 Kanban
- **待機一覧** (/tickets/waiting) — progress_notes === '待機' でフィルタ
- **状況管理** (/tasks) — ticket 横断 trouble_tasks 一覧

`/tasks` のフィルタ: status / task_type / 担当 / 検索 (debounce 300ms) / 期限・発生日 range。
ソート: created_at / occurred_at / due_date / next_action_due / status + 昇降切替。
行クリックで親チケットを別タブで開く。

バックエンド: ippoan/rust-alc-api#262 の `GET /trouble/tasks` を利用。
staging では backend マージ後に動作確認する。

## Test plan

- [x] vitest: 28 files / 192 tests pass
- [x] 動作確認: /wt-quick でナビ表示・リンク target 確認 (ユーザー確認済)

Closes #108