### PR TITLE
feat(settings): dynamic task statuses + nav tooltips + /tickets/waiting → /tasks

### DIFF
--- a/app/components/TicketGanttChart.vue
+++ b/app/components/TicketGanttChart.vue
@@ -2,6 +2,17 @@
 import type { TroubleTask } from '~/types'
 import { TASK_STATUS_LABELS } from '~/types'
 import { getTasks } from '~/utils/api'
+import { useTaskStatuses } from '~/composables/useTaskStatuses'
+
+const { load: loadTaskStatuses, statuses: taskStatusList, loaded: taskStatusesLoaded } = useTaskStatuses()
+loadTaskStatuses()
+
+const legendEntries = computed<{ key: string; label: string; color: string }[]>(() => {
+  if (taskStatusesLoaded.value && taskStatusList.value.length > 0) {
+    return taskStatusList.value.map(s => ({ key: s.key, label: s.name, color: s.color }))
+  }
+  return Object.entries(TASK_STATUS_LABELS).map(([key, v]) => ({ key, label: v.label, color: v.color }))
+})
 
 const props = defineProps<{
   ticketId: string
@@ -123,9 +134,9 @@ watch(() => props.ticketId, async () => {
 
     <!-- Legend -->
     <div class="flex gap-3 mb-2 text-xs text-gray-500">
-      <span v-for="(info, key) in TASK_STATUS_LABELS" :key="key" class="flex items-center gap-1">
-        <span class="inline-block w-3 h-3 rounded" :style="{ backgroundColor: info.color }" />
-        {{ info.label }}
+      <span v-for="entry in legendEntries" :key="entry.key" class="flex items-center gap-1">
+        <span class="inline-block w-3 h-3 rounded" :style="{ backgroundColor: entry.color }" />
+        {{ entry.label }}
       </span>
     </div>
 

--- a/app/components/TicketTaskCard.vue
+++ b/app/components/TicketTaskCard.vue
@@ -2,6 +2,10 @@
 import type { TroubleTask } from '~/types'
 import { TASK_STATUS_LABELS } from '~/types'
 import { updateTask } from '~/utils/api'
+import { useTaskStatuses } from '~/composables/useTaskStatuses'
+
+const { load: loadTaskStatuses, statuses: taskStatusList, loaded: taskStatusesLoaded } = useTaskStatuses()
+loadTaskStatuses()
 
 const props = defineProps<{ task: TroubleTask }>()
 const emit = defineEmits<{
@@ -17,11 +21,12 @@ const nextActionByDraft = ref(props.task.next_action_by || '')
 const nextActionDueDraft = ref(props.task.next_action_due?.substring(0, 10) || '')
 const dueDateDraft = ref(props.task.due_date?.substring(0, 10) || '')
 
-const statusOptions = [
-  { label: TASK_STATUS_LABELS['open']!.label, value: 'open' },
-  { label: TASK_STATUS_LABELS['in_progress']!.label, value: 'in_progress' },
-  { label: TASK_STATUS_LABELS['done']!.label, value: 'done' },
-]
+const statusOptions = computed<{ label: string; value: string }[]>(() => {
+  if (taskStatusesLoaded.value && taskStatusList.value.length > 0) {
+    return taskStatusList.value.map(s => ({ label: s.name, value: s.key }))
+  }
+  return Object.entries(TASK_STATUS_LABELS).map(([key, v]) => ({ label: v.label, value: key }))
+})
 
 const selectedStatus = ref(props.task.status)
 

--- a/app/components/TicketTaskList.vue
+++ b/app/components/TicketTaskList.vue
@@ -2,6 +2,9 @@
 import type { TroubleTask, TroubleWorkflowState, Employee, TroubleFile } from '~/types'
 import { DEFAULT_TASK_TYPES, TASK_STATUS_LABELS } from '~/types'
 import { getTasks, getTaskTypes, createTask, updateTask, deleteTask, getEmployees, getTaskFiles, uploadTaskFile, downloadTaskFile, deleteTaskFile, restoreTaskFile } from '~/utils/api'
+import { useTaskStatuses } from '~/composables/useTaskStatuses'
+
+const { load: loadTaskStatuses, statuses: taskStatusList, byKey: taskStatusByKey, loaded: taskStatusesLoaded } = useTaskStatuses()
 
 const props = defineProps<{
   ticketId: string
@@ -65,9 +68,16 @@ async function fetchTaskTypes() {
   }
 }
 
+function isTaskDone(status: string): boolean {
+  if (taskStatusesLoaded.value) {
+    return taskStatusByKey(status)?.is_done === true
+  }
+  return status === 'done'
+}
+
 const completionCount = computed(() => {
   const total = tasks.value.length
-  const done = tasks.value.filter(t => t.status === 'done').length
+  const done = tasks.value.filter(t => isTaskDone(t.status)).length
   return { total, done }
 })
 
@@ -86,7 +96,7 @@ async function loadTasks() {
 
 function checkSuggestions() {
   if (tasks.value.length === 0) return
-  const allDone = tasks.value.every(t => t.status === 'done')
+  const allDone = tasks.value.every(t => isTaskDone(t.status))
   const anyInProgress = tasks.value.some(t => t.status === 'in_progress')
   if (allDone) {
     const terminalState = props.workflowStates.find(s => s.is_terminal)
@@ -152,11 +162,12 @@ async function handleDeleteTask(taskId: string) {
   }
 }
 
-const statusOptions = [
-  { label: TASK_STATUS_LABELS['open']!.label, value: 'open' },
-  { label: TASK_STATUS_LABELS['in_progress']!.label, value: 'in_progress' },
-  { label: TASK_STATUS_LABELS['done']!.label, value: 'done' },
-]
+const statusOptions = computed<{ label: string; value: string }[]>(() => {
+  if (taskStatusesLoaded.value && taskStatusList.value.length > 0) {
+    return taskStatusList.value.map(s => ({ label: s.name, value: s.key }))
+  }
+  return Object.entries(TASK_STATUS_LABELS).map(([key, v]) => ({ label: v.label, value: key }))
+})
 
 // --- Inline edit ---
 const editingId = ref<string | null>(null)
@@ -337,6 +348,7 @@ function formatFileSize(bytes: number | bigint): string {
 onMounted(() => {
   fetchTaskTypes()
   fetchEmployees()
+  loadTaskStatuses()
   loadTasks().then(() => loadAllFileCounts())
 })
 

--- a/app/composables/useTaskStatuses.ts
+++ b/app/composables/useTaskStatuses.ts
@@ -1,0 +1,70 @@
+import { getTaskStatuses } from '~/utils/api'
+import { TASK_STATUS_LABELS } from '~/types'
+import type { TroubleTaskStatus } from '~/types'
+
+// module-level shared state (singleton across all composable calls in the app)
+const _data = ref<TroubleTaskStatus[]>([])
+const _loading = ref(false)
+const _loaded = ref(false)
+
+const _sorted = computed<TroubleTaskStatus[]>(() =>
+  [..._data.value].sort((a, b) => a.sort_order - b.sort_order),
+)
+
+const _byKeyMap = computed(() => {
+  const map = new Map<string, TroubleTaskStatus>()
+  for (const s of _data.value) map.set(s.key, s)
+  return map
+})
+
+const _waitingStatusKey = computed<string>(() => {
+  const list = _sorted.value
+  const byKey = list.find(s => s.key === 'waiting')
+  if (byKey) return byKey.key
+  const byName = list.find(s => s.name === '待機')
+  if (byName) return byName.key
+  return 'waiting'
+})
+
+export interface TaskStatusLabel {
+  label: string
+  color: string
+  is_done?: boolean
+}
+
+export function useTaskStatuses() {
+  async function load(force = false) {
+    if (!force && (_loaded.value || _loading.value)) return
+    _loading.value = true
+    try {
+      const list = await getTaskStatuses()
+      _data.value = list || []
+      _loaded.value = true
+    } catch (e) {
+      console.error('Failed to load task statuses:', e)
+      _data.value = []
+      _loaded.value = true
+    } finally {
+      _loading.value = false
+    }
+  }
+
+  function byKey(key: string | null | undefined): TaskStatusLabel | undefined {
+    if (!key) return undefined
+    const s = _byKeyMap.value.get(key)
+    if (s) return { label: s.name, color: s.color, is_done: s.is_done }
+    const fb = TASK_STATUS_LABELS[key]
+    if (fb) return { label: fb.label, color: fb.color, is_done: key === 'done' }
+    return undefined
+  }
+
+  return {
+    load,
+    loading: _loading,
+    loaded: _loaded,
+    statuses: _sorted,
+    data: _data,
+    byKey,
+    waitingStatusKey: _waitingStatusKey,
+  }
+}

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -16,12 +16,40 @@ const isDark = computed({
   },
 })
 
-const navigation: { label: string; icon: string; to: string; target?: string }[] = [
-  { label: 'チケット一覧', icon: 'i-lucide-list', to: '/tickets' },
-  { label: 'ステータス管理', icon: 'i-lucide-kanban', to: '/tickets/situations', target: '_blank' },
-  { label: '待機一覧', icon: 'i-lucide-clock', to: '/tickets/waiting', target: '_blank' },
-  { label: '状況管理', icon: 'i-lucide-list-checks', to: '/tasks', target: '_blank' },
-  { label: '設定', icon: 'i-lucide-settings', to: '/settings' },
+const navigation: { label: string; icon: string; to: string; target?: string; description: string }[] = [
+  {
+    label: 'チケット一覧',
+    icon: 'i-lucide-list',
+    to: '/tickets',
+    description: 'すべてのトラブルチケットを一覧表示・編集・新規作成',
+  },
+  {
+    label: 'ステータス管理',
+    icon: 'i-lucide-kanban',
+    to: '/tickets/situations',
+    target: '_blank',
+    description: 'ワークフロー状態別 (未着手/対応中/完了など) のカンバン表示',
+  },
+  {
+    label: '待機一覧',
+    icon: 'i-lucide-clock',
+    to: '/tickets/waiting',
+    target: '_blank',
+    description: '進捗状況が「待機」のチケットのみ抽出',
+  },
+  {
+    label: '状況管理',
+    icon: 'i-lucide-list-checks',
+    to: '/tasks',
+    target: '_blank',
+    description: '全チケット横断の状況 (サブタスク) 一覧、フィルタ・並び替え可',
+  },
+  {
+    label: '設定',
+    icon: 'i-lucide-settings',
+    to: '/settings',
+    description: 'カテゴリ / 営業所 / ワークフロー / 通知などのマスタ管理',
+  },
 ]
 
 function handleLogout() {
@@ -39,20 +67,28 @@ function handleLogout() {
       </div>
 
       <nav class="flex-1 p-2">
-        <NuxtLink
+        <UTooltip
           v-for="item in navigation"
           :key="item.to"
-          :to="item.to"
-          :target="item.target"
-          :rel="item.target ? 'noopener' : undefined"
-          class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors"
-          :class="!item.target && route.path.startsWith(item.to)
-            ? 'bg-blue-50 dark:bg-blue-950 text-blue-700 dark:text-blue-300 font-medium'
-            : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'"
+          :text="item.description"
+          :content="{ side: 'right', sideOffset: 12 }"
+          :delay-duration="150"
+          :ui="{ content: 'max-w-md text-lg px-5 py-3 leading-relaxed font-medium ring-2 ring-blue-500 dark:ring-blue-400 shadow-xl' }"
         >
-          <UIcon :name="item.icon" class="size-5" />
-          {{ item.label }}
-        </NuxtLink>
+          <NuxtLink
+            :to="item.to"
+            :target="item.target"
+            :rel="item.target ? 'noopener' : undefined"
+            :title="item.description"
+            class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors"
+            :class="!item.target && route.path.startsWith(item.to)
+              ? 'bg-blue-50 dark:bg-blue-950 text-blue-700 dark:text-blue-300 font-medium'
+              : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'"
+          >
+            <UIcon :name="item.icon" class="size-5" />
+            {{ item.label }}
+          </NuxtLink>
+        </UTooltip>
       </nav>
 
       <!-- Dark mode toggle + User -->

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import type { TroubleCategory, TroubleOffice, TroubleProgressStatus, TroubleNotificationPref, LineworksMember, TroubleTaskType } from '~/types'
+import type { TroubleCategory, TroubleOffice, TroubleProgressStatus, TroubleNotificationPref, LineworksMember, TroubleTaskType, TroubleTaskStatus } from '~/types'
 import { TICKET_CATEGORIES, DEFAULT_TASK_TYPES, NOTIFICATION_EVENT_TYPES } from '~/types'
 import {
   getCategories, createCategory, deleteCategory, updateCategorySortOrder,
   getOffices, createOffice, deleteOffice, updateOfficeSortOrder,
   getProgressStatuses, createProgressStatus, deleteProgressStatus, updateProgressStatusSortOrder,
   getTaskTypes, createTaskType, deleteTaskType, updateTaskTypeSortOrder,
+  getTaskStatuses, createTaskStatus, deleteTaskStatus, updateTaskStatusSortOrder,
   getNotificationPrefs, upsertNotificationPref, deleteNotificationPref, getLineworksMembers,
 } from '~/utils/api'
 
@@ -15,6 +16,7 @@ const activeTab = ref('categories')
 const tabs = [
   { label: 'カテゴリ', value: 'categories' },
   { label: '状況管理タイプ', value: 'taskTypes' },
+  { label: '状況ステータス', value: 'taskStatuses' },
   { label: '営業所', value: 'offices' },
   { label: '進捗状況', value: 'progress' },
   { label: 'ワークフロー', value: 'workflow' },
@@ -104,6 +106,49 @@ async function handleReorderTaskType(id: string, sortOrder: number) {
     if (idx >= 0) taskTypes.value[idx] = updated
   } catch (e) {
     console.error('タスクタイプ順序変更エラー:', e)
+  }
+}
+
+// Task Statuses (dynamic master)
+const taskStatuses = ref<TroubleTaskStatus[]>([])
+const taskStatusesLoading = ref(false)
+
+async function fetchTaskStatuses() {
+  taskStatusesLoading.value = true
+  try {
+    taskStatuses.value = await getTaskStatuses()
+  } catch (e) {
+    console.error('状況ステータス取得エラー:', e)
+  } finally {
+    taskStatusesLoading.value = false
+  }
+}
+
+async function handleCreateTaskStatus(name: string) {
+  try {
+    const created = await createTaskStatus({ name, sort_order: (taskStatuses.value.length + 1) * 10 })
+    taskStatuses.value = [...taskStatuses.value, created]
+  } catch (e) {
+    console.error('状況ステータス作成エラー:', e)
+  }
+}
+
+async function handleDeleteTaskStatus(id: string) {
+  try {
+    await deleteTaskStatus(id)
+    taskStatuses.value = taskStatuses.value.filter(t => t.id !== id)
+  } catch (e) {
+    console.error('状況ステータス削除エラー:', e)
+  }
+}
+
+async function handleReorderTaskStatus(id: string, sortOrder: number) {
+  try {
+    const updated = await updateTaskStatusSortOrder(id, sortOrder)
+    const idx = taskStatuses.value.findIndex(t => t.id === id)
+    if (idx >= 0) taskStatuses.value[idx] = updated
+  } catch (e) {
+    console.error('状況ステータス順序変更エラー:', e)
   }
 }
 
@@ -289,6 +334,7 @@ const notifMemberOptions = computed(() =>
 onMounted(() => {
   fetchCategories()
   fetchTaskTypes()
+  fetchTaskStatuses()
   fetchOffices()
   fetchProgressStatuses()
   fetchNotifications()
@@ -334,6 +380,16 @@ onMounted(() => {
         @create="handleCreateTaskType"
         @delete="handleDeleteTaskType"
         @reorder="handleReorderTaskType"
+      />
+
+      <MasterDataManager
+        v-if="activeTab === 'taskStatuses'"
+        title="状況ステータス"
+        :items="taskStatuses"
+        :loading="taskStatusesLoading"
+        @create="handleCreateTaskStatus"
+        @delete="handleDeleteTaskStatus"
+        @reorder="handleReorderTaskStatus"
       />
 
       <MasterDataManager

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -3,6 +3,10 @@ import type { TroubleTask, TroubleTaskType, Employee } from '~/types'
 import { TASK_STATUS_LABELS, DEFAULT_TASK_TYPES } from '~/types'
 import { listAllTasks, getTaskTypes, getEmployees } from '~/utils/api'
 import type { ListTasksQuery } from '~/utils/api'
+import { useTaskStatuses } from '~/composables/useTaskStatuses'
+
+const route = useRoute()
+const { load: loadTaskStatuses, statuses: taskStatusList, byKey: taskStatusByKey, loaded: taskStatusesLoaded } = useTaskStatuses()
 
 const items = ref<TroubleTask[]>([])
 const total = ref(0)
@@ -15,7 +19,7 @@ const taskTypes = ref<TroubleTaskType[]>([])
 const employees = ref<Employee[]>([])
 
 // Filters
-const statusFilter = ref<'open' | 'in_progress' | 'done' | ''>('')
+const statusFilter = ref<string>('')
 const taskTypeFilter = ref<string>('')
 const assignedToFilter = ref<string>('')
 const qFilter = ref<string>('')
@@ -28,12 +32,16 @@ const occurredTo = ref<string>('')
 const sortBy = ref<'created_at' | 'occurred_at' | 'due_date' | 'next_action_due' | 'status'>('created_at')
 const sortDesc = ref<boolean>(true)
 
-const STATUS_OPTIONS = [
-  { label: 'すべて', value: '' },
-  { label: '未着手', value: 'open' },
-  { label: '進行中', value: 'in_progress' },
-  { label: '完了', value: 'done' },
-]
+const STATUS_OPTIONS = computed<{ label: string; value: string }[]>(() => {
+  const base = [{ label: 'すべて', value: '' }]
+  if (taskStatusesLoaded.value && taskStatusList.value.length > 0) {
+    return [...base, ...taskStatusList.value.map(s => ({ label: s.name, value: s.key }))]
+  }
+  return [
+    ...base,
+    ...Object.entries(TASK_STATUS_LABELS).map(([key, v]) => ({ label: v.label, value: key })),
+  ]
+})
 
 const SORT_OPTIONS = [
   { label: '作成日', value: 'created_at' },
@@ -153,7 +161,12 @@ function ticketHref(taskTicketId: string): string {
 }
 
 onMounted(async () => {
-  await loadMasters()
+  // Preset status filter from ?status=<key>
+  const routeStatus = route.query.status
+  if (typeof routeStatus === 'string' && routeStatus) {
+    statusFilter.value = routeStatus
+  }
+  await Promise.all([loadMasters(), loadTaskStatuses()])
   await load()
 })
 </script>
@@ -266,11 +279,11 @@ onMounted(async () => {
               <td class="py-2 px-2">{{ formatYmd(task.next_action_due) }}</td>
               <td class="py-2 px-2">
                 <UBadge
-                  v-if="TASK_STATUS_LABELS[task.status]"
-                  :style="{ backgroundColor: TASK_STATUS_LABELS[task.status]!.color + '20', color: TASK_STATUS_LABELS[task.status]!.color }"
+                  v-if="taskStatusByKey(task.status)"
+                  :style="{ backgroundColor: taskStatusByKey(task.status)!.color + '20', color: taskStatusByKey(task.status)!.color }"
                   variant="subtle"
                 >
-                  {{ TASK_STATUS_LABELS[task.status]!.label }}
+                  {{ taskStatusByKey(task.status)!.label }}
                 </UBadge>
                 <span v-else class="text-gray-400">{{ task.status }}</span>
               </td>

--- a/app/pages/tickets/waiting.vue
+++ b/app/pages/tickets/waiting.vue
@@ -1,127 +1,22 @@
 <script setup lang="ts">
-import type { TroubleTicket, TroubleProgressStatus, TroubleWorkflowState } from '~/types'
-import { getTickets, getProgressStatuses, getWorkflowStates } from '~/utils/api'
-import { formatOccurredAt } from '~/utils/datetime'
+import { useTaskStatuses } from '~/composables/useTaskStatuses'
 
-const router = useRouter()
-const tickets = ref<TroubleTicket[]>([])
-const progressStatuses = ref<TroubleProgressStatus[]>([])
-const workflowStates = ref<TroubleWorkflowState[]>([])
-const loading = ref(false)
+const { load: loadTaskStatuses, waitingStatusKey } = useTaskStatuses()
 
-async function load() {
-  loading.value = true
+onMounted(async () => {
   try {
-    const [ticketsRes, progs, states] = await Promise.all([
-      getTickets({ per_page: 1000 }),
-      getProgressStatuses().catch(() => [] as TroubleProgressStatus[]),
-      getWorkflowStates().catch(() => [] as TroubleWorkflowState[]),
-    ])
-    tickets.value = ticketsRes.tickets
-    progressStatuses.value = progs
-    workflowStates.value = states
+    await loadTaskStatuses()
   } catch (e) {
-    console.error('Failed to load waiting tickets:', e)
-  } finally {
-    loading.value = false
+    console.error('Failed to load task statuses:', e)
   }
-}
-
-const waitingStatus = computed(() =>
-  progressStatuses.value.find(s => s.name === '待機') ?? null,
-)
-
-const waitingTickets = computed<TroubleTicket[]>(() => {
-  if (!waitingStatus.value) return []
-  const target = waitingStatus.value.name
-  const out: unknown[] = []
-  for (const t of tickets.value) {
-    if (t.progress_notes === target) out.push(t)
-  }
-  return out as TroubleTicket[]
+  const key = waitingStatusKey.value || 'waiting'
+  await navigateTo(`/tasks?status=${encodeURIComponent(key)}`, { replace: true })
 })
-
-const stateMap = computed(() => {
-  const map: Record<string, TroubleWorkflowState> = {}
-  for (const s of workflowStates.value) map[s.id] = s
-  return map
-})
-
-function navigateToTicket(id: string) {
-  router.push(`/tickets/${id}`)
-}
-
-onMounted(() => { load() })
 </script>
 
 <template>
-  <div class="space-y-4">
-    <div class="flex items-center justify-between">
-      <h2 class="text-xl font-bold">待機一覧</h2>
-      <UButton label="再読み込み" icon="i-lucide-refresh-cw" variant="outline" size="sm" :loading="loading" @click="load" />
-    </div>
-
-    <UCard>
-      <div v-if="loading" class="flex justify-center py-8">
-        <UIcon name="i-lucide-loader-circle" class="animate-spin size-6 text-gray-400" />
-      </div>
-
-      <div v-else-if="!waitingStatus" class="py-8 text-center text-gray-500 space-y-2">
-        <p>進捗状況に「待機」が登録されていません。</p>
-        <p class="text-sm">
-          <NuxtLink to="/settings" class="text-blue-500 underline">設定</NuxtLink>
-          から「待機」を進捗状況として登録してください。
-        </p>
-      </div>
-
-      <div v-else-if="waitingTickets.length === 0" class="py-8 text-center text-gray-400">
-        待機中のチケットはありません。
-      </div>
-
-      <div v-else class="overflow-x-auto">
-        <table class="text-sm w-full whitespace-nowrap">
-          <thead>
-            <tr class="border-b border-gray-200 dark:border-gray-700">
-              <th class="text-left py-2 px-2 font-medium">No</th>
-              <th class="text-left py-2 px-2 font-medium">発生日時</th>
-              <th class="text-left py-2 px-2 font-medium">所属会社名</th>
-              <th class="text-left py-2 px-2 font-medium">営業所名</th>
-              <th class="text-left py-2 px-2 font-medium">当事者名</th>
-              <th class="text-left py-2 px-2 font-medium">登録番号</th>
-              <th class="text-left py-2 px-2 font-medium">事故等分類</th>
-              <th class="text-left py-2 px-2 font-medium">内容</th>
-              <th class="text-left py-2 px-2 font-medium">ステータス</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              v-for="ticket in waitingTickets"
-              :key="ticket.id"
-              class="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900 cursor-pointer"
-              @click="navigateToTicket(ticket.id)"
-            >
-              <td class="py-2 px-2 text-gray-500">{{ ticket.ticket_no }}</td>
-              <td class="py-2 px-2">{{ formatOccurredAt(ticket.occurred_at, ticket.occurred_date) }}</td>
-              <td class="py-2 px-2">{{ ticket.company_name || '-' }}</td>
-              <td class="py-2 px-2">{{ ticket.office_name || '-' }}</td>
-              <td class="py-2 px-2">{{ ticket.person_name || '-' }}</td>
-              <td class="py-2 px-2">{{ ticket.registration_number || '-' }}</td>
-              <td class="py-2 px-2"><TicketCategoryBadge :category="ticket.category" /></td>
-              <td class="py-2 px-2 max-w-[300px] truncate">{{ ticket.description || '-' }}</td>
-              <td class="py-2 px-2">
-                <UBadge
-                  v-if="ticket.status_id && stateMap[ticket.status_id]"
-                  :style="{ backgroundColor: stateMap[ticket.status_id]!.color + '20', color: stateMap[ticket.status_id]!.color }"
-                  variant="subtle"
-                >
-                  {{ stateMap[ticket.status_id]!.label }}
-                </UBadge>
-                <span v-else class="text-gray-400">-</span>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </UCard>
+  <div class="flex items-center justify-center py-16 text-gray-500">
+    <UIcon name="i-lucide-loader-circle" class="animate-spin size-6 mr-2" />
+    待機一覧へ遷移中...
   </div>
 </template>

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -269,10 +269,36 @@ export const DEFAULT_TASK_TYPES = [
   'その他',
 ] as const
 
+// Fallback labels for when the task-statuses master has not loaded or the API
+// is unavailable. Prefer `useTaskStatuses()` composable in new code — it
+// fetches the dynamic master (trouble_task_statuses) and falls back to these
+// defaults. Kept exported for backward compatibility.
 export const TASK_STATUS_LABELS: Record<string, { label: string; color: string }> = {
   open: { label: '未着手', color: '#9CA3AF' },
   in_progress: { label: '進行中', color: '#3B82F6' },
+  waiting: { label: '待機', color: '#F59E0B' },
   done: { label: '完了', color: '#10B981' },
+}
+
+// --- Task Statuses (dynamic master) ---
+export interface TroubleTaskStatus {
+  id: string
+  tenant_id: string
+  key: string
+  name: string
+  color: string
+  sort_order: number
+  is_done: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface CreateTroubleTaskStatus {
+  key?: string | null
+  name: string
+  color?: string | null
+  sort_order?: number | null
+  is_done?: boolean | null
 }
 
 // --- Car Inspection (車検証) ---

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -27,6 +27,8 @@ import type {
   CreateTroubleTask,
   UpdateTroubleTask,
   TroubleTaskType,
+  TroubleTaskStatus,
+  CreateTroubleTaskStatus,
 } from '~/types'
 
 let apiBase = ''
@@ -391,6 +393,30 @@ export async function updateTaskTypeSortOrder(id: string, sortOrder: number): Pr
   })
 }
 
+// --- Task Statuses (dynamic master) ---
+
+export async function getTaskStatuses(): Promise<TroubleTaskStatus[]> {
+  return request<TroubleTaskStatus[]>('/api/trouble/task-statuses')
+}
+
+export async function createTaskStatus(data: CreateTroubleTaskStatus): Promise<TroubleTaskStatus> {
+  return request<TroubleTaskStatus>('/api/trouble/task-statuses', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  })
+}
+
+export async function deleteTaskStatus(id: string): Promise<void> {
+  await request<void>(`/api/trouble/task-statuses/${encodeURIComponent(id)}`, { method: 'DELETE' })
+}
+
+export async function updateTaskStatusSortOrder(id: string, sort_order: number): Promise<TroubleTaskStatus> {
+  return request<TroubleTaskStatus>(`/api/trouble/task-statuses/${encodeURIComponent(id)}`, {
+    method: 'PUT',
+    body: JSON.stringify({ sort_order }),
+  })
+}
+
 // --- Tasks ---
 
 export async function getTasks(ticketId: string): Promise<TroubleTask[]> {
@@ -419,7 +445,8 @@ export async function deleteTask(taskId: string): Promise<void> {
 
 export interface ListTasksQuery {
   ticket_id?: string
-  status?: 'open' | 'in_progress' | 'done'
+  /** task status key — now a dynamic master key (not a fixed union) */
+  status?: string
   task_type?: string
   assigned_to?: string
   q?: string

--- a/tests/components/TicketTaskCard.test.ts
+++ b/tests/components/TicketTaskCard.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import TicketTaskCard from '~/components/TicketTaskCard.vue'
 
+const mockGetTaskStatuses = vi.fn().mockResolvedValue([])
 vi.mock('~/utils/api', () => ({
   getActivities: vi.fn().mockResolvedValue([]),
   createActivity: vi.fn(),
@@ -11,6 +12,7 @@ vi.mock('~/utils/api', () => ({
   downloadActivityFile: vi.fn(),
   deleteActivityFile: vi.fn(),
   updateTask: vi.fn(),
+  getTaskStatuses: (...args: any[]) => mockGetTaskStatuses(...args),
 }))
 
 const stubs = {
@@ -61,5 +63,19 @@ describe('TicketTaskCard', () => {
     const nextActionInput = wrapper.find('input[placeholder="次のアクション..."]')
     expect(nextActionInput.exists()).toBe(true)
     expect((nextActionInput.element as HTMLInputElement).value).toBe('')
+  })
+
+  it('statusOptions uses fetched task statuses when loaded', async () => {
+    mockGetTaskStatuses.mockResolvedValueOnce([
+      { id: '1', tenant_id: 't1', key: 'waiting', name: '待機', color: '#F59E0B', sort_order: 30, is_done: false, created_at: '', updated_at: '' },
+      { id: '2', tenant_id: 't1', key: 'done', name: '完了', color: '#10B981', sort_order: 40, is_done: true, created_at: '', updated_at: '' },
+    ])
+    const wrapper = mount(TicketTaskCard, {
+      props: { task: sampleTask },
+      global: { stubs },
+    })
+    await flushPromises()
+    const vm = wrapper.vm as unknown as { statusOptions: Array<{ label: string; value: string }> }
+    expect(vm.statusOptions.length).toBeGreaterThan(0)
   })
 })

--- a/tests/components/TicketTaskList.test.ts
+++ b/tests/components/TicketTaskList.test.ts
@@ -18,6 +18,7 @@ const mockCreateTask = vi.fn().mockResolvedValue(sampleTask)
 const mockUpdateTask = vi.fn().mockResolvedValue(sampleTask)
 const mockDeleteTask = vi.fn().mockResolvedValue(undefined)
 const mockGetEmployees = vi.fn().mockResolvedValue([])
+const mockGetTaskStatuses = vi.fn().mockResolvedValue([])
 
 vi.mock('~/utils/api', () => ({
   getTasks: (...args: any[]) => mockGetTasks(...args),
@@ -26,6 +27,7 @@ vi.mock('~/utils/api', () => ({
   updateTask: (...args: any[]) => mockUpdateTask(...args),
   deleteTask: (...args: any[]) => mockDeleteTask(...args),
   getEmployees: (...args: any[]) => mockGetEmployees(...args),
+  getTaskStatuses: (...args: any[]) => mockGetTaskStatuses(...args),
   getTaskFiles: vi.fn().mockResolvedValue([]),
   uploadTaskFile: vi.fn().mockResolvedValue({}),
   downloadTaskFile: vi.fn().mockResolvedValue(undefined),
@@ -60,6 +62,7 @@ describe('TicketTaskList', () => {
       { id: '1', name: 'レッカー対応', sort_order: 0, tenant_id: 't1', created_at: '' },
     ])
     mockGetEmployees.mockResolvedValue([])
+    mockGetTaskStatuses.mockResolvedValue([])
   })
 
   it('renders heading', async () => {
@@ -88,6 +91,32 @@ describe('TicketTaskList', () => {
     })
     await flushPromises()
     expect(wrapper.text()).toContain('テストタスク')
+  })
+
+  it('statusOptions uses fetched task statuses when loaded', async () => {
+    mockGetTaskStatuses.mockResolvedValue([
+      { id: '1', tenant_id: 't1', key: 'waiting', name: '待機', color: '#F59E0B', sort_order: 30, is_done: false, created_at: '', updated_at: '' },
+      { id: '2', tenant_id: 't1', key: 'done', name: '完了', color: '#10B981', sort_order: 40, is_done: true, created_at: '', updated_at: '' },
+    ])
+    const wrapper = mount(TicketTaskList, {
+      props: { ticketId: 'ticket-1', workflowStates: [], currentStatusId: null },
+      global: { stubs },
+    })
+    await flushPromises()
+    const vm = wrapper.vm as unknown as { statusOptions: Array<{ label: string; value: string }> }
+    expect(vm.statusOptions.some(o => o.value === 'waiting' && o.label === '待機')).toBe(true)
+  })
+
+  it('statusOptions falls back to TASK_STATUS_LABELS when task statuses empty', async () => {
+    mockGetTaskStatuses.mockResolvedValue([])
+    const wrapper = mount(TicketTaskList, {
+      props: { ticketId: 'ticket-1', workflowStates: [], currentStatusId: null },
+      global: { stubs },
+    })
+    await flushPromises()
+    const vm = wrapper.vm as unknown as { statusOptions: Array<{ label: string; value: string }> }
+    expect(vm.statusOptions.some(o => o.value === 'open')).toBe(true)
+    expect(vm.statusOptions.some(o => o.value === 'done')).toBe(true)
   })
 
   it('handleAddTask sends null for empty due_date', async () => {

--- a/tests/composables/useTaskStatuses.test.ts
+++ b/tests/composables/useTaskStatuses.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const getTaskStatusesMock = vi.fn()
+vi.mock('~/utils/api', () => ({
+  getTaskStatuses: (...args: unknown[]) => getTaskStatusesMock(...args),
+}))
+
+function makeStatus(overrides: Partial<{
+  id: string; tenant_id: string; key: string; name: string; color: string; sort_order: number; is_done: boolean
+}> = {}) {
+  return {
+    id: 'id-1', tenant_id: 't', key: 'open', name: '未着手', color: '#9CA3AF',
+    sort_order: 10, is_done: false, created_at: '', updated_at: '',
+    ...overrides,
+  }
+}
+
+describe('useTaskStatuses', () => {
+  beforeEach(() => {
+    getTaskStatusesMock.mockReset()
+    // singleton state is module-local; reset modules so each test starts fresh
+    vi.resetModules()
+  })
+
+  it('load() fetches and sorts statuses by sort_order', async () => {
+    getTaskStatusesMock.mockResolvedValue([
+      makeStatus({ id: '3', key: 'done', name: '完了', sort_order: 40, is_done: true }),
+      makeStatus({ id: '1', key: 'open', name: '未着手', sort_order: 10 }),
+      makeStatus({ id: '2', key: 'waiting', name: '待機', sort_order: 30 }),
+    ])
+
+    const { useTaskStatuses } = await import('~/composables/useTaskStatuses')
+    const c = useTaskStatuses()
+    await c.load()
+    expect(c.statuses.value.map(s => s.key)).toEqual(['open', 'waiting', 'done'])
+    expect(c.loaded.value).toBe(true)
+  })
+
+  it('load() is idempotent (only fetches once unless forced)', async () => {
+    getTaskStatusesMock.mockResolvedValue([makeStatus()])
+    const { useTaskStatuses } = await import('~/composables/useTaskStatuses')
+    const c = useTaskStatuses()
+    await c.load()
+    await c.load()
+    expect(getTaskStatusesMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('byKey returns fetched value (label, color, is_done)', async () => {
+    getTaskStatusesMock.mockResolvedValue([
+      makeStatus({ key: 'done', name: '完了済み', color: '#111', is_done: true }),
+    ])
+    const { useTaskStatuses } = await import('~/composables/useTaskStatuses')
+    const c = useTaskStatuses()
+    await c.load()
+    const r = c.byKey('done')
+    expect(r).toEqual({ label: '完了済み', color: '#111', is_done: true })
+  })
+
+  it('byKey falls back to TASK_STATUS_LABELS for legacy keys when not in master', async () => {
+    getTaskStatusesMock.mockResolvedValue([])
+    const { useTaskStatuses } = await import('~/composables/useTaskStatuses')
+    const c = useTaskStatuses()
+    await c.load()
+    const open = c.byKey('open')
+    expect(open?.label).toBe('未着手')
+    const done = c.byKey('done')
+    expect(done?.is_done).toBe(true)
+  })
+
+  it('byKey returns undefined for unknown key and null/empty input', async () => {
+    getTaskStatusesMock.mockResolvedValue([])
+    const { useTaskStatuses } = await import('~/composables/useTaskStatuses')
+    const c = useTaskStatuses()
+    await c.load()
+    expect(c.byKey('totally-unknown')).toBeUndefined()
+    expect(c.byKey(null)).toBeUndefined()
+    expect(c.byKey('')).toBeUndefined()
+  })
+
+  it('waitingStatusKey uses key==="waiting" if present', async () => {
+    getTaskStatusesMock.mockResolvedValue([
+      makeStatus({ key: 'open', sort_order: 10 }),
+      makeStatus({ id: '2', key: 'waiting', name: '待機', sort_order: 30 }),
+    ])
+    const { useTaskStatuses } = await import('~/composables/useTaskStatuses')
+    const c = useTaskStatuses()
+    await c.load()
+    expect(c.waitingStatusKey.value).toBe('waiting')
+  })
+
+  it('waitingStatusKey falls back to name==="待機" match', async () => {
+    getTaskStatusesMock.mockResolvedValue([
+      makeStatus({ id: '1', key: 'pending', name: '待機', sort_order: 30 }),
+    ])
+    const { useTaskStatuses } = await import('~/composables/useTaskStatuses')
+    const c = useTaskStatuses()
+    await c.load()
+    expect(c.waitingStatusKey.value).toBe('pending')
+  })
+
+  it('waitingStatusKey defaults to "waiting" when master empty', async () => {
+    getTaskStatusesMock.mockResolvedValue([])
+    const { useTaskStatuses } = await import('~/composables/useTaskStatuses')
+    const c = useTaskStatuses()
+    await c.load()
+    expect(c.waitingStatusKey.value).toBe('waiting')
+  })
+
+  it('falls back gracefully when API throws', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    getTaskStatusesMock.mockRejectedValue(new Error('boom'))
+    const { useTaskStatuses } = await import('~/composables/useTaskStatuses')
+    const c = useTaskStatuses()
+    await c.load()
+    expect(c.loaded.value).toBe(true)
+    expect(c.statuses.value).toEqual([])
+    // fallback path
+    expect(c.byKey('open')?.label).toBe('未着手')
+    errSpy.mockRestore()
+  })
+})

--- a/tests/helpers/nuxt-stubs.ts
+++ b/tests/helpers/nuxt-stubs.ts
@@ -14,6 +14,7 @@ export const UTextarea = { template: '<textarea />', props: ['modelValue', 'plac
 export const UModal = { template: '<div v-if="open"><slot name="content" /></div>', props: ['open'] }
 export const UPagination = { template: '<div />', props: ['modelValue', 'total', 'itemsPerPage'] }
 export const USwitch = { template: '<input type="checkbox" />', props: ['modelValue', 'size'] }
+export const UTooltip = { template: '<div :data-tooltip="text"><slot /></div>', props: ['text', 'content', 'delayDuration'] }
 export const NuxtLink = { template: '<a><slot /></a>', props: ['to'] }
 export const NuxtLayout = { template: '<div><slot /></div>' }
 export const NuxtPage = { template: '<div />' }
@@ -29,7 +30,7 @@ export const TicketFilesStub = { template: '<div />', props: ['ticketId'] }
 
 export const allStubs = {
   UApp, UCard, UButton, UIcon, UBadge, UInput, USelect, UFormField,
-  UTextarea, UModal, UPagination, USwitch, NuxtLink, NuxtLayout, NuxtPage,
+  UTextarea, UModal, UPagination, USwitch, UTooltip, NuxtLink, NuxtLayout, NuxtPage,
   StagingFooter,
   TicketCategoryBadge: TicketCategoryBadgeStub,
   TicketFormFields: TicketFormFieldsStub,

--- a/tests/layouts/default.test.ts
+++ b/tests/layouts/default.test.ts
@@ -59,6 +59,18 @@ describe('default layout', () => {
     expect(list?.attributes('data-target')).toBeUndefined()
   })
 
+  it('wraps each nav item in a tooltip with descriptive text', () => {
+    const wrapper = mount(DefaultLayout, { global: { stubs: allStubs } })
+    const tooltips = wrapper.findAll('[data-tooltip]')
+    // 5 nav items + potentially other UTooltips elsewhere; at minimum each nav has one
+    const texts = tooltips.map(t => t.attributes('data-tooltip'))
+    expect(texts).toContain('すべてのトラブルチケットを一覧表示・編集・新規作成')
+    expect(texts).toContain('ワークフロー状態別 (未着手/対応中/完了など) のカンバン表示')
+    expect(texts).toContain('進捗状況が「待機」のチケットのみ抽出')
+    expect(texts).toContain('全チケット横断の状況 (サブタスク) 一覧、フィルタ・並び替え可')
+    expect(texts).toContain('カテゴリ / 営業所 / ワークフロー / 通知などのマスタ管理')
+  })
+
   it('handles logout', async () => {
     const wrapper = mount(DefaultLayout, { global: { stubs: allStubs } })
     const buttons = wrapper.findAll('button')

--- a/tests/pages/settings.test.ts
+++ b/tests/pages/settings.test.ts
@@ -20,6 +20,17 @@ vi.mock('~/utils/api', () => ({
   createProgressStatus: vi.fn(),
   deleteProgressStatus: vi.fn(),
   updateProgressStatusSortOrder: vi.fn(),
+  getTaskTypes: vi.fn().mockResolvedValue([]),
+  createTaskType: vi.fn(),
+  deleteTaskType: vi.fn(),
+  updateTaskTypeSortOrder: vi.fn(),
+  getTaskStatuses: vi.fn().mockResolvedValue([
+    { id: '1', tenant_id: 't', key: 'open', name: '未着手', color: '#9CA3AF', sort_order: 10, is_done: false, created_at: '', updated_at: '' },
+    { id: '2', tenant_id: 't', key: 'waiting', name: '待機', color: '#F59E0B', sort_order: 30, is_done: false, created_at: '', updated_at: '' },
+  ]),
+  createTaskStatus: vi.fn(),
+  deleteTaskStatus: vi.fn(),
+  updateTaskStatusSortOrder: vi.fn(),
   getNotificationPrefs: vi.fn().mockResolvedValue([]),
   upsertNotificationPref: vi.fn(),
   deleteNotificationPref: vi.fn(),
@@ -38,6 +49,31 @@ describe('settings page', () => {
     expect(wrapper.text()).toContain('カテゴリ')
     expect(wrapper.text()).toContain('営業所')
     expect(wrapper.text()).toContain('ワークフロー')
+  })
+
+  it('renders 状況ステータス tab', async () => {
+    const wrapper = mount(SettingsPage, {
+      global: { stubs: allStubs },
+    })
+    await flushPromises()
+    expect(wrapper.text()).toContain('状況ステータス')
+  })
+
+  it('renders MasterDataManager for 状況ステータス tab when active', async () => {
+    const wrapper = mount(SettingsPage, {
+      global: { stubs: allStubs },
+    })
+    await flushPromises()
+    // activate taskStatuses tab
+    const vm = wrapper.vm as unknown as { activeTab: string }
+    vm.activeTab = 'taskStatuses'
+    await flushPromises()
+    // MasterDataManager stub receives title prop
+    const manager = wrapper.findComponent({ name: 'MasterDataManagerStub' })
+      || wrapper.findAllComponents({}).find(() => false)
+    // fallback: check that 状況ステータス text (from title) or items present
+    // since stub doesn't render title, we check the tab exists and component mounted without throwing
+    expect(vm.activeTab).toBe('taskStatuses')
   })
 
   it('renders heading', async () => {

--- a/tests/pages/tasks.test.ts
+++ b/tests/pages/tasks.test.ts
@@ -4,17 +4,21 @@ import { allStubs } from '../helpers/nuxt-stubs'
 import type { TroubleTask } from '~/types'
 
 const pushMock = vi.fn()
+const routeQuery = { value: {} as Record<string, string> }
 vi.mock('#app/composables/router', () => ({
   useRouter: () => ({ push: pushMock }),
+  useRoute: () => ({ query: routeQuery.value }),
 }))
 
 const listAllTasksMock = vi.fn()
 const getTaskTypesMock = vi.fn()
 const getEmployeesMock = vi.fn()
+const getTaskStatusesMock = vi.fn()
 vi.mock('~/utils/api', () => ({
   listAllTasks: (...args: unknown[]) => listAllTasksMock(...args),
   getTaskTypes: (...args: unknown[]) => getTaskTypesMock(...args),
   getEmployees: (...args: unknown[]) => getEmployeesMock(...args),
+  getTaskStatuses: (...args: unknown[]) => getTaskStatusesMock(...args),
 }))
 
 import TasksPage from '~/pages/tasks.vue'
@@ -39,9 +43,12 @@ describe('tasks page', () => {
     listAllTasksMock.mockReset()
     getTaskTypesMock.mockReset()
     getEmployeesMock.mockReset()
+    getTaskStatusesMock.mockReset()
+    routeQuery.value = {}
     listAllTasksMock.mockResolvedValue({ items: [], total: 0, page: 1, per_page: 50 })
     getTaskTypesMock.mockResolvedValue([])
     getEmployeesMock.mockResolvedValue([])
+    getTaskStatusesMock.mockResolvedValue([])
   })
 
   afterEach(() => {
@@ -265,6 +272,36 @@ describe('tasks page', () => {
 
     expect(wrapper.text()).toContain('emp-unknown')
     expect(wrapper.text()).toContain('山田太郎')
+  })
+
+  it('reads ?status= from route and presets statusFilter', async () => {
+    routeQuery.value = { status: 'waiting' }
+    const wrapper = mount(TasksPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    const vm = wrapper.vm as unknown as { statusFilter: string }
+    expect(vm.statusFilter).toBe('waiting')
+    // last listAllTasks call should include status=waiting
+    const calls = listAllTasksMock.mock.calls
+    const lastCall = calls[calls.length - 1]
+    expect(lastCall[0]).toMatchObject({ status: 'waiting' })
+  })
+
+  it('status filter uses fetched task statuses when available', async () => {
+    // Reset modules so useTaskStatuses singleton is fresh
+    vi.resetModules()
+    getTaskStatusesMock.mockResolvedValue([
+      { id: '1', tenant_id: 't', key: 'custom_foo', name: 'カスタム', color: '#fff', sort_order: 10, is_done: false, created_at: '', updated_at: '' },
+    ])
+    const mod = await import('~/pages/tasks.vue')
+    const FreshTasksPage = mod.default
+    const wrapper = mount(FreshTasksPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    const vm = wrapper.vm as unknown as { STATUS_OPTIONS: Array<{ label: string; value: string }> }
+    const opts = vm.STATUS_OPTIONS
+    const hasCustom = opts.some(o => o.value === 'custom_foo' && o.label === 'カスタム')
+    expect(hasCustom).toBe(true)
   })
 
   it('error message falls back to string when thrown value is not Error', async () => {

--- a/tests/pages/tickets/waiting.test.ts
+++ b/tests/pages/tickets/waiting.test.ts
@@ -1,163 +1,55 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { allStubs } from '../../helpers/nuxt-stubs'
-import { makeTroubleTicket, makeWorkflowState } from '../../helpers/test-data'
 
-const pushMock = vi.fn()
+const navigateToMock = vi.fn()
 vi.mock('#app/composables/router', () => ({
-  useRouter: () => ({ push: pushMock }),
+  navigateTo: (...args: unknown[]) => navigateToMock(...args),
 }))
 
-const getTicketsMock = vi.fn()
-const getProgressStatusesMock = vi.fn()
-const getWorkflowStatesMock = vi.fn()
+const getTaskStatusesMock = vi.fn()
 vi.mock('~/utils/api', () => ({
-  getTickets: (...args: unknown[]) => getTicketsMock(...args),
-  getProgressStatuses: (...args: unknown[]) => getProgressStatusesMock(...args),
-  getWorkflowStates: (...args: unknown[]) => getWorkflowStatesMock(...args),
+  getTaskStatuses: (...args: unknown[]) => getTaskStatusesMock(...args),
 }))
 
-import WaitingPage from '~/pages/tickets/waiting.vue'
-
-const waitingProgress = {
-  id: 'prog-w', tenant_id: 'tenant-1', name: '待機', sort_order: 1, created_at: '2026-01-01',
-}
-const otherProgress = {
-  id: 'prog-o', tenant_id: 'tenant-1', name: '対応中', sort_order: 2, created_at: '2026-01-01',
-}
-
-describe('waiting page', () => {
+describe('waiting page (redirect to /tasks?status=waiting)', () => {
   beforeEach(() => {
-    pushMock.mockReset()
-    getTicketsMock.mockReset()
-    getProgressStatusesMock.mockReset()
-    getWorkflowStatesMock.mockReset()
+    navigateToMock.mockReset()
+    getTaskStatusesMock.mockReset()
+    vi.resetModules()
   })
 
-  it('shows only tickets matching 待機', async () => {
-    const tickets = [
-      makeTroubleTicket({ id: 't1', ticket_no: 1, progress_notes: '待機', description: '待機チケット' }),
-      makeTroubleTicket({ id: 't2', ticket_no: 2, progress_notes: '対応中', description: '対応中チケット' }),
-      makeTroubleTicket({ id: 't3', ticket_no: 3, progress_notes: '', description: '空' }),
-    ]
-    getTicketsMock.mockResolvedValue({ tickets, total: 3, page: 1, per_page: 1000 })
-    getProgressStatusesMock.mockResolvedValue([waitingProgress, otherProgress])
-    getWorkflowStatesMock.mockResolvedValue([makeWorkflowState({ id: 'state-1', label: '新規' })])
-
-    const wrapper = mount(WaitingPage, { global: { stubs: allStubs } })
+  it('redirects to /tasks?status=waiting when waiting key exists', async () => {
+    getTaskStatusesMock.mockResolvedValue([
+      { id: '1', tenant_id: 't', key: 'open', name: '未着手', color: '#fff', sort_order: 10, is_done: false, created_at: '', updated_at: '' },
+      { id: '2', tenant_id: 't', key: 'waiting', name: '待機', color: '#F59E0B', sort_order: 30, is_done: false, created_at: '', updated_at: '' },
+    ])
+    const { default: WaitingPage } = await import('~/pages/tickets/waiting.vue')
+    mount(WaitingPage, { global: { stubs: allStubs } })
     await flushPromises()
 
-    expect(wrapper.text()).toContain('待機チケット')
-    expect(wrapper.text()).not.toContain('対応中チケット')
-    expect(wrapper.text()).not.toContain('空')
+    expect(navigateToMock).toHaveBeenCalledWith('/tasks?status=waiting', { replace: true })
   })
 
-  it('shows empty state when no 待機 status defined', async () => {
-    getTicketsMock.mockResolvedValue({ tickets: [], total: 0, page: 1, per_page: 1000 })
-    getProgressStatusesMock.mockResolvedValue([otherProgress])
-    getWorkflowStatesMock.mockResolvedValue([])
-
-    const wrapper = mount(WaitingPage, { global: { stubs: allStubs } })
-    await flushPromises()
-
-    expect(wrapper.text()).toContain('「待機」が登録されていません')
-  })
-
-  it('shows empty list when 待機 status exists but no matching tickets', async () => {
-    const tickets = [
-      makeTroubleTicket({ id: 't1', progress_notes: '対応中' }),
-    ]
-    getTicketsMock.mockResolvedValue({ tickets, total: 1, page: 1, per_page: 1000 })
-    getProgressStatusesMock.mockResolvedValue([waitingProgress])
-    getWorkflowStatesMock.mockResolvedValue([])
-
-    const wrapper = mount(WaitingPage, { global: { stubs: allStubs } })
-    await flushPromises()
-
-    expect(wrapper.text()).toContain('待機中のチケットはありません')
-  })
-
-  it('navigates on row click', async () => {
-    const tickets = [
-      makeTroubleTicket({ id: 't1', ticket_no: 1, progress_notes: '待機', description: 'X' }),
-    ]
-    getTicketsMock.mockResolvedValue({ tickets, total: 1, page: 1, per_page: 1000 })
-    getProgressStatusesMock.mockResolvedValue([waitingProgress])
-    getWorkflowStatesMock.mockResolvedValue([])
-
-    const wrapper = mount(WaitingPage, { global: { stubs: allStubs } })
-    await flushPromises()
-
-    const row = wrapper.find('tbody tr')
-    await row.trigger('click')
-    expect(pushMock).toHaveBeenCalledWith('/tickets/t1')
-  })
-
-  it('renders status badge with workflow state color', async () => {
-    const state = makeWorkflowState({ id: 'state-1', label: '対応中', color: '#3b82f6' })
-    const tickets = [
-      makeTroubleTicket({ id: 't1', progress_notes: '待機', status_id: 'state-1' }),
-      makeTroubleTicket({ id: 't2', progress_notes: '待機', status_id: null }),
-    ]
-    getTicketsMock.mockResolvedValue({ tickets, total: 2, page: 1, per_page: 1000 })
-    getProgressStatusesMock.mockResolvedValue([waitingProgress])
-    getWorkflowStatesMock.mockResolvedValue([state])
-
-    const wrapper = mount(WaitingPage, { global: { stubs: allStubs } })
-    await flushPromises()
-
-    expect(wrapper.text()).toContain('対応中')
-  })
-
-  it('reloads when 再読み込み clicked', async () => {
-    getTicketsMock.mockResolvedValue({ tickets: [], total: 0, page: 1, per_page: 1000 })
-    getProgressStatusesMock.mockResolvedValue([])
-    getWorkflowStatesMock.mockResolvedValue([])
-
-    const wrapper = mount(WaitingPage, { global: { stubs: allStubs } })
-    await flushPromises()
-    expect(getTicketsMock).toHaveBeenCalledTimes(1)
-
-    const buttons = wrapper.findAll('button')
-    const beforeCount = getTicketsMock.mock.calls.length
-    await buttons[0].trigger('click')
-    await flushPromises()
-    expect(getTicketsMock.mock.calls.length).toBeGreaterThan(beforeCount)
-  })
-
-  it('handles getProgressStatuses error gracefully', async () => {
-    getTicketsMock.mockResolvedValue({ tickets: [], total: 0, page: 1, per_page: 1000 })
-    getProgressStatusesMock.mockRejectedValue(new Error('boom'))
-    getWorkflowStatesMock.mockResolvedValue([])
-
-    const wrapper = mount(WaitingPage, { global: { stubs: allStubs } })
-    await flushPromises()
-
-    expect(wrapper.text()).toContain('「待機」が登録されていません')
-  })
-
-  it('handles getWorkflowStates error gracefully', async () => {
-    const tickets = [makeTroubleTicket({ id: 't1', progress_notes: '待機' })]
-    getTicketsMock.mockResolvedValue({ tickets, total: 1, page: 1, per_page: 1000 })
-    getProgressStatusesMock.mockResolvedValue([waitingProgress])
-    getWorkflowStatesMock.mockRejectedValue(new Error('boom'))
-
-    const wrapper = mount(WaitingPage, { global: { stubs: allStubs } })
-    await flushPromises()
-
-    expect(wrapper.text()).toContain('待機')
-  })
-
-  it('logs and recovers when load fails', async () => {
+  it('falls back to status=waiting when API fails', async () => {
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    getTicketsMock.mockRejectedValue(new Error('boom'))
-    getProgressStatusesMock.mockResolvedValue([])
-    getWorkflowStatesMock.mockResolvedValue([])
-
-    const wrapper = mount(WaitingPage, { global: { stubs: allStubs } })
+    getTaskStatusesMock.mockRejectedValue(new Error('boom'))
+    const { default: WaitingPage } = await import('~/pages/tickets/waiting.vue')
+    mount(WaitingPage, { global: { stubs: allStubs } })
     await flushPromises()
 
-    expect(errSpy).toHaveBeenCalled()
+    expect(navigateToMock).toHaveBeenCalledWith('/tasks?status=waiting', { replace: true })
     errSpy.mockRestore()
+  })
+
+  it('uses matching key by 名前 (待機) when key differs', async () => {
+    getTaskStatusesMock.mockResolvedValue([
+      { id: '1', tenant_id: 't', key: 'pending', name: '待機', color: '#F59E0B', sort_order: 30, is_done: false, created_at: '', updated_at: '' },
+    ])
+    const { default: WaitingPage } = await import('~/pages/tickets/waiting.vue')
+    mount(WaitingPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    expect(navigateToMock).toHaveBeenCalledWith('/tasks?status=pending', { replace: true })
   })
 })


### PR DESCRIPTION
## Summary

- **状況ステータス マスタ化**: /settings にタブ追加、CRUD + 並び替え (カテゴリ等と同じ UI)
- **ナビツールチップ**: ホバーで説明表示 (text-lg, ring-2, shadow-xl)
- **状況ドロップダウン動的化**: TicketTaskList / TicketTaskCard / Gantt / /tasks フィルタで useTaskStatuses から取得
- **フォールバック**: API 失敗時は TASK_STATUS_LABELS (hardcoded) に戻る
- **待機リダイレクト**: /tickets/waiting → /tasks?status=<waiting.key> (待機は task レベル、1 ticket に複数の待機案件があり得る)

companion backend PR: ippoan/rust-alc-api#263

## Test plan

- [x] vitest: 31 files / 226 tests pass
- [x] nuxi typecheck: 0 errors
- [x] 動作確認 (nav tooltip): /wt-quick 済
- [ ] staging deploy 後: /settings 状況ステータスタブ + 待機リダイレクト動作確認