### PR TITLE
feat(layout): replace sidebar logout block with AuthToolbar (Apps button)

### DIFF
--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -1,2 +1,2 @@
-export { useAuth } from '@ippoan/auth-client'
+export { useAuth, AuthToolbar } from '@ippoan/auth-client'
 export type { AuthState } from '@ippoan/auth-client'

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-const { username, clearAuth } = useAuth()
+import { AuthToolbar } from '~/composables/useAuth'
+
 const route = useRoute()
 const _darkMode = ref(false)
 let _colorMode: { value: string; preference: string } | null = null
@@ -52,10 +53,6 @@ const navigation: { label: string; icon: string; to: string; target?: string; de
   },
 ]
 
-function handleLogout() {
-  clearAuth()
-  navigateTo('/login')
-}
 </script>
 
 <template>
@@ -91,22 +88,18 @@ function handleLogout() {
         </UTooltip>
       </nav>
 
-      <!-- Dark mode toggle + User -->
-      <div class="p-4 border-t border-gray-200 dark:border-gray-800">
-        <div class="flex items-center justify-between mb-3">
+      <!-- Dark mode toggle + AuthToolbar (Apps / Settings / Logout) -->
+      <div class="p-4 border-t border-gray-200 dark:border-gray-800 space-y-3">
+        <div class="flex items-center justify-between">
           <span class="text-xs text-gray-500 dark:text-gray-400">ダークモード</span>
           <USwitch v-model="isDark" size="xs" />
         </div>
-        <div class="text-sm text-gray-600 dark:text-gray-400 truncate mb-2">
-          {{ username }}
-        </div>
-        <UButton
-          label="ログアウト"
-          icon="i-lucide-log-out"
-          variant="ghost"
-          size="sm"
-          block
-          @click="handleLogout"
+        <AuthToolbar
+          class="flex flex-col items-stretch gap-1
+                 [&>*]:w-full [&>button]:justify-start
+                 [&>button]:px-3 [&>button]:py-1.5 [&>button]:text-sm"
+          :show-copy-url="false"
+          :show-qr="false"
         />
       </div>
     </aside>

--- a/tests/helpers/nuxt-stubs.ts
+++ b/tests/helpers/nuxt-stubs.ts
@@ -19,6 +19,10 @@ export const NuxtLink = { template: '<a><slot /></a>', props: ['to'] }
 export const NuxtLayout = { template: '<div><slot /></div>' }
 export const NuxtPage = { template: '<div />' }
 export const StagingFooter = { template: '<div />', props: ['apiBase', 'tenantId'] }
+export const AuthToolbar = {
+  template: '<div data-testid="auth-toolbar"><button data-testid="apps-btn">Apps</button></div>',
+  props: ['showCopyUrl', 'showQr', 'showApps', 'showSettings', 'showLogout', 'showUserInfo', 'showOrgSlug'],
+}
 export const TicketCategoryBadgeStub = { template: '<span />', props: ['category'] }
 export const TicketFormFieldsStub = { template: '<div />', props: ['modelValue', 'mode'] }
 export const MasterDataManagerStub = { template: '<div />', props: ['title', 'items', 'builtinItems', 'loading'] }
@@ -42,6 +46,7 @@ export const allStubs = {
   UApp, UCard, UButton, UIcon, UBadge, UInput, USelect, UFormField,
   UTextarea, UModal, UPagination, USwitch, UTooltip, NuxtLink, NuxtLayout, NuxtPage,
   StagingFooter,
+  AuthToolbar,
   TicketCategoryBadge: TicketCategoryBadgeStub,
   TicketFormFields: TicketFormFieldsStub,
   MasterDataManager: MasterDataManagerStub,

--- a/tests/layouts/default.test.ts
+++ b/tests/layouts/default.test.ts
@@ -1,37 +1,27 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount, flushPromises } from '@vue/test-utils'
-import { ref } from 'vue'
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
 import { allStubs } from '../helpers/nuxt-stubs'
 
-const clearAuthMock = vi.fn()
-const navigateToMock = vi.fn()
-
 vi.mock('~/composables/useAuth', () => ({
-  useAuth: () => ({
-    username: ref('テストユーザー'),
-    clearAuth: clearAuthMock,
-  }),
+  AuthToolbar: { template: '<div data-testid="auth-toolbar"><button>Apps</button></div>' },
 }))
 
 vi.mock('#app/composables/router', () => ({
   useRoute: () => ({ path: '/tickets' }),
-  navigateTo: (...args: unknown[]) => navigateToMock(...args),
 }))
 
 
 import DefaultLayout from '~/layouts/default.vue'
 
 describe('default layout', () => {
-  beforeEach(() => { clearAuthMock.mockReset(); navigateToMock.mockReset() })
-
-  it('renders navigation and user name', () => {
+  it('renders navigation and AuthToolbar', () => {
     const wrapper = mount(DefaultLayout, { global: { stubs: allStubs }, slots: { default: '<p>content</p>' } })
     expect(wrapper.text()).toContain('チケット一覧')
     expect(wrapper.text()).toContain('ステータス管理')
     expect(wrapper.text()).toContain('待機一覧')
     expect(wrapper.text()).toContain('状況管理')
     expect(wrapper.text()).toContain('設定')
-    expect(wrapper.text()).toContain('テストユーザー')
+    expect(wrapper.find('[data-testid="auth-toolbar"]').exists()).toBe(true)
     expect(wrapper.text()).toContain('content')
   })
 
@@ -62,21 +52,11 @@ describe('default layout', () => {
   it('wraps each nav item in a tooltip with descriptive text', () => {
     const wrapper = mount(DefaultLayout, { global: { stubs: allStubs } })
     const tooltips = wrapper.findAll('[data-tooltip]')
-    // 5 nav items + potentially other UTooltips elsewhere; at minimum each nav has one
     const texts = tooltips.map(t => t.attributes('data-tooltip'))
     expect(texts).toContain('すべてのトラブルチケットを一覧表示・編集・新規作成')
     expect(texts).toContain('ワークフロー状態別 (未着手/対応中/完了など) のカンバン表示')
     expect(texts).toContain('進捗状況が「待機」のチケットのみ抽出')
     expect(texts).toContain('全チケット横断の状況 (サブタスク) 一覧、フィルタ・並び替え可')
     expect(texts).toContain('カテゴリ / 営業所 / ワークフロー / 通知などのマスタ管理')
-  })
-
-  it('handles logout', async () => {
-    const wrapper = mount(DefaultLayout, { global: { stubs: allStubs } })
-    const buttons = wrapper.findAll('button')
-    await buttons[buttons.length - 1].trigger('click')
-    await flushPromises()
-    expect(clearAuthMock).toHaveBeenCalled()
-    expect(navigateToMock).toHaveBeenCalledWith('/login')
   })
 })


### PR DESCRIPTION
Embed @ippoan/auth-client AuthToolbar in default layout sidebar so users can jump to other apps via the Apps button (opens auth-worker /top in new tab), matching the UX in Notify and other apps. Replaces the bespoke username + logout block.