### PR TITLE
fix(ui): expand USelect dropdown content to fit full option labels

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -1,0 +1,11 @@
+export default defineAppConfig({
+  ui: {
+    select: {
+      slots: {
+        // トリガー幅は固定で並べたいが、開いたメニュー側はラベル全文を表示したい。
+        // min-w でトリガー幅を下限に保ちつつ w-fit で内容に追従して広がるようにする。
+        content: 'min-w-(--reka-select-trigger-width) w-fit',
+      },
+    },
+  },
+})

--- a/tests/pages/login.test.ts
+++ b/tests/pages/login.test.ts
@@ -8,6 +8,7 @@ vi.mock('#app/composables/router', () => ({ definePageMeta: vi.fn() }))
 vi.mock('#app/nuxt', () => ({
   useRuntimeConfig: () => ({ public: {} }),
   useNuxtApp: () => ({}),
+  defineAppConfig: <T>(c: T) => c,
 }))
 
 import LoginPage from '~/pages/login.vue'

--- a/tests/pages/settings.test.ts
+++ b/tests/pages/settings.test.ts
@@ -5,6 +5,7 @@ import { allStubs } from '../helpers/nuxt-stubs'
 vi.mock('#app/nuxt', () => ({
   useRuntimeConfig: () => ({ public: { authWorkerUrl: 'https://auth.example.com' } }),
   useNuxtApp: () => ({}),
+  defineAppConfig: <T>(c: T) => c,
 }))
 
 vi.mock('~/utils/api', () => ({


### PR DESCRIPTION
Refs #120

## Summary
- `app/app.config.ts` を新規追加し、Nuxt UI v4 `USelect` の content slot をグローバルに `min-w-(--reka-select-trigger-width) w-fit` で上書き。
- トリガー幅は固定 (`w-32` 等) のまま、開いたメニュー側のみが内容に追従して広がるため、「対物事故(自損)」「対物事故(他損)」「苦情・トラブル」等のラベルが三点リーダで省略されなくなる。
- グローバル設定のため `tickets/index.vue` 以外の USelect (`pages/tasks.vue`, `settings.vue`, `WorkflowManager` 等) も同様に全文表示される。

## Test plan
- [ ] チケット一覧のカテゴリ/営業所/進捗状況ドロップダウンを開き、全選択肢が省略なく表示されること
- [ ] トリガー (閉じた状態) のレイアウト幅がフィルター行・一括登録行で崩れないこと
- [ ] ダーク/ライト両モードで表示崩れがないこと
- [ ] 他画面 (tasks, settings, WorkflowManager) の USelect でも長いラベルが全文表示されること
- [ ] 既存の `tests/pages/tickets/` 系テストが通ること

---
_Generated by [Claude Code](https://claude.ai/code/session_01AePetVKwu5K13ANJuiT63q)_