### PR TITLE
fix(auth): @ippoan/auth-client を ^0.2.65 に bump (cookie 配布 login 復旧)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@internationalized/date": "^3.12.1",
-    "@ippoan/auth-client": "^0.2.55",
+    "@ippoan/auth-client": "^0.2.65",
     "@nuxt/ui": "^4.5.1",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "frappe-gantt": "^1.2.2",


### PR DESCRIPTION
## 背景

`ippoan/auth-worker#284` で auth-worker が `.ippoan.org` 宛のログイン callback を **token を URL fragment に載せず `logi_auth_token` cookie だけで配布**するようになった。これにより `/auth/callback` の `@ippoan/auth-client` `AuthCallback`(旧版 = `consumeFragment()` のみ)が token を拾えず、**`trouble.ippoan.org` の login が失敗**していた。

`ippoan/auth-worker#285` で `AuthCallback` を cookie/storage 復元に対応させ、`@ippoan/auth-client@0.2.65` として publish 済み。

## 変更

`@ippoan/auth-client` を `^0.2.55` → `^0.2.65` に bump。`install_command: 'npm install'` なので lockfile pin を超えて manifest に追従解決する。

## 反映

- PR merge → **staging** に deploy
- **本番 `trouble.ippoan.org` は tag release** で反映

Refs ippoan/auth-worker#285

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M997qVMYMSCWrYGizcPT19)_