### PR TITLE
feat(tasks): inline status edit on /tasks (状況管理 + 待機一覧)

### DIFF
--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { TroubleTask, TroubleTaskType, Employee } from '~/types'
 import { TASK_STATUS_LABELS, DEFAULT_TASK_TYPES } from '~/types'
-import { listAllTasks, getTaskTypes, getEmployees } from '~/utils/api'
+import { listAllTasks, getTaskTypes, getEmployees, updateTask } from '~/utils/api'
 import type { ListTasksQuery } from '~/utils/api'
 import { useTaskStatuses } from '~/composables/useTaskStatuses'
 
@@ -42,6 +42,36 @@ const STATUS_OPTIONS = computed<{ label: string; value: string }[]>(() => {
     ...Object.entries(TASK_STATUS_LABELS).map(([key, v]) => ({ label: v.label, value: key })),
   ]
 })
+
+// Inline edit dropdown on each table row: no "すべて" option, only real statuses.
+const inlineStatusOptions = computed<{ label: string; value: string }[]>(() => {
+  if (taskStatusesLoaded.value && taskStatusList.value.length > 0) {
+    return taskStatusList.value.map(s => ({ label: s.name, value: s.key }))
+  }
+  return Object.entries(TASK_STATUS_LABELS).map(([key, v]) => ({ label: v.label, value: key }))
+})
+
+const statusSaving = ref<Record<string, boolean>>({})
+
+async function handleStatusChange(task: TroubleTask, newStatus: string) {
+  if (!newStatus || newStatus === task.status) return
+  statusSaving.value = { ...statusSaving.value, [task.id]: true }
+  const prev = task.status
+  // Optimistic update
+  task.status = newStatus
+  try {
+    const updated = await updateTask(task.id, { status: newStatus })
+    const idx = items.value.findIndex(t => t.id === task.id)
+    if (idx >= 0) items.value[idx] = updated
+  } catch (e) {
+    task.status = prev
+    errorMessage.value = e instanceof Error ? e.message : 'ステータス更新に失敗しました'
+  } finally {
+    const next = { ...statusSaving.value }
+    delete next[task.id]
+    statusSaving.value = next
+  }
+}
 
 const SORT_OPTIONS = [
   { label: '作成日', value: 'created_at' },
@@ -278,14 +308,15 @@ onMounted(async () => {
               <td class="py-2 px-2">{{ employeeName(task.next_action_by) }}</td>
               <td class="py-2 px-2">{{ formatYmd(task.next_action_due) }}</td>
               <td class="py-2 px-2">
-                <UBadge
-                  v-if="taskStatusByKey(task.status)"
-                  :style="{ backgroundColor: taskStatusByKey(task.status)!.color + '20', color: taskStatusByKey(task.status)!.color }"
-                  variant="subtle"
-                >
-                  {{ taskStatusByKey(task.status)!.label }}
-                </UBadge>
-                <span v-else class="text-gray-400">{{ task.status }}</span>
+                <USelect
+                  :model-value="task.status"
+                  :items="inlineStatusOptions"
+                  size="xs"
+                  class="min-w-[6rem]"
+                  :disabled="statusSaving[task.id]"
+                  data-testid="task-status-select"
+                  @update:model-value="(v: string) => handleStatusChange(task, v)"
+                />
               </td>
               <td class="py-2 px-2">{{ formatYmd(task.created_at) }}</td>
             </tr>

--- a/tests/pages/tasks.test.ts
+++ b/tests/pages/tasks.test.ts
@@ -14,11 +14,13 @@ const listAllTasksMock = vi.fn()
 const getTaskTypesMock = vi.fn()
 const getEmployeesMock = vi.fn()
 const getTaskStatusesMock = vi.fn()
+const updateTaskMock = vi.fn()
 vi.mock('~/utils/api', () => ({
   listAllTasks: (...args: unknown[]) => listAllTasksMock(...args),
   getTaskTypes: (...args: unknown[]) => getTaskTypesMock(...args),
   getEmployees: (...args: unknown[]) => getEmployeesMock(...args),
   getTaskStatuses: (...args: unknown[]) => getTaskStatusesMock(...args),
+  updateTask: (...args: unknown[]) => updateTaskMock(...args),
 }))
 
 import TasksPage from '~/pages/tasks.vue'
@@ -44,6 +46,7 @@ describe('tasks page', () => {
     getTaskTypesMock.mockReset()
     getEmployeesMock.mockReset()
     getTaskStatusesMock.mockReset()
+    updateTaskMock.mockReset()
     routeQuery.value = {}
     listAllTasksMock.mockResolvedValue({ items: [], total: 0, page: 1, per_page: 50 })
     getTaskTypesMock.mockResolvedValue([])
@@ -76,8 +79,9 @@ describe('tasks page', () => {
     expect(wrapper.text()).toContain('タスクA')
     expect(wrapper.text()).toContain('タスクB')
     expect(wrapper.text()).toContain('山田太郎')
-    expect(wrapper.text()).toContain('未着手')
-    expect(wrapper.text()).toContain('進行中')
+    // Status is rendered as an inline USelect per row; assert selects are present
+    const selects = wrapper.findAll('[data-testid="task-status-select"]')
+    expect(selects.length).toBe(2)
   })
 
   it('shows empty state when items is empty', async () => {
@@ -248,14 +252,16 @@ describe('tasks page', () => {
     expect(wrapper.text()).toContain('-')
   })
 
-  it('renders unknown status as-is (fallback branch)', async () => {
+  it('preserves unknown status value on the row for inline select', async () => {
     const tasks = [makeTask({ id: 'task-1', status: 'weird-status' })]
     listAllTasksMock.mockResolvedValue({ items: tasks, total: 1, page: 1, per_page: 50 })
 
     const wrapper = mount(TasksPage, { global: { stubs: allStubs } })
     await flushPromises()
 
-    expect(wrapper.text()).toContain('weird-status')
+    const vm = wrapper.vm as unknown as { items: Array<{ status: string }> }
+    expect(vm.items[0]!.status).toBe('weird-status')
+    expect(wrapper.find('[data-testid="task-status-select"]').exists()).toBe(true)
   })
 
   it('resolves employee name from id, falls back to id if unknown', async () => {
@@ -313,5 +319,71 @@ describe('tasks page', () => {
 
     expect(wrapper.text()).toContain('string error')
     errSpy.mockRestore()
+  })
+
+  it('inline status change calls updateTask and updates the row', async () => {
+    listAllTasksMock.mockResolvedValue({
+      items: [makeTask({ id: 'task-1', status: 'open' })],
+      total: 1,
+      page: 1,
+      per_page: 50,
+    })
+    updateTaskMock.mockImplementation((id: string, body: { status: string }) =>
+      Promise.resolve(makeTask({ id, status: body.status })),
+    )
+
+    const wrapper = mount(TasksPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    const vm = wrapper.vm as unknown as {
+      handleStatusChange: (t: { id: string; status: string }, v: string) => Promise<void>
+      items: Array<{ id: string; status: string }>
+    }
+    await vm.handleStatusChange(vm.items[0]!, 'in_progress')
+    await flushPromises()
+
+    expect(updateTaskMock).toHaveBeenCalledWith('task-1', { status: 'in_progress' })
+    expect(vm.items[0]!.status).toBe('in_progress')
+  })
+
+  it('inline status change reverts on API failure', async () => {
+    listAllTasksMock.mockResolvedValue({
+      items: [makeTask({ id: 'task-1', status: 'open' })],
+      total: 1,
+      page: 1,
+      per_page: 50,
+    })
+    updateTaskMock.mockRejectedValue(new Error('save failed'))
+
+    const wrapper = mount(TasksPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    const vm = wrapper.vm as unknown as {
+      handleStatusChange: (t: { id: string; status: string }, v: string) => Promise<void>
+      items: Array<{ id: string; status: string }>
+    }
+    await vm.handleStatusChange(vm.items[0]!, 'done')
+    await flushPromises()
+
+    expect(vm.items[0]!.status).toBe('open')
+    expect(wrapper.text()).toContain('save failed')
+  })
+
+  it('inline status change is a no-op when value is empty or unchanged', async () => {
+    listAllTasksMock.mockResolvedValue({
+      items: [makeTask({ id: 'task-1', status: 'open' })],
+      total: 1,
+      page: 1,
+      per_page: 50,
+    })
+    const wrapper = mount(TasksPage, { global: { stubs: allStubs } })
+    await flushPromises()
+    const vm = wrapper.vm as unknown as {
+      handleStatusChange: (t: { id: string; status: string }, v: string) => Promise<void>
+      items: Array<{ id: string; status: string }>
+    }
+    await vm.handleStatusChange(vm.items[0]!, '')
+    await vm.handleStatusChange(vm.items[0]!, 'open')
+    expect(updateTaskMock).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

- テーブル行のステータス列を UBadge 表示から USelect ドロップダウンに変更
- 変更時: optimistic update → `updateTask()` → 失敗時は元に戻してエラー表示
- 保存中は disabled で連打防止
- 待機一覧 (/tickets/waiting → /tasks?status=waiting) でも同じ挙動
- useTaskStatuses から動的に選択肢を生成 (マスタ未ロード時は TASK_STATUS_LABELS fallback)

## Test plan

- [x] vitest: 31 files / 229 tests pass (新規 3 テスト: 成功 / API失敗ロールバック / no-op ガード)
- [x] nuxi typecheck: 0 errors
- [x] 動作確認: /wt-quick でドロップダウン切替 → 状態反映 (ユーザー確認済)