### PR TITLE
ci(release-wave): caller の on:types から release-wave-stage を除去

### DIFF
--- a/.github/workflows/release-wave.yml
+++ b/.github/workflows/release-wave.yml
@@ -12,7 +12,6 @@ name: Release Wave
 on:
   repository_dispatch:
     types:
-      - release-wave-stage
       - release-wave-flip
       - release-wave-rollback
       - release-wave-traffic-rollback   # frontend 単独 rollback (cloudflare-workers)


### PR DESCRIPTION
## 概要

ci-workflows#96 の stage 撤去に伴う caller cleanup。ci-dashboard #246（stage dispatch 廃止）+ ci-workflows #101（handler の stage-* job / `release-wave-stage` event 撤去）が merged されたので、`release-wave.yml` caller が `release-wave-stage` を listen する必要がなくなった。

`on: repository_dispatch: types` から `release-wave-stage` を除去（`release-wave-flip` / `-rollback` / `-traffic-rollback` / `-backend-rollback` のみ）。dispatch 元は既に消えているので挙動変化なし。

Refs ippoan/ci-workflows#96
Refs ippoan/ci-dashboard#244

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYnhZeg24YNLyZsSb87YTo)_