### PR TITLE
refactor(auth): callback ページを @ippoan/auth-client の AuthCallback に置換

### DIFF
--- a/app/pages/auth/callback.vue
+++ b/app/pages/auth/callback.vue
@@ -1,31 +1,11 @@
 <script setup lang="ts">
+// callback の共通ロジック/UI は @ippoan/auth-client の AuthCallback に集約済み
+// (Refs ippoan/auth-worker#257、nuxt-dtako-admin との相互コピーを 1 本化)
+import { AuthCallback } from '@ippoan/auth-client'
+
 definePageMeta({ layout: 'auth' })
-
-const { consumeFragment } = useAuth()
-const error = ref<string | null>(null)
-
-onMounted(() => {
-  const success = consumeFragment()
-  if (success) {
-    navigateTo('/tickets')
-  } else {
-    error.value = '認証に失敗しました。再度ログインしてください。'
-  }
-})
 </script>
 
 <template>
-  <UCard class="w-full max-w-sm">
-    <div class="text-center space-y-4">
-      <template v-if="error">
-        <UIcon name="i-lucide-alert-circle" class="size-12 text-red-500 mx-auto" />
-        <p class="text-red-600">{{ error }}</p>
-        <UButton label="ログインに戻る" to="/login" variant="outline" />
-      </template>
-      <template v-else>
-        <UIcon name="i-lucide-loader-circle" class="size-12 animate-spin text-gray-400 mx-auto" />
-        <p class="text-gray-500">認証中...</p>
-      </template>
-    </div>
-  </UCard>
+  <AuthCallback redirect-to="/tickets" login-path="/login" />
 </template>

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@internationalized/date": "^3.12.1",
-    "@ippoan/auth-client": "^0.2.28",
+    "@ippoan/auth-client": "^0.2.55",
     "@nuxt/ui": "^4.5.1",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "frappe-gantt": "^1.2.2",

--- a/tests/pages/auth/callback.test.ts
+++ b/tests/pages/auth/callback.test.ts
@@ -1,36 +1,29 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
 import { allStubs } from '../../helpers/nuxt-stubs'
 
-const consumeFragmentMock = vi.fn()
-const navigateToMock = vi.fn()
-
-vi.mock('~/composables/useAuth', () => ({ useAuth: () => ({ consumeFragment: consumeFragmentMock }) }))
+// callback の挙動 (consumeFragment 成否 → 遷移 / エラー表示) は
+// @ippoan/auth-client の AuthCallback に集約された (Refs ippoan/auth-worker#257)。
+// ここでは page が lib コンポーネントに正しい props で委譲していること (wiring)
+// だけを固定する。
+vi.mock('@ippoan/auth-client', () => ({
+  AuthCallback: {
+    name: 'AuthCallback',
+    props: { redirectTo: { type: String }, loginPath: { type: String } },
+    template: '<div data-testid="auth-callback">{{ redirectTo }}|{{ loginPath }}</div>',
+  },
+}))
 vi.mock('#app/composables/router', () => ({
   definePageMeta: vi.fn(),
-  navigateTo: (...args: unknown[]) => navigateToMock(...args),
 }))
-vi.mock('#app/nuxt', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>()
-  return { ...actual, ref: (val: unknown) => ({ value: val }), onMounted: (fn: () => void) => fn() }
-})
 
 import CallbackPage from '~/pages/auth/callback.vue'
 
 describe('auth/callback page', () => {
-  beforeEach(() => { consumeFragmentMock.mockReset(); navigateToMock.mockReset() })
-
-  it('navigates to /tickets on success', async () => {
-    consumeFragmentMock.mockReturnValue(true)
-    mount(CallbackPage, { global: { stubs: allStubs } })
-    await flushPromises()
-    expect(navigateToMock).toHaveBeenCalledWith('/tickets')
-  })
-
-  it('shows error on failure', async () => {
-    consumeFragmentMock.mockReturnValue(false)
+  it('AuthCallback (lib) に /tickets リダイレクトで委譲する', () => {
     const wrapper = mount(CallbackPage, { global: { stubs: allStubs } })
-    await flushPromises()
-    expect(wrapper.text()).toContain('認証に失敗しました')
+    const el = wrapper.get('[data-testid="auth-callback"]')
+    expect(el.text()).toContain('/tickets')
+    expect(el.text()).toContain('/login')
   })
 })


### PR DESCRIPTION
## 概要

Nuxt app 間で相互コピーされていた auth callback ページを `@ippoan/auth-client@0.2.55` の `AuthCallback` コンポーネントに置換する consumer 移行 (lib 側: ippoan/auth-worker#260)。

Refs ippoan/auth-worker#257

## 変更内容

- `app/pages/auth/callback.vue` → `<AuthCallback redirect-to="/tickets" login-path="/login" />` (nuxt-dtako-admin との相互コピーを 1 本化)
- `tests/pages/auth/callback.test.ts` を wiring テストに書き換え — consumeFragment 成否 → 遷移 / エラー表示の挙動は lib コンポーネントに集約されたため、page が正しい props で委譲していることだけを固定
- `@ippoan/auth-client` を `^0.2.55` に bump

## 備考

- `package-lock.json` は意図的に未更新 (CCoW container に GitHub Packages token が無く再生成不可)。CI は `install_command: 'npm install'` のため manifest に追従して 0.2.55 を解決する
- UI は Nuxt UI (UCard/UIcon) から lib の plain Tailwind マークアップ (CSS spinner) に変わる — 表示は同等、エラー時 action は slot で差し替え可
- callback.vue は coverage_100 未登録のためカバレッジ gate への影響なし

https://claude.ai/code/session_017RcaTi26gsPjZ8r2Qdf6z5

---
_Generated by [Claude Code](https://claude.ai/code/session_017RcaTi26gsPjZ8r2Qdf6z5)_