### PR TITLE
chore: update @ippoan/auth-client to ^0.2.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@internationalized/date": "^3.12.1",
-        "@ippoan/auth-client": "0.1.65-dev.9bf0838",
+        "@ippoan/auth-client": "^0.2.28",
         "@nuxt/ui": "^4.5.1",
         "@nuxtjs/tailwindcss": "^6.14.0",
         "frappe-gantt": "^1.2.2",
@@ -1623,9 +1623,9 @@
       "license": "MIT"
     },
     "node_modules/@ippoan/auth-client": {
-      "version": "0.1.65-dev.9bf0838",
-      "resolved": "https://npm.pkg.github.com/download/@ippoan/auth-client/0.1.65-dev.9bf0838/65fbea85546054da8658e3aa856c09e2d456a79f",
-      "integrity": "sha512-U5rn7LrtM0jlu1/ZIK3UrA/RV3sCxUAKq6bAgtk1luLXRVApa4oKUHESR1Scig65bsRW0xcTkHnDoUL8vhOygQ==",
+      "version": "0.2.28",
+      "resolved": "https://npm.pkg.github.com/download/@ippoan/auth-client/0.2.28/8884caa8e55c071d7f2fa0e2a3bc999cd88b1551",
+      "integrity": "sha512-PSdj6ZVe3/nDTZksrXtvHVxO1eQWx4rGclg4vIzhlZevYOwZztkvE82Bf1EBuhZUeLWJxm9CmFyMilYpOcimYQ==",
       "dependencies": {
         "uqr": "^0.1.2"
       },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@internationalized/date": "^3.12.1",
-    "@ippoan/auth-client": "0.1.65-dev.9bf0838",
+    "@ippoan/auth-client": "^0.2.28",
     "@nuxt/ui": "^4.5.1",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "frappe-gantt": "^1.2.2",


### PR DESCRIPTION
## Summary

- `@ippoan/auth-client` を `0.1.65-dev.9bf0838` (古い dev pin) → `^0.2.28` stable track に移行
- 他 frontend (alc-app / nuxt-pwa-carins / nuxt-notify) と version を揃える
- PR #117 で AuthToolbar 採用済み + auth-worker PR #86 (merged) の `/admin/sso ?from=` 対応で、設定画面から nuxt-trouble に戻る

## 後方互換

`?from=` がない場合は `/top` フォールバック (auth-worker 側で対応済み)。

## 注意点

dev track (`0.1.x-dev.<hash>`) → stable track (`^0.2.x`) への切替なので、minor バージョン跨ぎ。AuthToolbar の API (props/events) は 0.2.x 系で安定。

## Test plan
- [x] `npm install` で lockfile 更新 (3箇所の 0.2.28 反映)
- [ ] CI pass
- [ ] staging deploy 後、AuthToolbar から設定 → 戻る = nuxt-trouble