### PR TITLE
chore(deps): @ippoan/auth-client を ^0.2.75 stable に repin (rust-alc-api#434)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@internationalized/date": "^3.12.1",
-    "@ippoan/auth-client": "dev",
+    "@ippoan/auth-client": "^0.2.75",
     "@nuxt/ui": "^4.5.1",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "frappe-gantt": "^1.2.2",


### PR DESCRIPTION
## 概要

`@ippoan/auth-client` を `"dev"` → `"^0.2.75"`(stable) に repin。**prod(v\* tag) build は stable release**、**staging(PR/main push) は `use_auth_client_dev` が `@dev` を overlay** する二系統運用に揃える。

main(push) で dev overlay が走らず、lockfile pin の古い dev（[npm/cli#7562](https://github.com/npm/cli/issues/7562)）が入って typecheck/vitest が赤になっていた問題を解消する。

- 本 repin 単体でも main push は stable 0.2.75（exports あり）を入れて緑化。
- ippoan/auth-worker#305（use-auth-client-dev を tag 以外で overlay）が merge されると staging が dev overlay に切替 → 「staging=dev / prod=vtag」完成。
- `use_auth_client_dev: true` は維持。

Refs ippoan/rust-alc-api#434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019bihe6n6P8Pds5grZzR4ga)_