### PR TITLE
test: coverage_100 gate 回帰 5 file を 100% に再達成して登録簿へ戻す

### DIFF
--- a/coverage_100.toml
+++ b/coverage_100.toml
@@ -1,13 +1,24 @@
 # Files that must maintain 100% test coverage.
 # CI will fail if any listed file drops below 100%.
 # 形式は org 標準の [[files]] entries (@ippoan/test-utils の checker が読む)。
-#
-# 注: 旧 `files = [...]` 配列形式の間は checker が登録 0 件扱いで gate が
-# vacuous だった。その間に回帰した 5 file (useAppInit / useTicketDetail /
-# useTicketList / useTicketNew / api.ts) は #138 で 100% 再達成後に戻す。
+
+[[files]]
+path = "app/composables/useAppInit.ts"
 
 [[files]]
 path = "app/composables/useAuth.ts"
 
 [[files]]
+path = "app/composables/useTicketDetail.ts"
+
+[[files]]
+path = "app/composables/useTicketList.ts"
+
+[[files]]
+path = "app/composables/useTicketNew.ts"
+
+[[files]]
 path = "app/middleware/auth.global.ts"
+
+[[files]]
+path = "app/utils/api.ts"

--- a/tests/composables/useAppInit.test.ts
+++ b/tests/composables/useAppInit.test.ts
@@ -73,4 +73,16 @@ describe('useAppInit', () => {
     const { isLoading } = useAppInit()
     expect(isLoading.value).toBe(false)
   })
+
+  it('onUnauthorized handler clears auth and navigates to /login', async () => {
+    const { setup } = useAppInit()
+    await setup()
+
+    const onUnauthorized = initApiMock.mock.calls[0][4] as () => void
+    onUnauthorized()
+
+    expect(clearAuthMock).toHaveBeenCalled()
+    const { navigateTo } = await import('#app/composables/router')
+    expect(navigateTo).toHaveBeenCalledWith('/login')
+  })
 })

--- a/tests/composables/useTicketDetail.test.ts
+++ b/tests/composables/useTicketDetail.test.ts
@@ -120,6 +120,15 @@ describe('useTicketDetail', () => {
     expect(useTicketDetail('x').displayValue('category')).toBe('-')
   })
 
+  it('displayValue formats occurred_at via formatOccurredAt', async () => {
+    if (isLive) return
+    getTicketMock.mockResolvedValue(makeTroubleTicket({ occurred_at: null, occurred_date: '2026-01-15' }))
+    getWorkflowStatesMock.mockResolvedValue([])
+    const d = useTicketDetail('test-id')
+    await d.load()
+    expect(d.displayValue('occurred_at')).toBe('2026-01-15')
+  })
+
   it('startEdit populates form', async () => {
     if (!isLive) { getTicketMock.mockResolvedValue(ticket); getWorkflowStatesMock.mockResolvedValue([]) }
     const d = useTicketDetail(tid())

--- a/tests/composables/useTicketList.test.ts
+++ b/tests/composables/useTicketList.test.ts
@@ -9,6 +9,9 @@ const deleteTicketMock = vi.fn()
 const exportTicketsCsvMock = vi.fn()
 const createTicketMock = vi.fn()
 const setupDefaultWorkflowMock = vi.fn()
+const getCategoriesMock = vi.fn()
+const getOfficesMock = vi.fn()
+const getProgressStatusesMock = vi.fn()
 
 vi.mock('~/utils/api', async (importOriginal) => {
   if (process.env.API_BASE_URL) return await importOriginal()
@@ -20,6 +23,9 @@ vi.mock('~/utils/api', async (importOriginal) => {
     exportTicketsCsv: (...args: unknown[]) => exportTicketsCsvMock(...args),
     createTicket: (...args: unknown[]) => createTicketMock(...args),
     setupDefaultWorkflow: (...args: unknown[]) => setupDefaultWorkflowMock(...args),
+    getCategories: (...args: unknown[]) => getCategoriesMock(...args),
+    getOffices: (...args: unknown[]) => getOfficesMock(...args),
+    getProgressStatuses: (...args: unknown[]) => getProgressStatusesMock(...args),
   }
 })
 
@@ -43,6 +49,9 @@ describe('useTicketList', () => {
     exportTicketsCsvMock.mockReset()
     createTicketMock.mockReset()
     setupDefaultWorkflowMock.mockReset()
+    getCategoriesMock.mockReset()
+    getOfficesMock.mockReset()
+    getProgressStatusesMock.mockReset()
   })
   afterEach(() => teardownApi())
 
@@ -338,6 +347,50 @@ describe('useTicketList', () => {
     l.resetNewTicket()
     expect(l.newTicket.category).toBe('')
     expect(l.newTicket.person_name).toBe('')
+  })
+
+  it('handleInlineCreate includes person_is_external flag', async () => {
+    if (isLive) return
+    getWorkflowStatesMock.mockResolvedValue([{ id: 's1' }])
+    createTicketMock.mockResolvedValue({ id: 'new-id' })
+    getTicketsMock.mockResolvedValue({ tickets: [], total: 0, page: 1, per_page: 20 })
+
+    const l = useTicketList()
+    l.newTicket.category = '貨物事故'
+    l.newTicket.person_is_external = true
+    await l.handleInlineCreate()
+
+    const payload = createTicketMock.mock.calls[0][0]
+    expect(payload.person_is_external).toBe(true)
+  })
+
+  // Master data
+  it('fetchMasterData loads categories, offices, progress statuses', async () => {
+    if (isLive) return
+    getCategoriesMock.mockResolvedValue([{ id: 'c1', tenant_id: 't1', name: '貨物事故', sort_order: 1, created_at: '' }])
+    getOfficesMock.mockResolvedValue([{ id: 'o1', tenant_id: 't1', name: '東京営業所', sort_order: 1, created_at: '' }])
+    getProgressStatusesMock.mockResolvedValue([{ id: 'p1', tenant_id: 't1', name: '対応中', sort_order: 1, created_at: '' }])
+
+    const l = useTicketList()
+    await l.fetchMasterData()
+
+    expect(l.categories.value.length).toBe(1)
+    expect(l.officeOptions.value).toEqual([{ label: '東京営業所', value: '東京営業所' }])
+    expect(l.progressOptions.value).toEqual([{ label: '対応中', value: '対応中' }])
+  })
+
+  it('fetchMasterData falls back to empty arrays on per-call failure', async () => {
+    if (isLive) return
+    getCategoriesMock.mockRejectedValue(new Error('cats fail'))
+    getOfficesMock.mockRejectedValue(new Error('offs fail'))
+    getProgressStatusesMock.mockRejectedValue(new Error('progs fail'))
+
+    const l = useTicketList()
+    await l.fetchMasterData()
+
+    expect(l.categories.value).toEqual([])
+    expect(l.officeOptions.value).toEqual([])
+    expect(l.progressOptions.value).toEqual([])
   })
 
   it('createCategoryOptions has correct length with no DB categories', () => {

--- a/tests/composables/useTicketNew.test.ts
+++ b/tests/composables/useTicketNew.test.ts
@@ -84,6 +84,22 @@ describe('useTicketNew', () => {
     expect(setupDefaultWorkflowMock).toHaveBeenCalled()
   })
 
+  it('includes occurred_at and occurred_date when set', async () => {
+    if (isLive) return
+    getWorkflowStatesMock.mockResolvedValue([{ id: 's1' }])
+    createTicketMock.mockResolvedValue({ id: 'new-id' })
+
+    const { form, handleSubmit } = useTicketNew()
+    form.value.category = '貨物事故'
+    form.value.occurred_at = '2026-01-15T09:30'
+    await handleSubmit()
+
+    const payload = createTicketMock.mock.calls[0][0]
+    expect(payload.occurred_date).toBe('2026-01-15')
+    expect(typeof payload.occurred_at).toBe('string')
+    expect(payload.occurred_at).toMatch(/^2026-01-15T/)
+  })
+
   it('handles Error on create failure', async () => {
     if (isLive) return
     getWorkflowStatesMock.mockResolvedValue([{ id: 's1' }])

--- a/tests/utils/api-phase4.test.ts
+++ b/tests/utils/api-phase4.test.ts
@@ -1,0 +1,567 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  setupApi,
+  teardownApi,
+  mockFetch,
+  stubOk,
+  assertMock,
+  verifyApi,
+  expectMock,
+  isLive,
+  API_BASE,
+  restoreNativeApis,
+} from '../helpers/api-test-env'
+import {
+  getProgressStatuses,
+  createProgressStatus,
+  deleteProgressStatus,
+  updateProgressStatusSortOrder,
+  getFileBlobUrl,
+  restoreFile,
+  getTrashFiles,
+  getNotificationPrefs,
+  upsertNotificationPref,
+  deleteNotificationPref,
+  getLineworksMembers,
+  createSchedule,
+  getTicketSchedules,
+  cancelSchedule,
+  getTaskTypes,
+  createTaskType,
+  deleteTaskType,
+  updateTaskTypeSortOrder,
+  getTaskStatuses,
+  createTaskStatus,
+  deleteTaskStatus,
+  updateTaskStatusSortOrder,
+  getTasks,
+  createTask,
+  updateTask,
+  deleteTask,
+  listAllTasks,
+  getTaskFiles,
+  uploadTaskFile,
+  downloadTaskFile,
+  deleteTaskFile,
+  restoreTaskFile,
+} from '~/utils/api'
+
+// #138: coverage_100 gate が vacuous だった間に未テストのまま増えた API 群。
+// カバレッジ gate は mock モード (test job) で計測されるため、live では skip する。
+describe('Trouble API Phase 4', () => {
+  beforeEach(async () => {
+    restoreNativeApis()
+    await setupApi()
+  })
+  afterEach(() => teardownApi())
+
+  // --- Progress Statuses ---
+  describe('getProgressStatuses', () => {
+    it('fetches progress statuses', async () => {
+      await verifyApi(() => getProgressStatuses(), [{ id: 'p1', name: '対応中' }])
+      assertMock(() => {
+        expectMock(mockFetch).toHaveBeenCalledWith(
+          `${API_BASE}/api/trouble/progress-statuses`,
+          expect.objectContaining({ headers: expect.any(Object) }),
+        )
+      })
+    })
+  })
+
+  describe('createProgressStatus', () => {
+    it('creates a progress status', async () => {
+      if (isLive) {
+        const p = await createProgressStatus({ name: `test-prog-${Date.now()}` })
+        expect(p.id).toBeDefined()
+        await deleteProgressStatus(p.id)
+        return
+      }
+      await verifyApi(() => createProgressStatus({ name: '対応中' }), { id: 'p1', name: '対応中' })
+      assertMock(() => {
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/api/trouble/progress-statuses`)
+        expect(opts.method).toBe('POST')
+        expect(JSON.parse(opts.body)).toEqual({ name: '対応中' })
+      })
+    })
+  })
+
+  describe('deleteProgressStatus', () => {
+    it('deletes a progress status', async () => {
+      if (isLive) return // createProgressStatus 側でテスト済み
+      await verifyApi(() => deleteProgressStatus('p1'), {}, { expect204: true })
+      assertMock(() => {
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/api/trouble/progress-statuses/p1`)
+        expect(opts.method).toBe('DELETE')
+      })
+    })
+  })
+
+  describe('updateProgressStatusSortOrder', () => {
+    it('updates progress status sort order', async () => {
+      if (isLive) {
+        const p = await createProgressStatus({ name: `sort-prog-${Date.now()}` })
+        const updated = await updateProgressStatusSortOrder(p.id, 5)
+        expect(updated.sort_order).toBe(5)
+        await deleteProgressStatus(p.id)
+        return
+      }
+      await verifyApi(() => updateProgressStatusSortOrder('p1', 5), { id: 'p1', sort_order: 5 })
+      assertMock(() => {
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/api/trouble/progress-statuses/p1`)
+        expect(opts.method).toBe('PUT')
+        expect(JSON.parse(opts.body)).toEqual({ sort_order: 5 })
+      })
+    })
+  })
+
+  // --- Files (blob / trash / restore) ---
+  describe('getFileBlobUrl', () => {
+    it('returns object URL for fetched blob', async () => {
+      if (isLive) return
+      const blobUrl = 'blob:http://localhost/fake'
+      const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue(blobUrl)
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['data'])),
+      })
+      const url = await getFileBlobUrl('f1')
+      expect(url).toBe(blobUrl)
+      const [calledUrl] = mockFetch.mock.calls[0]
+      expect(calledUrl).toBe(`${API_BASE}/api/trouble/files/f1/download`)
+      createObjectURLSpy.mockRestore()
+    })
+
+    it('throws on non-ok response', async () => {
+      if (isLive) return
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 404 })
+      await expect(getFileBlobUrl('f1')).rejects.toThrow('ファイル取得失敗: 404')
+    })
+  })
+
+  describe('restoreFile', () => {
+    it('restores a deleted file', async () => {
+      if (isLive) return
+      await verifyApi(() => restoreFile('f1'), {}, { expect204: true })
+      assertMock(() => {
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/api/trouble/files/f1/restore`)
+        expect(opts.method).toBe('POST')
+      })
+    })
+  })
+
+  describe('getTrashFiles', () => {
+    it('fetches trash files for a ticket', async () => {
+      if (isLive) return
+      await verifyApi(() => getTrashFiles('ticket-1'), [{ id: 'f1', filename: 'old.pdf' }])
+      assertMock(() => {
+        expectMock(mockFetch).toHaveBeenCalledWith(
+          `${API_BASE}/api/trouble/tickets/ticket-1/files/trash`,
+          expect.objectContaining({ headers: expect.any(Object) }),
+        )
+      })
+    })
+  })
+
+  // --- Notification Prefs ---
+  describe('getNotificationPrefs', () => {
+    it('fetches notification prefs', async () => {
+      if (isLive) return
+      await verifyApi(() => getNotificationPrefs(), [{ id: 'n1', channel: 'lineworks' }])
+      assertMock(() => {
+        expectMock(mockFetch).toHaveBeenCalledWith(
+          `${API_BASE}/api/trouble/notification-prefs`,
+          expect.objectContaining({ headers: expect.any(Object) }),
+        )
+      })
+    })
+  })
+
+  describe('upsertNotificationPref', () => {
+    it('upserts a notification pref', async () => {
+      if (isLive) return
+      const data = { channel: 'lineworks', target_id: 'u1', enabled: true }
+      await verifyApi(
+        () => upsertNotificationPref(data as Parameters<typeof upsertNotificationPref>[0]),
+        { id: 'n1', ...data },
+      )
+      assertMock(() => {
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/api/trouble/notification-prefs`)
+        expect(opts.method).toBe('POST')
+      })
+    })
+  })
+
+  describe('deleteNotificationPref', () => {
+    it('deletes a notification pref', async () => {
+      if (isLive) return
+      await verifyApi(() => deleteNotificationPref('n1'), {}, { expect204: true })
+      assertMock(() => {
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/api/trouble/notification-prefs/n1`)
+        expect(opts.method).toBe('DELETE')
+      })
+    })
+  })
+
+  describe('getLineworksMembers', () => {
+    it('fetches lineworks members', async () => {
+      if (isLive) return
+      await verifyApi(() => getLineworksMembers(), [{ id: 'u1', name: 'テスト太郎' }])
+      assertMock(() => {
+        expectMock(mockFetch).toHaveBeenCalledWith(
+          `${API_BASE}/api/trouble/lineworks/members`,
+          expect.objectContaining({ headers: expect.any(Object) }),
+        )
+      })
+    })
+  })
+
+  // --- Schedules ---
+  describe('createSchedule', () => {
+    it('creates a schedule', async () => {
+      if (isLive) return
+      const data = { ticket_id: 'ticket-1', scheduled_at: '2026-07-01T09:00:00Z', message: '点検' }
+      await verifyApi(
+        () => createSchedule(data as Parameters<typeof createSchedule>[0]),
+        { id: 'sch1', ...data },
+      )
+      assertMock(() => {
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/api/trouble/schedules`)
+        expect(opts.method).toBe('POST')
+      })
+    })
+  })
+
+  describe('getTicketSchedules', () => {
+    it('fetches schedules for a ticket', async () => {
+      if (isLive) return
+      await verifyApi(() => getTicketSchedules('ticket-1'), [{ id: 'sch1' }])
+      assertMock(() => {
+        expectMock(mockFetch).toHaveBeenCalledWith(
+          `${API_BASE}/api/trouble/tickets/ticket-1/schedules`,
+          expect.objectContaining({ headers: expect.any(Object) }),
+        )
+      })
+    })
+  })
+
+  describe('cancelSchedule', () => {
+    it('cancels a schedule', async () => {
+      if (isLive) return
+      await verifyApi(() => cancelSchedule('sch1'), {}, { expect204: true })
+      assertMock(() => {
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/api/trouble/schedules/sch1`)
+        expect(opts.method).toBe('DELETE')
+      })
+    })
+  })
+
+  // --- Task Types ---
+  describe('getTaskTypes', () => {
+    it('fetches task types', async () => {
+      if (isLive) return
+      await verifyApi(() => getTaskTypes(), [{ id: 'tt1', name: '修理' }])
+      assertMock(() => {
+        expectMock(mockFetch).toHaveBeenCalledWith(
+          `${API_BASE}/api/trouble/task-types`,
+          expect.objectContaining({ headers: expect.any(Object) }),
+        )
+      })
+    })
+  })
+
+  describe('createTaskType', () => {
+    it('creates a task type', async () => {
+      if (isLive) return
+      await verifyApi(() => createTaskType({ name: '修理' }), { id: 'tt1', name: '修理' })
+      assertMock(() => {
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/api/trouble/task-types`)
+        expect(opts.method).toBe('POST')
+        expect(JSON.parse(opts.body)).toEqual({ name: '修理' })
+      })
+    })
+  })
+
+  describe('deleteTaskType', () => {
+    it('deletes a task type', async () => {
+      if (isLive) return
+      await verifyApi(() => deleteTaskType('tt1'), {}, { expect204: true })
+      assertMock(() => {
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/api/trouble/task-types/tt1`)
+        expect(opts.method).toBe('DELETE')
+      })
+    })
+  })
+
+  describe('updateTaskTypeSortOrder', () => {
+    it('updates task type sort order', async () => {
+      if (isLive) return
+      await verifyApi(() => updateTaskTypeSortOrder('tt1', 3), { id: 'tt1', sort_order: 3 })
+      assertMock(() => {
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/api/trouble/task-types/tt1`)
+        expect(opts.method).toBe('PUT')
+        expect(JSON.parse(opts.body)).toEqual({ sort_order: 3 })
+      })
+    })
+  })
+
+  // --- Task Statuses ---
+  describe('getTaskStatuses', () => {
+    it('fetches task statuses', async () => {
+      if (isLive) return
+      await verifyApi(() => getTaskStatuses(), [{ id: 'ts1', key: 'open', name: '未着手' }])
+      assertMock(() => {
+        expectMock(mockFetch).toHaveBeenCalledWith(
+          `${API_BASE}/api/trouble/task-statuses`,
+          expect.objectContaining({ headers: expect.any(Object) }),
+        )
+      })
+    })
+  })
+
+  describe('createTaskStatus', () => {
+    it('creates a task status', async () => {
+      if (isLive) return
+      const data = { key: 'open', name: '未着手' }
+      await verifyApi(
+        () => createTaskStatus(data as Parameters<typeof createTaskStatus>[0]),
+        { id: 'ts1', ...data },
+      )
+      assertMock(() => {
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/api/trouble/task-statuses`)
+        expect(opts.method).toBe('POST')
+      })
+    })
+  })
+
+  describe('deleteTaskStatus', () => {
+    it('deletes a task status', async () => {
+      if (isLive) return
+      await verifyApi(() => deleteTaskStatus('ts1'), {}, { expect204: true })
+      assertMock(() => {
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/api/trouble/task-statuses/ts1`)
+        expect(opts.method).toBe('DELETE')
+      })
+    })
+  })
+
+  describe('updateTaskStatusSortOrder', () => {
+    it('updates task status sort order', async () => {
+      if (isLive) return
+      await verifyApi(() => updateTaskStatusSortOrder('ts1', 2), { id: 'ts1', sort_order: 2 })
+      assertMock(() => {
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/api/trouble/task-statuses/ts1`)
+        expect(opts.method).toBe('PUT')
+        expect(JSON.parse(opts.body)).toEqual({ sort_order: 2 })
+      })
+    })
+  })
+
+  // --- Tasks ---
+  describe('getTasks', () => {
+    it('fetches tasks for a ticket', async () => {
+      if (isLive) return
+      await verifyApi(() => getTasks('ticket-1'), [{ id: 'task-1' }])
+      assertMock(() => {
+        expectMock(mockFetch).toHaveBeenCalledWith(
+          `${API_BASE}/api/trouble/tickets/ticket-1/tasks`,
+          expect.objectContaining({ headers: expect.any(Object) }),
+        )
+      })
+    })
+  })
+
+  describe('createTask', () => {
+    it('creates a task', async () => {
+      if (isLive) return
+      const data = { title: 'タスク', assigned_to: '担当A', next_action_by: '担当B' }
+      await verifyApi(
+        () => createTask('ticket-1', data as Parameters<typeof createTask>[1]),
+        { id: 'task-1', ...data },
+      )
+      assertMock(() => {
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/api/trouble/tickets/ticket-1/tasks`)
+        expect(opts.method).toBe('POST')
+      })
+    })
+  })
+
+  describe('updateTask', () => {
+    it('updates a task', async () => {
+      if (isLive) return
+      await verifyApi(
+        () => updateTask('task-1', { title: '更新' } as Parameters<typeof updateTask>[1]),
+        { id: 'task-1', title: '更新' },
+      )
+      assertMock(() => {
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/api/trouble/tasks/task-1`)
+        expect(opts.method).toBe('PUT')
+      })
+    })
+  })
+
+  describe('deleteTask', () => {
+    it('deletes a task', async () => {
+      if (isLive) return
+      await verifyApi(() => deleteTask('task-1'), {}, { expect204: true })
+      assertMock(() => {
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/api/trouble/tasks/task-1`)
+        expect(opts.method).toBe('DELETE')
+      })
+    })
+  })
+
+  // --- Cross-ticket Tasks ---
+  describe('listAllTasks', () => {
+    it('lists tasks without query', async () => {
+      if (isLive) return
+      const mockData = { items: [], total: 0, page: 1, per_page: 20 }
+      await verifyApi(() => listAllTasks(), mockData)
+      assertMock(() => {
+        const [url] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/api/trouble/tasks`)
+      })
+    })
+
+    it('lists tasks with query params, skipping empty values', async () => {
+      if (isLive) return
+      const mockData = { items: [], total: 0, page: 2, per_page: 50 }
+      await verifyApi(
+        () => listAllTasks({ status: 'open', q: '', assigned_to: undefined, page: 2, per_page: 50 }),
+        mockData,
+      )
+      assertMock(() => {
+        const [url] = mockFetch.mock.calls[0]
+        expect(url).toContain('status=open')
+        expect(url).toContain('page=2')
+        expect(url).not.toContain('q=')
+        expect(url).not.toContain('assigned_to')
+      })
+    })
+  })
+
+  // --- Task Files ---
+  describe('getTaskFiles', () => {
+    it('fetches files for a task', async () => {
+      if (isLive) return
+      await verifyApi(() => getTaskFiles('task-1'), [{ id: 'f1', filename: 'test.pdf' }])
+      assertMock(() => {
+        expectMock(mockFetch).toHaveBeenCalledWith(
+          `${API_BASE}/api/trouble/tasks/task-1/files`,
+          expect.objectContaining({ headers: expect.any(Object) }),
+        )
+      })
+    })
+  })
+
+  describe('uploadTaskFile', () => {
+    it('uploads a file to a task', async () => {
+      if (isLive) return
+      const mockData = { id: 'f1', filename: 'test.pdf' }
+      stubOk(mockData)
+      const file = new File(['content'], 'test.pdf', { type: 'application/pdf' })
+      const result = await uploadTaskFile('task-1', file)
+      expect(result).toEqual(mockData)
+      const [url, opts] = mockFetch.mock.calls[0]
+      expect(url).toBe(`${API_BASE}/api/trouble/tasks/task-1/files`)
+      expect(opts.method).toBe('POST')
+      expect(opts.body).toBeInstanceOf(FormData)
+    })
+  })
+
+  describe('downloadTaskFile', () => {
+    it('triggers task file download', async () => {
+      if (isLive) return
+      const blobUrl = 'blob:http://localhost/fake'
+      const clickMock = vi.fn()
+      const createElementSpy = vi.spyOn(document, 'createElement').mockReturnValue({
+        href: '', download: '', click: clickMock,
+      } as unknown as HTMLElement)
+      const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue(blobUrl)
+      const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['data'])),
+        headers: new Headers({ 'Content-Disposition': 'attachment; filename="task.pdf"' }),
+      })
+      await downloadTaskFile('f1')
+      expect(clickMock).toHaveBeenCalled()
+      const [url] = mockFetch.mock.calls[0]
+      expect(url).toBe(`${API_BASE}/api/trouble/task-files/f1/download`)
+      expect(revokeObjectURLSpy).toHaveBeenCalledWith(blobUrl)
+
+      createElementSpy.mockRestore()
+      createObjectURLSpy.mockRestore()
+      revokeObjectURLSpy.mockRestore()
+    })
+
+    it('falls back to "download" filename without Content-Disposition', async () => {
+      if (isLive) return
+      const clickMock = vi.fn()
+      const anchor = { href: '', download: '', click: clickMock }
+      const createElementSpy = vi.spyOn(document, 'createElement')
+        .mockReturnValue(anchor as unknown as HTMLElement)
+      const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:x')
+      const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['data'])),
+        headers: new Headers(),
+      })
+      await downloadTaskFile('f1')
+      expect(anchor.download).toBe('download')
+
+      createElementSpy.mockRestore()
+      createObjectURLSpy.mockRestore()
+      revokeObjectURLSpy.mockRestore()
+    })
+
+    it('throws on non-ok response', async () => {
+      if (isLive) return
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 404 })
+      await expect(downloadTaskFile('f1')).rejects.toThrow('ダウンロード失敗: 404')
+    })
+  })
+
+  describe('deleteTaskFile', () => {
+    it('deletes a task file', async () => {
+      if (isLive) return
+      await verifyApi(() => deleteTaskFile('f1'), {}, { expect204: true })
+      assertMock(() => {
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/api/trouble/task-files/f1`)
+        expect(opts.method).toBe('DELETE')
+      })
+    })
+  })
+
+  describe('restoreTaskFile', () => {
+    it('restores a task file', async () => {
+      if (isLive) return
+      await verifyApi(() => restoreTaskFile('f1'), {}, { expect204: true })
+      assertMock(() => {
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/api/trouble/files/f1/restore`)
+        expect(opts.method).toBe('POST')
+      })
+    })
+  })
+})


### PR DESCRIPTION
## 概要

PR #137 で coverage_100 gate を再武装した結果露呈した、vacuous 期間中の回帰 5 file のテストを補強し、lines 100% を再達成して `coverage_100.toml` に再登録する。

## 変更内容

| file | before | 補強した経路 |
|---|---|---|
| `app/composables/useAppInit.ts` | 81.81% | onUnauthorized callback (clearAuth + `/login` 遷移) |
| `app/composables/useTicketDetail.ts` | 97.95% | `displayValue('occurred_at')` の formatOccurredAt 経路 |
| `app/composables/useTicketList.ts` | 91.66% | `fetchMasterData` (成功 / per-call fallback) / `officeOptions` / `progressOptions` / `person_is_external` payload |
| `app/composables/useTicketNew.ts` | 92.85% | occurred_at 入力時の `occurred_at` / `occurred_date` payload |
| `app/utils/api.ts` | 61.31% | progress-statuses / files (blob/trash/restore) / notification-prefs / lineworks members / schedules / task-types / task-statuses / tasks / listAllTasks / task-files の全 32 関数 (`tests/utils/api-phase4.test.ts` 新設) |

- `coverage_100.toml` に上記 5 file を再登録 (計 7 file、全て lines 100% 実測済み)
- 新規テストは live (integration) モードでは skip し、gate 計測の mock モード (`test` job) でのみ走る。progress-statuses の CRUD のみ live dance あり

## 検証

```
$ npm run test:coverage   # 269 tests passed
$ node scripts/check_coverage_100.mjs
All 7 files at 100% lines (0 also checked branches).
```

Refs #138

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhkgxKWTehmnLWqffude3z)_