### PR TITLE
fix(tickets): surface inline ticket-create errors

### DIFF
--- a/app/composables/useTicketList.ts
+++ b/app/composables/useTicketList.ts
@@ -134,6 +134,8 @@ export function useTicketList() {
   // Inline create
   const showInlineCreate = ref(false)
   const creating = ref(false)
+  const createError = ref<string | null>(null)
+
   const newTicket = reactive({
     category: '' as string,
     occurred_at: '',
@@ -169,7 +171,11 @@ export function useTicketList() {
   }
 
   async function handleInlineCreate() {
-    if (!newTicket.category) return
+    createError.value = null
+    if (!newTicket.category) {
+      createError.value = 'カテゴリは必須です'
+      return
+    }
     creating.value = true
     try {
       const states = await getWorkflowStates()
@@ -202,6 +208,7 @@ export function useTicketList() {
       await fetchTickets()
     } catch (e) {
       console.error('Failed to create:', e)
+      createError.value = e instanceof Error ? e.message : '作成に失敗しました'
     } finally {
       creating.value = false
     }
@@ -273,7 +280,7 @@ export function useTicketList() {
     filter, selectedStatuses, tickets, total, workflowStates, loading,
     deleteTarget, showDeleteModal, stateMap, totalPages,
     categoryOptions, createCategoryOptions, officeOptions, progressOptions, filteredTickets,
-    showInlineCreate, creating, newTicket,
+    showInlineCreate, creating, createError, newTicket,
     categories, offices, progressStatuses,
     loadStatusFilter, toggleStatus, toggleAllStatuses,
     resetNewTicket, handleInlineCreate,

--- a/app/pages/tickets/index.vue
+++ b/app/pages/tickets/index.vue
@@ -9,7 +9,7 @@ const {
   filter, selectedStatuses, tickets, loading,
   deleteTarget, showDeleteModal, stateMap, totalPages,
   categoryOptions, createCategoryOptions, officeOptions, progressOptions, filteredTickets,
-  showInlineCreate, creating, newTicket, workflowStates, total,
+  showInlineCreate, creating, createError, newTicket, workflowStates, total,
   loadStatusFilter, toggleStatus, toggleAllStatuses,
   resetNewTicket, handleInlineCreate,
   fetchTickets, fetchWorkflowStates, fetchMasterData,
@@ -183,6 +183,7 @@ watch(() => ({ ...filter }), () => { fetchTickets() }, { deep: true })
         <UButton label="作成" size="sm" :loading="creating" :disabled="!newTicket.category" @click="handleInlineCreate" />
         <UButton icon="i-lucide-x" variant="ghost" size="sm" @click="showInlineCreate = false; resetNewTicket()" />
       </div>
+      <p v-if="createError" class="text-xs text-red-500 mt-1 px-1">作成エラー: {{ createError }}</p>
     </div>
 
     <!-- Table -->


### PR DESCRIPTION
## 問題

`/tickets` のインライン新規作成で「作成」を押しても**チケットが入らず、エラーも何も表示されない**（staging で再現）。

## 原因

`useTicketList.handleInlineCreate` が:
- カテゴリ未入力時に `if (!newTicket.category) return` で**無言 return**
- 作成失敗を `catch (e) { console.error('Failed to create:', e) }` で **console にしか出さない**

ため、`createTicket` が API エラー（おそらく 422）で落ちても画面に何も出ませんでした。

## 修正

- `createError` ref を追加し、カテゴリ未入力ガードと catch でメッセージをセット
- インライン作成フォームの下に `作成エラー: {{ createError }}` を表示

これで作成失敗時に rust から返るエラー内容（どのフィールドが不正か等）が画面に出ます。根本原因（なぜ create が失敗するか）は staging ログ + この表示で切り分けます。

Refs #122

---
_Generated by [Claude Code](https://claude.ai/code/session_012zLhVkMuDnAyBWZNLnuorh)_