### PR TITLE
feat(trouble): unify date inputs to YmdInput/YmdtInput with calendar popover

### DIFF
--- a/app/components/TicketFormFields.vue
+++ b/app/components/TicketFormFields.vue
@@ -105,10 +105,9 @@ function updateEmployee(employeeId: string) {
       </UFormField>
 
       <UFormField label="発生日時">
-        <UInput
-          type="datetime-local"
-          :model-value="(model.occurred_at as string) || ''"
-          @update:model-value="update('occurred_at', $event)"
+        <YmdtInput
+          :model-value="(model.occurred_at as string) || undefined"
+          @update:model-value="(v: string | undefined) => update('occurred_at', v ?? '')"
         />
       </UFormField>
     </fieldset>
@@ -318,10 +317,9 @@ function updateEmployee(employeeId: string) {
       </div>
 
       <UFormField label="対応期限">
-        <UInput
-          type="date"
-          :model-value="(model.due_date as string) || ''"
-          @update:model-value="update('due_date', $event ? new Date($event).toISOString() : null)"
+        <YmdInput
+          :model-value="((model.due_date as string) || '').slice(0, 10) || undefined"
+          @update:model-value="(v: string | undefined) => update('due_date', v ? new Date(v).toISOString() : null)"
         />
       </UFormField>
     </fieldset>

--- a/app/components/TicketTaskCard.vue
+++ b/app/components/TicketTaskCard.vue
@@ -138,11 +138,9 @@ async function saveDueDate() {
         @keydown.enter="($event.target as HTMLInputElement).blur()"
       />
       <span class="text-[10px] text-gray-400 shrink-0">期限</span>
-      <input
-        v-model="dueDateDraft"
-        type="date"
-        class="text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500 w-32"
-        @change="saveDueDate"
+      <YmdInput
+        :model-value="dueDateDraft || undefined"
+        @update:model-value="(v: string | undefined) => { dueDateDraft = v ?? ''; saveDueDate() }"
       />
     </div>
   </div>

--- a/app/components/TicketTaskList.vue
+++ b/app/components/TicketTaskList.vue
@@ -391,7 +391,12 @@ const FORM_GRID = 'grid-cols-[6rem_7rem_1fr_1fr_8rem_2.5rem]'
           <USelect v-if="isEditing(task.id, 'task_type')" :model-value="editingValue" :items="taskTypes" size="xs" class="min-w-0" @update:model-value="editingValue = $event; saveEdit(task.id, 'task_type')" />
           <span v-else class="inline-flex items-center text-[11px] px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-700/60 text-gray-600 dark:text-gray-300 truncate cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-600/60 transition-colors" @click="startEdit(task, 'task_type')">{{ task.task_type }}</span>
           <!-- occurred_at -->
-          <input v-if="isEditing(task.id, 'occurred_at')" v-model="editingValue" type="date" class="min-w-0 text-xs border border-blue-500 rounded px-1 py-0.5 bg-transparent" @blur="saveEdit(task.id, 'occurred_at')" />
+          <YmdInput
+            v-if="isEditing(task.id, 'occurred_at')"
+            :model-value="editingValue || undefined"
+            class="min-w-0"
+            @update:model-value="(v: string | undefined) => { editingValue = v ?? ''; saveEdit(task.id, 'occurred_at') }"
+          />
           <span v-else class="text-xs text-gray-400 truncate cursor-pointer hover:text-gray-200 transition-colors" @click="startEdit(task, 'occurred_at')">
             <span class="text-[10px] text-gray-500 inline-block w-8 mr-0.5 [text-align-last:justify]">発生:</span>{{ task.occurred_at?.substring(0, 10) || '-' }}
           </span>
@@ -426,7 +431,12 @@ const FORM_GRID = 'grid-cols-[6rem_7rem_1fr_1fr_8rem_2.5rem]'
           <span />
           <span />
           <!-- due_date (aligned under occurred_at) -->
-          <input v-if="isEditing(task.id, 'due_date')" v-model="editingValue" type="date" class="min-w-0 text-xs border border-blue-500 rounded px-1 py-0.5 bg-transparent" @blur="saveEdit(task.id, 'due_date')" />
+          <YmdInput
+            v-if="isEditing(task.id, 'due_date')"
+            :model-value="editingValue || undefined"
+            class="min-w-0"
+            @update:model-value="(v: string | undefined) => { editingValue = v ?? ''; saveEdit(task.id, 'due_date') }"
+          />
           <span v-else class="text-xs text-gray-400 truncate cursor-pointer hover:text-gray-200 transition-colors" @click="startEdit(task, 'due_date')">
             <span class="text-[10px] text-gray-500 inline-block w-8 mr-0.5 [text-align-last:justify]">期限:</span>{{ task.due_date?.substring(0, 10) || '-' }}
           </span>
@@ -477,7 +487,11 @@ const FORM_GRID = 'grid-cols-[6rem_7rem_1fr_1fr_8rem_2.5rem]'
           <USelect v-model="newTask.task_type" :items="taskTypes" size="xs" class="min-w-0" />
           <div class="flex items-center gap-1 min-w-0">
             <span class="text-[10px] text-gray-500 shrink-0">日時</span>
-            <input v-model="newTask.occurred_at" type="date" class="min-w-0 flex-1 text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" />
+            <YmdInput
+              :model-value="newTask.occurred_at || undefined"
+              class="min-w-0 flex-1"
+              @update:model-value="(v: string | undefined) => { newTask.occurred_at = v ?? '' }"
+            />
           </div>
           <input v-model="newTask.title" placeholder="タイトル" class="min-w-0 text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" @keydown.enter="handleAddTask" />
           <input v-model="newTask.description" placeholder="内容" class="min-w-0 text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" />
@@ -489,7 +503,11 @@ const FORM_GRID = 'grid-cols-[6rem_7rem_1fr_1fr_8rem_2.5rem]'
           <span />
           <div class="flex items-center gap-1 min-w-0">
             <span class="text-[10px] text-gray-500 shrink-0">期限</span>
-            <input v-model="newTask.due_date" type="date" class="min-w-0 flex-1 text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" />
+            <YmdInput
+              :model-value="newTask.due_date || undefined"
+              class="min-w-0 flex-1"
+              @update:model-value="(v: string | undefined) => { newTask.due_date = v ?? '' }"
+            />
           </div>
           <input v-model="newTask.next_action" placeholder="次のアクション" class="min-w-0 text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" />
           <input v-model="newTask.next_action_detail" placeholder="詳細" class="min-w-0 text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" />

--- a/app/components/YmdInput.vue
+++ b/app/components/YmdInput.vue
@@ -1,0 +1,253 @@
+<script setup lang="ts">
+import { CalendarDate } from '@internationalized/date'
+import { computed, nextTick, ref, watch } from 'vue'
+
+const props = defineProps<{
+  modelValue: string | undefined
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string | undefined): void
+}>()
+
+const year = ref('')
+const month = ref('')
+const day = ref('')
+
+const yearRef = ref<HTMLInputElement | null>(null)
+const monthRef = ref<HTMLInputElement | null>(null)
+const dayRef = ref<HTMLInputElement | null>(null)
+
+const popoverOpen = ref(false)
+
+let selfUpdate = false
+
+watch(
+  () => props.modelValue,
+  (v) => {
+    if (selfUpdate) {
+      selfUpdate = false
+      return
+    }
+    if (!v) {
+      year.value = ''
+      month.value = ''
+      day.value = ''
+      return
+    }
+    const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(v)
+    if (m) {
+      year.value = m[1]!
+      month.value = m[2]!
+      day.value = m[3]!
+    }
+  },
+  { immediate: true },
+)
+
+function emitModel() {
+  selfUpdate = true
+  if (year.value.length === 4 && month.value.length >= 1 && day.value.length >= 1) {
+    const mm = month.value.padStart(2, '0')
+    const dd = day.value.padStart(2, '0')
+    emit('update:modelValue', `${year.value}-${mm}-${dd}`)
+  }
+  else {
+    emit('update:modelValue', undefined)
+  }
+}
+
+function clearAll() {
+  year.value = ''
+  month.value = ''
+  day.value = ''
+  emitModel()
+  nextTick(() => yearRef.value?.focus())
+}
+
+function sanitize(s: string): string {
+  return s.replace(/\D/g, '')
+}
+
+function onYearInput(e: Event) {
+  const v = sanitize((e.target as HTMLInputElement).value).slice(0, 4)
+  year.value = v
+  if (v.length === 4) nextTick(() => monthRef.value?.focus())
+  emitModel()
+}
+
+function onMonthInput(e: Event) {
+  const v = sanitize((e.target as HTMLInputElement).value).slice(0, 2)
+  month.value = v
+  const advance = v.length === 2 || (v.length === 1 && Number(v) > 1)
+  if (advance) nextTick(() => dayRef.value?.focus())
+  emitModel()
+}
+
+function onDayInput(e: Event) {
+  const v = sanitize((e.target as HTMLInputElement).value).slice(0, 2)
+  day.value = v
+  emitModel()
+}
+
+type Ref = typeof year
+
+function bump(
+  r: Ref,
+  delta: number,
+  emptyDefault: number,
+  min: number,
+  max: number,
+  wrap: boolean,
+  pad: number,
+) {
+  let next: number
+  if (r.value === '') {
+    next = emptyDefault
+  }
+  else {
+    next = Number(r.value) + delta
+    if (wrap) {
+      if (next > max) next = min
+      else if (next < min) next = max
+    }
+    else {
+      if (next > max) next = max
+      else if (next < min) next = min
+    }
+  }
+  r.value = String(next).padStart(pad, '0')
+  emitModel()
+}
+
+function bumpYear(delta: number) {
+  const now = new Date().getFullYear()
+  bump(year, delta, now, 1900, 2100, false, 4)
+}
+function bumpMonth(delta: number) {
+  const now = new Date().getMonth() + 1
+  bump(month, delta, now, 1, 12, true, 2)
+}
+function bumpDay(delta: number) {
+  const now = new Date().getDate()
+  bump(day, delta, now, 1, 31, true, 2)
+}
+
+function onYearKeydown(e: KeyboardEvent) {
+  if (e.key === 'ArrowUp') { e.preventDefault(); bumpYear(1); return }
+  if (e.key === 'ArrowDown') { e.preventDefault(); bumpYear(-1); return }
+  if (e.key === 'ArrowRight') { e.preventDefault(); monthRef.value?.focus(); return }
+  if (e.key === '/' || e.key === '-' || e.key === '.') {
+    e.preventDefault()
+    monthRef.value?.focus()
+  }
+}
+
+function onMonthKeydown(e: KeyboardEvent) {
+  if (e.key === 'ArrowUp') { e.preventDefault(); bumpMonth(1); return }
+  if (e.key === 'ArrowDown') { e.preventDefault(); bumpMonth(-1); return }
+  if (e.key === 'ArrowLeft') { e.preventDefault(); yearRef.value?.focus(); return }
+  if (e.key === 'ArrowRight') { e.preventDefault(); dayRef.value?.focus(); return }
+  if (e.key === 'Backspace' && month.value === '') {
+    e.preventDefault()
+    yearRef.value?.focus()
+    return
+  }
+  if (e.key === '/' || e.key === '-' || e.key === '.') {
+    e.preventDefault()
+    dayRef.value?.focus()
+  }
+}
+
+function onDayKeydown(e: KeyboardEvent) {
+  if (e.key === 'ArrowUp') { e.preventDefault(); bumpDay(1); return }
+  if (e.key === 'ArrowDown') { e.preventDefault(); bumpDay(-1); return }
+  if (e.key === 'ArrowLeft') { e.preventDefault(); monthRef.value?.focus(); return }
+  if (e.key === 'Backspace' && day.value === '') {
+    e.preventDefault()
+    monthRef.value?.focus()
+  }
+}
+
+const calendarValue = computed<CalendarDate | undefined>(() => {
+  if (!props.modelValue) return undefined
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(props.modelValue)
+  if (!m) return undefined
+  return new CalendarDate(Number(m[1]), Number(m[2]), Number(m[3]))
+})
+
+function onCalendarSelect(v: CalendarDate | undefined) {
+  if (!v) {
+    emit('update:modelValue', undefined)
+  }
+  else {
+    const y = String(v.year)
+    const mm = String(v.month).padStart(2, '0')
+    const dd = String(v.day).padStart(2, '0')
+    emit('update:modelValue', `${y}-${mm}-${dd}`)
+  }
+  popoverOpen.value = false
+}
+</script>
+
+<template>
+  <div
+    class="inline-flex items-center gap-0.5 h-8 px-2 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded text-sm"
+  >
+    <input
+      ref="yearRef"
+      :value="year"
+      type="text"
+      inputmode="numeric"
+      maxlength="4"
+      placeholder="YYYY"
+      class="w-12 text-center outline-none bg-transparent"
+      @input="onYearInput"
+      @keydown="onYearKeydown"
+    >
+    <span class="text-gray-400">/</span>
+    <input
+      ref="monthRef"
+      :value="month"
+      type="text"
+      inputmode="numeric"
+      maxlength="2"
+      placeholder="MM"
+      class="w-6 text-center outline-none bg-transparent"
+      @input="onMonthInput"
+      @keydown="onMonthKeydown"
+    >
+    <span class="text-gray-400">/</span>
+    <input
+      ref="dayRef"
+      :value="day"
+      type="text"
+      inputmode="numeric"
+      maxlength="2"
+      placeholder="DD"
+      class="w-6 text-center outline-none bg-transparent"
+      @input="onDayInput"
+      @keydown="onDayKeydown"
+    >
+    <button
+      v-if="year || month || day"
+      type="button"
+      class="ml-1 p-0.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 cursor-pointer"
+      title="クリア"
+      @click="clearAll"
+    >
+      <UIcon name="i-lucide-x" class="size-3.5" />
+    </button>
+    <UPopover v-model:open="popoverOpen">
+      <button
+        type="button"
+        class="ml-1 p-0.5 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 cursor-pointer"
+      >
+        <UIcon name="i-lucide-calendar" class="size-4" />
+      </button>
+      <template #content>
+        <UCalendar :model-value="calendarValue" class="p-2" @update:model-value="onCalendarSelect" />
+      </template>
+    </UPopover>
+  </div>
+</template>

--- a/app/components/YmdInput.vue
+++ b/app/components/YmdInput.vue
@@ -176,16 +176,17 @@ const calendarValue = computed<CalendarDate | undefined>(() => {
   return new CalendarDate(Number(m[1]), Number(m[2]), Number(m[3]))
 })
 
-function onCalendarSelect(v: CalendarDate | undefined) {
-  if (!v) {
+function onCalendarSelect(v: unknown) {
+  if (!v || Array.isArray(v) || (typeof v === 'object' && v !== null && 'start' in v)) {
     emit('update:modelValue', undefined)
+    popoverOpen.value = false
+    return
   }
-  else {
-    const y = String(v.year)
-    const mm = String(v.month).padStart(2, '0')
-    const dd = String(v.day).padStart(2, '0')
-    emit('update:modelValue', `${y}-${mm}-${dd}`)
-  }
+  const d = v as CalendarDate
+  const y = String(d.year)
+  const mm = String(d.month).padStart(2, '0')
+  const dd = String(d.day).padStart(2, '0')
+  emit('update:modelValue', `${y}-${mm}-${dd}`)
   popoverOpen.value = false
 }
 </script>

--- a/app/components/YmdtInput.vue
+++ b/app/components/YmdtInput.vue
@@ -1,0 +1,401 @@
+<script setup lang="ts">
+import { CalendarDate } from '@internationalized/date'
+import { computed, nextTick, ref, watch } from 'vue'
+
+const props = defineProps<{
+  modelValue: string | undefined
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string | undefined): void
+}>()
+
+const year = ref('')
+const month = ref('')
+const day = ref('')
+const hour = ref('')
+const minute = ref('')
+
+const yearRef = ref<HTMLInputElement | null>(null)
+const monthRef = ref<HTMLInputElement | null>(null)
+const dayRef = ref<HTMLInputElement | null>(null)
+const hourRef = ref<HTMLInputElement | null>(null)
+const minuteRef = ref<HTMLInputElement | null>(null)
+
+const popoverOpen = ref(false)
+
+let selfUpdate = false
+
+watch(
+  () => props.modelValue,
+  (v) => {
+    if (selfUpdate) {
+      selfUpdate = false
+      return
+    }
+    if (!v) {
+      year.value = ''
+      month.value = ''
+      day.value = ''
+      hour.value = ''
+      minute.value = ''
+      return
+    }
+    const m = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})/.exec(v)
+    if (m) {
+      year.value = m[1]!
+      month.value = m[2]!
+      day.value = m[3]!
+      hour.value = m[4]!
+      minute.value = m[5]!
+    }
+  },
+  { immediate: true },
+)
+
+function emitModel() {
+  selfUpdate = true
+  const yOk = year.value.length === 4
+  const mOk = month.value.length >= 1
+  const dOk = day.value.length >= 1
+  const hOk = hour.value.length >= 1
+  const minOk = minute.value.length >= 1
+  if (yOk && mOk && dOk && hOk && minOk) {
+    const mm = month.value.padStart(2, '0')
+    const dd = day.value.padStart(2, '0')
+    const hh = hour.value.padStart(2, '0')
+    const mi = minute.value.padStart(2, '0')
+    emit('update:modelValue', `${year.value}-${mm}-${dd}T${hh}:${mi}`)
+  }
+  else {
+    emit('update:modelValue', undefined)
+  }
+}
+
+function clearAll() {
+  year.value = ''
+  month.value = ''
+  day.value = ''
+  hour.value = ''
+  minute.value = ''
+  emitModel()
+  nextTick(() => yearRef.value?.focus())
+}
+
+function sanitize(s: string): string {
+  return s.replace(/\D/g, '')
+}
+
+function onYearInput(e: Event) {
+  const v = sanitize((e.target as HTMLInputElement).value).slice(0, 4)
+  year.value = v
+  if (v.length === 4) nextTick(() => monthRef.value?.focus())
+  emitModel()
+}
+
+function onMonthInput(e: Event) {
+  const v = sanitize((e.target as HTMLInputElement).value).slice(0, 2)
+  month.value = v
+  const advance = v.length === 2 || (v.length === 1 && Number(v) > 1)
+  if (advance) nextTick(() => dayRef.value?.focus())
+  emitModel()
+}
+
+function onDayInput(e: Event) {
+  const v = sanitize((e.target as HTMLInputElement).value).slice(0, 2)
+  day.value = v
+  const advance = v.length === 2 || (v.length === 1 && Number(v) > 3)
+  if (advance) nextTick(() => hourRef.value?.focus())
+  emitModel()
+}
+
+function onHourInput(e: Event) {
+  const v = sanitize((e.target as HTMLInputElement).value).slice(0, 2)
+  hour.value = v
+  const advance = v.length === 2 || (v.length === 1 && Number(v) > 2)
+  if (advance) nextTick(() => minuteRef.value?.focus())
+  emitModel()
+}
+
+function onMinuteInput(e: Event) {
+  const v = sanitize((e.target as HTMLInputElement).value).slice(0, 2)
+  minute.value = v
+  emitModel()
+}
+
+function fillNow() {
+  const d = new Date()
+  year.value = String(d.getFullYear())
+  month.value = String(d.getMonth() + 1).padStart(2, '0')
+  day.value = String(d.getDate()).padStart(2, '0')
+  hour.value = String(d.getHours()).padStart(2, '0')
+  minute.value = String(d.getMinutes()).padStart(2, '0')
+  emitModel()
+}
+
+type RefStr = typeof year
+
+function bump(
+  r: RefStr,
+  delta: number,
+  emptyDefault: number,
+  min: number,
+  max: number,
+  wrap: boolean,
+  pad: number,
+) {
+  let next: number
+  if (r.value === '') {
+    next = emptyDefault
+  }
+  else {
+    next = Number(r.value) + delta
+    if (wrap) {
+      if (next > max) next = min
+      else if (next < min) next = max
+    }
+    else {
+      if (next > max) next = max
+      else if (next < min) next = min
+    }
+  }
+  r.value = String(next).padStart(pad, '0')
+  emitModel()
+}
+
+function bumpYear(delta: number) {
+  bump(year, delta, new Date().getFullYear(), 1900, 2100, false, 4)
+}
+function bumpMonth(delta: number) {
+  bump(month, delta, new Date().getMonth() + 1, 1, 12, true, 2)
+}
+function bumpDay(delta: number) {
+  bump(day, delta, new Date().getDate(), 1, 31, true, 2)
+}
+function bumpHour(delta: number) {
+  bump(hour, delta, new Date().getHours(), 0, 23, true, 2)
+}
+function bumpMinute(delta: number) {
+  bump(minute, delta, new Date().getMinutes(), 0, 59, true, 2)
+}
+
+function handleArrow(e: KeyboardEvent, bumpFn: (d: number) => void): boolean {
+  if (e.key === 'ArrowUp') { e.preventDefault(); bumpFn(1); return true }
+  if (e.key === 'ArrowDown') { e.preventDefault(); bumpFn(-1); return true }
+  return false
+}
+
+function onYearKeydown(e: KeyboardEvent) {
+  if (handleArrow(e, bumpYear)) return
+  if (e.key === 'ArrowRight') { e.preventDefault(); monthRef.value?.focus(); return }
+  if (e.key === '/' || e.key === '-' || e.key === '.') {
+    e.preventDefault()
+    monthRef.value?.focus()
+  }
+}
+
+function onMonthKeydown(e: KeyboardEvent) {
+  if (handleArrow(e, bumpMonth)) return
+  if (e.key === 'ArrowLeft') { e.preventDefault(); yearRef.value?.focus(); return }
+  if (e.key === 'ArrowRight') { e.preventDefault(); dayRef.value?.focus(); return }
+  if (e.key === 'Backspace' && month.value === '') {
+    e.preventDefault()
+    yearRef.value?.focus()
+    return
+  }
+  if (e.key === '/' || e.key === '-' || e.key === '.') {
+    e.preventDefault()
+    dayRef.value?.focus()
+  }
+}
+
+function onDayKeydown(e: KeyboardEvent) {
+  if (handleArrow(e, bumpDay)) return
+  if (e.key === 'ArrowLeft') { e.preventDefault(); monthRef.value?.focus(); return }
+  if (e.key === 'ArrowRight') { e.preventDefault(); hourRef.value?.focus(); return }
+  if (e.key === 'Backspace' && day.value === '') {
+    e.preventDefault()
+    monthRef.value?.focus()
+    return
+  }
+  if ([' ', 'T', 't', '/', '-', '.'].includes(e.key)) {
+    e.preventDefault()
+    hourRef.value?.focus()
+  }
+}
+
+function onHourKeydown(e: KeyboardEvent) {
+  if (handleArrow(e, bumpHour)) return
+  if (e.key === 'ArrowLeft') { e.preventDefault(); dayRef.value?.focus(); return }
+  if (e.key === 'ArrowRight') { e.preventDefault(); minuteRef.value?.focus(); return }
+  if (e.key === 'Backspace' && hour.value === '') {
+    e.preventDefault()
+    dayRef.value?.focus()
+    return
+  }
+  if (e.key === ':') {
+    e.preventDefault()
+    minuteRef.value?.focus()
+  }
+}
+
+function onMinuteKeydown(e: KeyboardEvent) {
+  if (handleArrow(e, bumpMinute)) return
+  if (e.key === 'ArrowLeft') { e.preventDefault(); hourRef.value?.focus(); return }
+  if (e.key === 'Backspace' && minute.value === '') {
+    e.preventDefault()
+    hourRef.value?.focus()
+  }
+}
+
+const calendarValue = computed<CalendarDate | undefined>(() => {
+  if (!props.modelValue) return undefined
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(props.modelValue)
+  if (!m) return undefined
+  return new CalendarDate(Number(m[1]), Number(m[2]), Number(m[3]))
+})
+
+function onCalendarSelect(v: CalendarDate | undefined) {
+  if (!v) {
+    year.value = ''
+    month.value = ''
+    day.value = ''
+    emitModel()
+    return
+  }
+  year.value = String(v.year)
+  month.value = String(v.month).padStart(2, '0')
+  day.value = String(v.day).padStart(2, '0')
+  if (!hour.value) hour.value = '00'
+  if (!minute.value) minute.value = '00'
+  emitModel()
+}
+
+const HOURS = Array.from({ length: 24 }, (_, i) => String(i).padStart(2, '0'))
+const MINUTES = Array.from({ length: 60 }, (_, i) => String(i).padStart(2, '0'))
+
+function onHourPick(e: Event) {
+  hour.value = (e.target as HTMLSelectElement).value
+  if (!minute.value) minute.value = '00'
+  emitModel()
+}
+
+function onMinutePick(e: Event) {
+  minute.value = (e.target as HTMLSelectElement).value
+  if (!hour.value) hour.value = '00'
+  emitModel()
+}
+
+function setNowAndClose() {
+  fillNow()
+  popoverOpen.value = false
+}
+</script>
+
+<template>
+  <div
+    class="inline-flex items-center gap-0.5 h-8 px-2 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded text-sm"
+  >
+    <input
+      ref="yearRef"
+      :value="year"
+      type="text"
+      inputmode="numeric"
+      maxlength="4"
+      placeholder="YYYY"
+      class="w-12 text-center outline-none bg-transparent"
+      @input="onYearInput"
+      @keydown="onYearKeydown"
+    >
+    <span class="text-gray-400">/</span>
+    <input
+      ref="monthRef"
+      :value="month"
+      type="text"
+      inputmode="numeric"
+      maxlength="2"
+      placeholder="MM"
+      class="w-6 text-center outline-none bg-transparent"
+      @input="onMonthInput"
+      @keydown="onMonthKeydown"
+    >
+    <span class="text-gray-400">/</span>
+    <input
+      ref="dayRef"
+      :value="day"
+      type="text"
+      inputmode="numeric"
+      maxlength="2"
+      placeholder="DD"
+      class="w-6 text-center outline-none bg-transparent"
+      @input="onDayInput"
+      @keydown="onDayKeydown"
+    >
+    <span class="mx-1 text-gray-300">|</span>
+    <input
+      ref="hourRef"
+      :value="hour"
+      type="text"
+      inputmode="numeric"
+      maxlength="2"
+      placeholder="HH"
+      class="w-6 text-center outline-none bg-transparent"
+      @input="onHourInput"
+      @keydown="onHourKeydown"
+    >
+    <span class="text-gray-400">:</span>
+    <input
+      ref="minuteRef"
+      :value="minute"
+      type="text"
+      inputmode="numeric"
+      maxlength="2"
+      placeholder="MM"
+      class="w-6 text-center outline-none bg-transparent"
+      @input="onMinuteInput"
+      @keydown="onMinuteKeydown"
+    >
+    <button
+      v-if="year || month || day || hour || minute"
+      type="button"
+      class="ml-1 p-0.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 cursor-pointer"
+      title="クリア"
+      @click="clearAll"
+    >
+      <UIcon name="i-lucide-x" class="size-3.5" />
+    </button>
+    <UPopover v-model:open="popoverOpen">
+      <button
+        type="button"
+        class="ml-1 p-0.5 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 cursor-pointer"
+      >
+        <UIcon name="i-lucide-calendar" class="size-4" />
+      </button>
+      <template #content>
+        <div class="flex flex-col">
+          <UCalendar :model-value="calendarValue" class="p-2" @update:model-value="onCalendarSelect" />
+          <div class="flex items-center gap-2 p-2 border-t border-gray-200 dark:border-gray-700 text-sm">
+            <select
+              :value="hour || '00'"
+              class="border border-gray-300 dark:border-gray-700 rounded px-2 py-1 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm outline-none [color-scheme:light] dark:[color-scheme:dark]"
+              @change="onHourPick"
+            >
+              <option v-for="h in HOURS" :key="h" :value="h">{{ h }}</option>
+            </select>
+            <span class="text-gray-400">:</span>
+            <select
+              :value="minute || '00'"
+              class="border border-gray-300 dark:border-gray-700 rounded px-2 py-1 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm outline-none [color-scheme:light] dark:[color-scheme:dark]"
+              @change="onMinutePick"
+            >
+              <option v-for="m in MINUTES" :key="m" :value="m">{{ m }}</option>
+            </select>
+            <div class="flex-1" />
+            <UButton size="xs" variant="outline" label="今" @click="setNowAndClose" />
+            <UButton size="xs" variant="ghost" label="閉じる" @click="popoverOpen = false" />
+          </div>
+        </div>
+      </template>
+    </UPopover>
+  </div>
+</template>

--- a/app/components/YmdtInput.vue
+++ b/app/components/YmdtInput.vue
@@ -255,17 +255,18 @@ const calendarValue = computed<CalendarDate | undefined>(() => {
   return new CalendarDate(Number(m[1]), Number(m[2]), Number(m[3]))
 })
 
-function onCalendarSelect(v: CalendarDate | undefined) {
-  if (!v) {
+function onCalendarSelect(v: unknown) {
+  if (!v || Array.isArray(v) || (typeof v === 'object' && v !== null && 'start' in v)) {
     year.value = ''
     month.value = ''
     day.value = ''
     emitModel()
     return
   }
-  year.value = String(v.year)
-  month.value = String(v.month).padStart(2, '0')
-  day.value = String(v.day).padStart(2, '0')
+  const d = v as CalendarDate
+  year.value = String(d.year)
+  month.value = String(d.month).padStart(2, '0')
+  day.value = String(d.day).padStart(2, '0')
   if (!hour.value) hour.value = '00'
   if (!minute.value) minute.value = '00'
   emitModel()

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -224,16 +224,28 @@ onMounted(async () => {
           <UInput v-model="qFilter" placeholder="キーワード" size="sm" />
         </UFormField>
         <UFormField label="期限 (から)">
-          <UInput v-model="dueFrom" type="date" size="sm" />
+          <YmdInput
+            :model-value="dueFrom || undefined"
+            @update:model-value="(v: string | undefined) => { dueFrom = v ?? '' }"
+          />
         </UFormField>
         <UFormField label="期限 (まで)">
-          <UInput v-model="dueTo" type="date" size="sm" />
+          <YmdInput
+            :model-value="dueTo || undefined"
+            @update:model-value="(v: string | undefined) => { dueTo = v ?? '' }"
+          />
         </UFormField>
         <UFormField label="発生日 (から)">
-          <UInput v-model="occurredFrom" type="date" size="sm" />
+          <YmdInput
+            :model-value="occurredFrom || undefined"
+            @update:model-value="(v: string | undefined) => { occurredFrom = v ?? '' }"
+          />
         </UFormField>
         <UFormField label="発生日 (まで)">
-          <UInput v-model="occurredTo" type="date" size="sm" />
+          <YmdInput
+            :model-value="occurredTo || undefined"
+            @update:model-value="(v: string | undefined) => { occurredTo = v ?? '' }"
+          />
         </UFormField>
         <UFormField label="並び">
           <div class="flex gap-2">

--- a/app/pages/tickets/[id].vue
+++ b/app/pages/tickets/[id].vue
@@ -286,9 +286,9 @@ onMounted(() => {
           <h3 class="text-lg font-bold">通知を予約</h3>
 
           <UFormField label="通知日時">
-            <UInput
-              v-model="scheduleForm.scheduled_at"
-              type="datetime-local"
+            <YmdtInput
+              :model-value="scheduleForm.scheduled_at || undefined"
+              @update:model-value="(v: string | undefined) => { scheduleForm.scheduled_at = v ?? '' }"
             />
           </UFormField>
 

--- a/app/pages/tickets/index.vue
+++ b/app/pages/tickets/index.vue
@@ -93,9 +93,9 @@ watch(() => ({ ...filter }), () => { fetchTickets() }, { deep: true })
       <UInput v-model="filter.person_name" placeholder="氏名" size="sm" class="w-24" />
       <UInput v-model="filter.company_name" placeholder="会社名" size="sm" class="w-28" />
       <USelect v-model="filter.office_name" :items="officeOptions" placeholder="営業所(全て)" size="sm" class="w-28" :disabled="officeOptions.length === 0" />
-      <UInput v-model="filter.date_from" type="date" size="sm" class="w-36" />
+      <YmdInput v-model="filter.date_from" />
       <span class="text-gray-400 text-xs">〜</span>
-      <UInput v-model="filter.date_to" type="date" size="sm" class="w-36" />
+      <YmdInput v-model="filter.date_to" />
       <UButton label="クリア" variant="ghost" size="xs" @click="clearFilter" />
     </div>
 
@@ -145,7 +145,11 @@ watch(() => ({ ...filter }), () => { fetchTickets() }, { deep: true })
     <div v-else class="overflow-x-auto p-3 rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50/50 dark:bg-blue-950/30">
       <div class="flex items-end gap-2 whitespace-nowrap min-w-[1600px]">
         <USelect v-model="newTicket.category" :items="createCategoryOptions" placeholder="カテゴリ" size="sm" class="w-28" />
-        <UInput v-model="newTicket.occurred_at" type="datetime-local" size="sm" class="w-44" />
+        <YmdtInput
+          :model-value="newTicket.occurred_at || undefined"
+          class="w-72"
+          @update:model-value="(v: string | undefined) => { newTicket.occurred_at = v ?? '' }"
+        />
         <UInput v-model="newTicket.company_name" placeholder="会社名" size="sm" class="w-24" />
         <USelect v-model="newTicket.office_name" :items="officeOptions" placeholder="営業所" size="sm" class="w-24" :disabled="officeOptions.length === 0" />
         <UInput v-model="newTicket.department" placeholder="運行課" size="sm" class="w-20" />
@@ -309,3 +313,4 @@ watch(() => ({ ...filter }), () => { fetchTickets() }, { deep: true })
     </UModal>
   </div>
 </template>
+

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -17,7 +17,7 @@ export default defineNuxtConfig({
 
   vite: {
     server: {
-      allowedHosts: ['nuxt-trouble.dev.ippoan.org'],
+      allowedHosts: ['nuxt-trouble.dev.ippoan.org', '.trycloudflare.com'],
     },
     optimizeDeps: {
       // @ippoan/auth-client は .ts ソースで公開されており Vite の dep pre-bundle で

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
+        "@internationalized/date": "^3.12.1",
         "@ippoan/auth-client": "0.1.65-dev.9bf0838",
         "@nuxt/ui": "^4.5.1",
         "@nuxtjs/tailwindcss": "^6.14.0",
@@ -1602,7 +1603,9 @@
       }
     },
     "node_modules/@internationalized/date": {
-      "version": "3.12.0",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
+      "integrity": "sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@internationalized/date": "^3.12.1",
     "@ippoan/auth-client": "0.1.65-dev.9bf0838",
     "@nuxt/ui": "^4.5.1",
     "@nuxtjs/tailwindcss": "^6.14.0",

--- a/tests/components/TicketFormFields.test.ts
+++ b/tests/components/TicketFormFields.test.ts
@@ -7,6 +7,8 @@ const stubs = {
   USelect: { template: '<select />', props: ['modelValue', 'items', 'placeholder'] },
   UInput: { template: '<input />', props: ['modelValue', 'placeholder', 'type'] },
   UTextarea: { template: '<textarea />', props: ['modelValue', 'placeholder', 'rows'] },
+  YmdInput: { template: '<input />', props: ['modelValue'] },
+  YmdtInput: { template: '<input />', props: ['modelValue'] },
 }
 
 describe('TicketFormFields', () => {

--- a/tests/components/TicketTaskCard.test.ts
+++ b/tests/components/TicketTaskCard.test.ts
@@ -25,6 +25,7 @@ const stubs = {
     template: '<select><option v-for="item in items" :key="item.value" :value="item.value">{{ item.label }}</option></select>',
     props: ['modelValue', 'items', 'size'],
   },
+  YmdInput: { template: '<input />', props: ['modelValue'] },
 }
 
 const sampleTask = {

--- a/tests/components/TicketTaskList.test.ts
+++ b/tests/components/TicketTaskList.test.ts
@@ -52,6 +52,11 @@ const stubs = {
   UFormField: { template: '<div><slot /></div>', props: ['label'] },
   UModal: { template: '<div v-if="open"><slot name="content" /></div>', props: ['open'] },
   TicketTaskCard: { template: '<div class="task-card">{{ task.title }}</div>', props: ['task'] },
+  YmdInput: {
+    template: '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value || undefined)" />',
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+  },
 }
 
 describe('TicketTaskList', () => {

--- a/tests/helpers/nuxt-stubs.ts
+++ b/tests/helpers/nuxt-stubs.ts
@@ -27,6 +27,16 @@ export const TicketCommentsStub = { template: '<div />', props: ['ticketId'] }
 export const TicketStatusHistoryStub = { template: '<div />', props: ['ticketId', 'workflowStates'] }
 export const TicketStatusTransitionStub = { template: '<div />', props: ['ticketId', 'currentStatusId', 'workflowStates'] }
 export const TicketFilesStub = { template: '<div />', props: ['ticketId'] }
+export const YmdInputStub = {
+  template: '<input data-ymd-input :value="modelValue || \'\'" @input="$emit(\'update:modelValue\', $event.target.value || undefined)" />',
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
+}
+export const YmdtInputStub = {
+  template: '<input data-ymdt-input :value="modelValue || \'\'" @input="$emit(\'update:modelValue\', $event.target.value || undefined)" />',
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
+}
 
 export const allStubs = {
   UApp, UCard, UButton, UIcon, UBadge, UInput, USelect, UFormField,
@@ -40,4 +50,6 @@ export const allStubs = {
   TicketStatusHistory: TicketStatusHistoryStub,
   TicketStatusTransition: TicketStatusTransitionStub,
   TicketFiles: TicketFilesStub,
+  YmdInput: YmdInputStub,
+  YmdtInput: YmdtInputStub,
 }


### PR DESCRIPTION
チケット一覧の日付フィルタを始め、プロジェクト全体の 13 箇所の type=date/datetime-local を自作の YmdInput / YmdtInput コンポーネントに統一。

## UX 改善

- 年/月/日/時/分 を個別の input に分割、桁数 or 範囲超過で次フィールドに自動 focus
- \`/\` \`-\` \`.\` \`:\` \`T\` スペース で次フィールドに移動
- ArrowUp / ArrowDown で +1 / -1 (空フィールドなら現在値を入れる)
- ArrowLeft / ArrowRight でフィールド間を移動
- Backspace で空フィールドから前のフィールドに戻る
- Backspace で year を空にしても month/day が保持される (selfUpdate guard で watcher 循環を阻止)
- X ボタンで全フィールドクリア (いずれかのフィールドに値がある時のみ表示)
- カレンダーアイコン → UPopover + UCalendar で日付選択
- YmdtInput の popover 内に時/分の select + 「今」ボタン
- Dark mode 対応 (select に color-scheme: dark)

## 置換箇所 (13 箇所)

- tickets/index.vue: 期間フィルタ 2 + 新規チケットの発生日時 1
- tickets/[id].vue: 通知予約 scheduled_at
- TicketFormFields.vue: 発生日時 + 対応期限
- TicketTaskCard.vue: 期限編集
- TicketTaskList.vue: inline 編集 (occurred_at/due_date) + 新規タスク入力
- tasks.vue: 4 フィルタ

## その他

- 依存追加: @internationalized/date (UCalendar の CalendarDate 構築用)
- nuxt.config.ts の allowedHosts に .trycloudflare.com 追加 (wt-quick 用)
- テストヘルパーに YmdInput / YmdtInput スタブ追加
- 全 229 テスト pass