### PR TITLE
fix(YmdInput): keep inline edit open when calendar popover steals focus

### DIFF
--- a/app/components/YmdInput.vue
+++ b/app/components/YmdInput.vue
@@ -88,6 +88,14 @@ function onDayInput(e: Event) {
 
 /** root の外へフォーカスが抜けたときだけ確定 (セル間移動では確定しない)。 */
 function commitOnBlur(e: FocusEvent) {
+  // カレンダーアイコンを押すと UPopover が開き、reka-ui が teleport 先の
+  // UCalendar にフォーカスを移すため input root から focusout が発火する。
+  // これを「確定」と誤判定して emit すると、TicketTaskList のように
+  // @update:model-value で即 saveEdit() → editingId=null → v-if 解除する親では
+  // 入力欄ごと消え、カレンダーを押した瞬間に消滅する (= 「クリックで消える」)。
+  // popover 操作中は確定しない。日付選択は onCalendarSelect が、popover を閉じて
+  // 他要素へ移ったときは下の relatedTarget 判定が確定を担う。
+  if (popoverOpen.value) return
   const next = e.relatedTarget as Node | null
   if (next && rootRef.value?.contains(next)) return
   emitModel()


### PR DESCRIPTION
Refs #132

## 症状

トラブル詳細ページのタスク一覧（状況管理）で、日付セル（発生日時 / 期限）を編集しようとカレンダーアイコン📅を押すと、カレンダーが出ずに **入力欄ごと消えてしまう**（「クリックで消える」）。

## 原因

`YmdInput` のカレンダーは `UPopover` + `UCalendar` で、ポップオーバーの中身は `<body>` 直下に teleport される。アイコンを押すと reka-ui が開く際にフォーカスをその `UCalendar` へ移すため、`YmdInput` のルートで `focusout` が発火する。

`commitOnBlur` はこれを「確定操作」と誤判定して `update:modelValue` を emit。`TicketTaskList` の日付セルは `@update:model-value` で即 `saveEdit()` を呼び、その先頭で `editingId = null` にするため、`v-if="isEditing(...)"` で表示されている `YmdInput`（とポップオーバー）が押した瞬間に DOM から消えていた。

```
📅 click
  → UPopover open → reka-ui moves focus to teleported UCalendar
  → focusout on YmdInput root
  → commitOnBlur emits update:modelValue
  → TicketTaskList saveEdit() → editingId = null
  → v-if false → YmdInput (+ popover) removed  ← 消える
```

## 修正

`commitOnBlur` を `popoverOpen` でガードし、カレンダーポップオーバーへフォーカスが入っている間はインライン編集を確定／終了しないようにした（`YmdInput.vue` の 1 ファイル・1 行のガード追加のみ）。

- 日付の選択は従来どおり `onCalendarSelect` が確定
- ポップオーバーを閉じて他要素へ移った場合は従来の `relatedTarget` 判定が確定を担う
- 手入力した値も、カレンダーを閉じて外へ移った時点で確定される

## 影響範囲

- `YmdInput` を `v-if` + `@update:model-value`→即保存 で使う **タスク一覧の発生日時・期限** が直る。
- `YmdtInput`（スケジュール予約モーダル・編集フォームの発生日時）は `focusout` 確定ロジックを持たない別設計のため影響なし。
- `@nuxt/ui` の DatePicker パターン自体は公式実装と一致しており、コンポーネントの使い方は変更していない。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qvt1ymuJkeAmRPynW3QnHU)_