### PR TITLE
ci: add cap-catalog extract workflow

### DIFF
--- a/.github/workflows/cap-catalog-extract.yml
+++ b/.github/workflows/cap-catalog-extract.yml
@@ -1,0 +1,13 @@
+name: cap-catalog extract
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  extract:
+    uses: ippoan/ci-workflows/.github/workflows/catalog-extract.yml@main
+    with:
+      language: ts


### PR DESCRIPTION
## Summary

`.github/workflows/cap-catalog-extract.yml` を追加し catalog-extract reusable を呼ぶ。`language: ts`。

Refs #140
Refs ippoan/cap-catalog#29

---
_Generated by [Claude Code](https://claude.ai/code/session_017nhvYbgAG11YRxMeSzDwmz)_