### PR TITLE
ci: add release-wave-retest dispatch receiver workflow

### DIFF
--- a/.github/workflows/release-wave-retest.yml
+++ b/.github/workflows/release-wave-retest.yml
@@ -1,0 +1,41 @@
+name: Release Wave Retest
+
+# ci-dashboard の Compatibility グラフの retest ボタンから飛んでくる
+# repository_dispatch (event: release-wave-retest) を受け、payload の
+# backend_image (= ghcr.io/ippoan/rust-alc-api:<sha>) を相手に integration
+# test を回し直して compat report を送り直す経路 (Refs ippoan/ci-dashboard#157)。
+#
+# frontend-ci.yml はこの retest 経路を想定済み:
+#   - report-compatibility job は github.event_name で gate されず、
+#     compat_backend_image (= dispatch payload の image) を優先採用する。
+#   - deploy / auto-merge / pr-limit / publish は github.event_name が
+#     pull_request / push の時だけ走るので repository_dispatch では skip。
+# has_deploy: false で deploy/publish 系もダブルで止める。
+
+on:
+  repository_dispatch:
+    types:
+      - release-wave-retest
+
+permissions:
+  contents: write
+  packages: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  retest:
+    uses: ippoan/ci-workflows/.github/workflows/frontend-ci.yml@main
+    with:
+      has_integration: true
+      has_deploy: false
+      # dispatch payload の backend image を test 相手に明示指定する。
+      # frontend-ci の report-compatibility がこの image をそのまま記録する。
+      compat_backend_repo: ippoan/rust-alc-api
+      compat_backend_image: ${{ github.event.client_payload.backend_image }}
+      compat_backend_image_env: API_IMAGE
+      # 以下は test.yml の ci job の with をそのまま流用 (同一 integration 構成)。
+      install_command: 'npm install'
+      post_install_script: 'npx nuxt prepare && npx wrangler types'
+      integration_env: 'API_BASE_URL=http://localhost:18080'
+    secrets: inherit


### PR DESCRIPTION
## 概要

ci-dashboard の Compatibility グラフの **retest ボタン**を押すと consumer repo に `repository_dispatch` (event: `release-wave-retest`、`client_payload` に `backend_repo` / `backend_image` / `prod_version`) が飛ぶが、本 repo に受け口が無く retest が動かなかった。

その受け口 `.github/workflows/release-wave-retest.yml` を追加する。

## 内容

- `on: repository_dispatch` の `types: [release-wave-retest]` のみで発火
- `ippoan/ci-workflows/.github/workflows/frontend-ci.yml@main` を呼ぶ
- `compat_backend_image` に `github.event.client_payload.backend_image` を渡す (肝)
- `has_deploy: false` で deploy/publish を止める
- `compat_backend_repo` / `compat_backend_image_env` / `install_command` / `post_install_script` / `integration_env` は本 repo の `test.yml` の ci job と同一

## 動作確認 (frontend-ci.yml の retest 経路)

- `report-compatibility` job は `github.event_name` で gate されず、`compat_backend_image` (= dispatch payload の image) を優先採用する (frontend-ci.yml L857-879)。よって repository_dispatch でも走り、dispatch された image を記録する。
- `deploy-staging` / `deploy-release` / `pr-limit` / `disable-auto-merge` / `publish-dev` / `publish-release` / `auto-merge` は全て `github.event_name == 'pull_request'` または `'push'` で gate されているため **repository_dispatch では skip**。auto-merge の誤発火は無い。
- `has_deploy: false` で deploy/publish 系を二重に停止。

Refs ippoan/ci-dashboard#157

https://claude.ai/code/session_012zLhVkMuDnAyBWZNLnuorh

---
_Generated by [Claude Code](https://claude.ai/code/session_012zLhVkMuDnAyBWZNLnuorh)_