### PR TITLE
fix(YmdInput): don't auto-save on arrow up/down

### DIFF
--- a/app/components/YmdInput.vue
+++ b/app/components/YmdInput.vue
@@ -129,8 +129,8 @@ function bump(
       else if (next < min) next = min
     }
   }
+  // ↑↓ で値を動かしても即保存しない。確定 (emit) は blur / Enter で行う。
   r.value = String(next).padStart(pad, '0')
-  emitModel()
 }
 
 function bumpYear(delta: number) {


### PR DESCRIPTION
## 問題

状況管理の日付入力で、**↑↓ キーで年月日を増減するたびに即保存**され「移動してすぐ保存されて不愉快」だった。

## 原因

前回（#124）で onInput は確定保存（blur/Enter）に直したが、`bump()`（↑↓ の増減）には `emitModel()` が残っていて、矢印を押すたびに `update:modelValue` → `updateTask` が走っていた。

## 修正

`bump()` から `emitModel()` を削除。↑↓ は内部状態のみ更新し、確定（emit）は blur / Enter に統一。

Refs #122

---
_Generated by [Claude Code](https://claude.ai/code/session_012zLhVkMuDnAyBWZNLnuorh)_