### PR TITLE
feat(proxy): createAuthWorkerProxyHandler (方式B) に切替えて SA key を排除

### DIFF
--- a/.claude/skills/nuxt-trouble-map/SKILL.md
+++ b/.claude/skills/nuxt-trouble-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nuxt-trouble-map
-generated-from: nuxt-trouble:5e241507c6f96402e9e47106fdc978841f89ba07
+generated-from: nuxt-trouble:cae92b8901a7194bf26ec913db5baf72fa9fdf29
 paths: [app/, server/]
 description: ippoan/nuxt-trouble (トラブル/状況管理 Nuxt 4 アプリ / Cloudflare Workers) の構造ナビゲーション。rust-alc-api `/api/troubles` を叩くチケット・タスク・ワークフロー管理 SPA。pages/composables/utils と ts-rs 生成型の配置、/api/proxy identity proxy、2 対応者フィールドの罠を 1 枚にまとめる。トリガー:「nuxt-trouble」「トラブル管理」「状況管理」「チケット」「trouble_tasks」「assigned_to」「next_action_by」「ワークフロー」「ガントチャート」「trouble.ippoan.org」「/api/proxy」等。
 ---
@@ -9,8 +9,9 @@ description: ippoan/nuxt-trouble (トラブル/状況管理 Nuxt 4 アプリ / C
 
 トラブル (状況) 管理アプリ。Nuxt 4 (`app/` ディレクトリ構成) + Cloudflare Workers。
 rust-alc-api の `/api/troubles` 系を叩く SPA。フロントは `app/utils/api.ts` を
-**同一 Worker の `/api/proxy/*` server route 経由**で叩き、proxy が auth-worker
-introspect で identity (tenant + user) を注入する (#434 step 2)。
+**同一 Worker の `/api/proxy/*` server route 経由**で叩き、proxy は auth-worker
+`/alc-proxy/*` に service binding で thin-forward する (#434 step 3 方式 B)。
+introspect / ACL / OIDC mint / identity (tenant + user) 注入は auth-worker 側。
 
 > ここは索引。細部 (関数シグネチャ・行) は repo 側が正。
 > frontmatter の `generated-from` が現在の tree-sha とズレたら
@@ -24,13 +25,13 @@ introspect で identity (tenant + user) を注入する (#434 step 2)。
 | **composables** | `useTicketList.ts` `useTicketDetail.ts` `useTicketNew.ts` `useTaskStatuses.ts` `useCarInspections.ts` `useAppInit.ts` `useAuth.ts` | チケット・タスク・車検証・初期化・認証 |
 | **components** | `Ticket*.vue` (FormFields / TaskList / TaskCard / StatusHistory / StatusTransition / GanttChart / CategoryBadge / CompactOverview / Files) `WorkflowManager.vue` `MasterDataManager.vue` `BulkImportModal.vue` `Ymd(t)Input.vue` | チケット UI / ワークフロー / マスタ / 一括取込 / 日付入力 |
 | **utils** | `app/utils/api.ts` (API client) `datetime.ts` `normalize.ts` `excel-import.ts` `carInspection.ts` | API 呼び出し本体 / 日付 / 正規化 / Excel 取込 |
-| **server (proxy)** | `server/api/proxy/[...path].ts` | `/api/proxy/*` → rust-alc-api。`@ippoan/auth-client/server` の `createIdentityProxyHandler` に委譲し、introspect 検証 → X-Tenant-ID + X-User-* 注入。INTERNAL_SHARED_SECRET (Secrets Store) + AUTH_WORKER service binding を resolve して渡す (#434 step 2) |
+| **server (proxy)** | `server/api/proxy/[...path].ts` | `/api/proxy/*` → auth-worker `/alc-proxy/*` → rust-alc-api。`@ippoan/auth-client/server` の `createAuthWorkerProxyHandler` で AUTH_WORKER service binding に thin-forward (方式 B)。introspect / ACL / OIDC mint / X-Tenant-ID + X-User-* 注入は auth-worker 側。INTERNAL_SHARED_SECRET (Secrets Store) を resolve して consumer proof として渡す。**client path が既に `/api/` を含むため `pathPrefix: '/'`** (二重 /api 防止)。AUTH_WORKER 未設定は 503 (fail-closed) (#434 step 3) |
 | **型 (生成)** | `app/types/generated/*` (Trouble* 系: Ticket/Task/Category/Office/ProgressStatus/Workflow* 等) + `app/types/index.ts` | rust-alc-api models.rs から **ts-rs 自動生成**。手動編集しない |
 | **middleware / layout** | `app/middleware/auth.global.ts` `app/layouts/{default,auth}.vue` | 全ルート認証ガード / レイアウト |
 
 ## entrypoint
 
-- **nitro**: `nuxt.config.ts` → `nitro.preset = "cloudflare_module"`、`main = .output/server/index.mjs` (wrangler.toml)。`server/api/proxy/[...path].ts` で identity proxy を持つ (それ以外は SPA)。
+- **nitro**: `nuxt.config.ts` → `nitro.preset = "cloudflare_module"`、`main = .output/server/index.mjs` (wrangler.toml)。`server/api/proxy/[...path].ts` で auth-worker `/alc-proxy/*` への thin-forward proxy を持つ (それ以外は SPA)。
 - **API base**: ブラウザは `/api/proxy` (相対 = 同一 Worker server route) を基点に fetch (`useAppInit.ts` が `initApi('/api/proxy', ...)`)。proxy が `runtimeConfig.alcApiUrl` (= `NUXT_ALC_API_URL`) の rust-alc-api に forward。`runtimeConfig.public.apiBase` (= `NUXT_PUBLIC_API_BASE`) は StagingFooter の export/import 用に残る。
 - **wrangler**: top-level = prod (`nuxt-trouble`, trouble.ippoan.org)。`[env.staging]` = `nuxt-trouble-staging` (trouble-staging.ippoan.org)。
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@internationalized/date": "^3.12.1",
-    "@ippoan/auth-client": "^0.2.75",
+    "@ippoan/auth-client": "dev",
     "@nuxt/ui": "^4.5.1",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "frappe-gantt": "^1.2.2",

--- a/server/api/proxy/[...path].ts
+++ b/server/api/proxy/[...path].ts
@@ -1,21 +1,17 @@
 /**
  * REST API プロキシ
- * /api/proxy/* → rust-alc-api の /api/* に転送
+ * /api/proxy/* → auth-worker /alc-proxy/* → rust-alc-api の /api/*
  *
- * #434 step 2: introspect 検証 → X-Tenant-ID + X-User-ID/Email/Role 注入を
- * @ippoan/auth-client/server の createIdentityProxyHandler に集約。旧
- * createApiProxyHandler + requireAuth (= X-Tenant-ID のみ注入) を置換する。
- * rust-alc-api は #441 で JWT 検証を撤去し注入 identity を信頼する dumb backend
- * になったため、X-User-* を載せないと require_tenant_header が AuthUser を
- * 復元できず AuthUser 必須 handler が 500 になる。createIdentityProxyHandler は
- * introspect 結果から X-User-* も載せてこれを解消する。
- *
- * introspect は AUTH_WORKER service binding (worker-to-worker, in-process) で
- * 叩くので外部 req を増やさない。INTERNAL_SHARED_SECRET は Secrets Store
- * binding (.get()) のため route 側で resolve してから渡す。
+ * #434 step 3 (方式 B): introspect / ACL / OIDC mint / identity 注入を
+ * auth-worker `/alc-proxy/*` に集約し、consumer は createAuthWorkerProxyHandler で
+ * service binding (AUTH_WORKER) に thin-forward するだけ。旧 createIdentityProxyHandler
+ * (方式 A) を置換。consumer は X-Alc-Proxy-Secret (=INTERNAL_SHARED_SECRET、consumer
+ * proof) + X-Alc-Proxy-Origin + browser JWT のみ載せる。auth-worker (#308) が
+ * X-Alc-Proxy-Secret を constant-time 検証してから JWT 検証 + ACL + OIDC mint +
+ * X-Tenant-ID/X-User-* 注入を行う。AUTH_WORKER は方式 B で必須 (未設定は 503)。
  */
 import type { H3Event } from 'h3'
-import { createIdentityProxyHandler } from '@ippoan/auth-client/server'
+import { createAuthWorkerProxyHandler } from '@ippoan/auth-client/server'
 
 function cfEnv(event: H3Event): Record<string, unknown> {
   return (event.context.cloudflare as { env?: Record<string, unknown> } | undefined)?.env ?? {}
@@ -39,25 +35,19 @@ export default defineEventHandler(async (event) => {
       statusMessage: 'INTERNAL_SHARED_SECRET binding が未設定です',
     })
   }
-  const authWorkerUrl =
-    typeof env.NUXT_PUBLIC_AUTH_WORKER_URL === 'string' && env.NUXT_PUBLIC_AUTH_WORKER_URL
-      ? env.NUXT_PUBLIC_AUTH_WORKER_URL
-      : 'https://auth.ippoan.org'
   const authWorker = env.AUTH_WORKER as { fetch: typeof fetch } | undefined
+  if (!authWorker) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: 'AUTH_WORKER service binding が未設定です',
+    })
+  }
 
-  const proxy = createIdentityProxyHandler({
-    backendUrl: (e) =>
-      (useRuntimeConfig(e).alcApiUrl as string) ||
-      'https://rust-alc-api-747065218280.asia-northeast1.run.app',
-    authWorkerUrl,
+  const proxy = createAuthWorkerProxyHandler({
     sharedSecret,
-    // app/utils/api.ts の request path が `/api/trouble/...` と **`/api/` を含む**
-    // ため、default pathPrefix='/api/' だと backend/api/api/trouble/... の二重 /api
-    // で 404 になる。pathPrefix='/' にして backend/api/trouble/... に正す
-    // (nuxt-dtako-admin / nuxt-items#35 と同方針)。
+    authWorkerFetch: () => authWorker.fetch.bind(authWorker),
+    // client の path が既に /api/trouble/... を含むため pathPrefix='/' (二重 /api 防止)。
     pathPrefix: '/',
-    // AUTH_WORKER service binding 経由で introspect (worker-to-worker, in-process)。
-    introspectFetch: authWorker ? () => authWorker.fetch.bind(authWorker) : undefined,
   })
   return proxy(event)
 })

--- a/tests/server/proxy.test.ts
+++ b/tests/server/proxy.test.ts
@@ -1,69 +1,67 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-// 転送 + introspect 検証 + identity 注入の本体は @ippoan/auth-client/server の
-// createIdentityProxyHandler に集約 (#434 step 2)。挙動テスト (introspect /
-// X-Tenant-ID + X-User-* 注入 / binary・JSON 分類) は lib 側 (auth-worker)。
-// ここでは本 repo の server route の wiring だけ固定する:
+// 転送 + introspect 検証 + identity 注入の本体は auth-worker `/alc-proxy/*` に
+// 集約され (#434 step 3 方式 B)、consumer は @ippoan/auth-client/server の
+// createAuthWorkerProxyHandler で service binding (AUTH_WORKER) に thin-forward
+// するだけ。挙動テスト (JWT 検証 / ACL / OIDC mint / X-Tenant-ID + X-User-* 注入)
+// は auth-worker 側。ここでは本 repo の server route の wiring だけ固定する:
 //   1. INTERNAL_SHARED_SECRET binding を resolve して渡す (未設定は throw)
-//   2. AUTH_WORKER service binding / authWorkerUrl / backendUrl を解決して委譲
-//   3. createIdentityProxyHandler の戻り値で proxy(event) を返す
+//   2. AUTH_WORKER service binding を解決して authWorkerFetch に渡す (未設定は throw)
+//   3. pathPrefix='/' を渡す (client path が既に /api/ を含むため二重 /api 防止)
+//   4. createAuthWorkerProxyHandler の戻り値で proxy(event) を返す
 //
 // 本 repo は @nuxt/test-utils 環境で、route の bare auto-import
-// (defineEventHandler / createError / useRuntimeConfig) は **実 nuxt/h3 が解決
-// される** (globalThis stub も #imports mock も実体に負ける)。よって:
+// (defineEventHandler / createError) は **実 nuxt/h3 が解決される**
+// (globalThis stub も #imports mock も実体に負ける)。よって:
 //   - createError は実 h3 でそのまま throw させ rejects.toThrow で検証
-//     (statusCode の内部検証は実体に委ねる)
-//   - useRuntimeConfig を呼ぶ backendUrl closure は invoke しない
-//     (`[nuxt] instance unavailable` を避ける。関数として渡ることだけ確認)
-// lib (createIdentityProxyHandler) のみ mock して wiring を見る。
+// lib (createAuthWorkerProxyHandler) のみ mock して wiring を見る。
 
-const { proxyFn, createIdentityProxyHandlerMock } = vi.hoisted(() => {
+const { proxyFn, createAuthWorkerProxyHandlerMock } = vi.hoisted(() => {
   const proxyFn = vi.fn(() => 'PROXY_RESULT')
   // route 直 import 時に top-level の defineEventHandler(...) を解決させるため
-  // globalThis に注入 (module import より前に走る hoisted)。createError /
-  // useRuntimeConfig は request 時呼び出しで実 nuxt/h3 が解決されるため stub しない。
+  // globalThis に注入 (module import より前に走る hoisted)。createError は
+  // request 時呼び出しで実 nuxt/h3 が解決されるため stub しない。
   ;(globalThis as Record<string, unknown>).defineEventHandler = (fn: unknown) => fn
   return {
     proxyFn,
-    createIdentityProxyHandlerMock: vi.fn((_opts: unknown) => proxyFn),
+    createAuthWorkerProxyHandlerMock: vi.fn((_opts: unknown) => proxyFn),
   }
 })
 
 vi.mock('@ippoan/auth-client/server', () => ({
-  createIdentityProxyHandler: createIdentityProxyHandlerMock,
+  createAuthWorkerProxyHandler: createAuthWorkerProxyHandlerMock,
 }))
 
 import handler from '../../server/api/proxy/[...path]'
 
 interface ProxyWiring {
-  backendUrl: (event: unknown) => string
-  authWorkerUrl: string
   sharedSecret: string
+  authWorkerFetch: (event: unknown) => typeof fetch
+  pathPrefix: string
 }
 
 const call = (event: unknown) => (handler as unknown as (e: unknown) => Promise<unknown>)(event)
 const eventWith = (env: Record<string, unknown>) => ({ context: { cloudflare: { env } } })
 
-describe('proxy handler wiring (createIdentityProxyHandler, #434)', () => {
+describe('proxy handler wiring (createAuthWorkerProxyHandler, #434 方式B)', () => {
   beforeEach(() => {
-    createIdentityProxyHandlerMock.mockClear()
+    createAuthWorkerProxyHandlerMock.mockClear()
     proxyFn.mockClear()
   })
 
-  it('INTERNAL_SHARED_SECRET があれば委譲し proxy(event) を返す', async () => {
+  it('INTERNAL_SHARED_SECRET + AUTH_WORKER があれば委譲し proxy(event) を返す', async () => {
     const event = eventWith({
       INTERNAL_SHARED_SECRET: 'secret-x',
-      NUXT_PUBLIC_AUTH_WORKER_URL: 'https://auth-test.example.com',
       AUTH_WORKER: { fetch: vi.fn() },
     })
     const res = await call(event)
-    expect(createIdentityProxyHandlerMock).toHaveBeenCalledTimes(1)
-    const opts = createIdentityProxyHandlerMock.mock.calls[0]![0] as ProxyWiring
+    expect(createAuthWorkerProxyHandlerMock).toHaveBeenCalledTimes(1)
+    const opts = createAuthWorkerProxyHandlerMock.mock.calls[0]![0] as ProxyWiring
     expect(opts.sharedSecret).toBe('secret-x')
-    expect(opts.authWorkerUrl).toBe('https://auth-test.example.com')
-    // backendUrl は関数として渡る (中身は useRuntimeConfig 解決 = 実 nuxt 依存
-    // なので invoke しない)。
-    expect(typeof opts.backendUrl).toBe('function')
+    // pathPrefix='/' (client path が既に /api/ を含むため二重 /api 防止)
+    expect(opts.pathPrefix).toBe('/')
+    // authWorkerFetch は service binding を返す関数として渡る
+    expect(typeof opts.authWorkerFetch).toBe('function')
     expect(proxyFn).toHaveBeenCalledWith(event)
     expect(res).toBe('PROXY_RESULT')
   })
@@ -74,19 +72,19 @@ describe('proxy handler wiring (createIdentityProxyHandler, #434)', () => {
       AUTH_WORKER: { fetch: vi.fn() },
     })
     await call(event)
-    const opts = createIdentityProxyHandlerMock.mock.calls[0]![0] as ProxyWiring
+    const opts = createAuthWorkerProxyHandlerMock.mock.calls[0]![0] as ProxyWiring
     expect(opts.sharedSecret).toBe('from-store')
   })
 
   it('INTERNAL_SHARED_SECRET 未設定なら委譲せず throw する', async () => {
     // 実 h3 createError が 503 を throw する。委譲には到達しない。
-    await expect(call(eventWith({}))).rejects.toThrow()
-    expect(createIdentityProxyHandlerMock).not.toHaveBeenCalled()
+    await expect(call(eventWith({ AUTH_WORKER: { fetch: vi.fn() } }))).rejects.toThrow()
+    expect(createAuthWorkerProxyHandlerMock).not.toHaveBeenCalled()
   })
 
-  it('NUXT_PUBLIC_AUTH_WORKER_URL 未設定なら本番 auth-worker にフォールバック', async () => {
-    await call(eventWith({ INTERNAL_SHARED_SECRET: 'x' }))
-    const opts = createIdentityProxyHandlerMock.mock.calls[0]![0] as ProxyWiring
-    expect(opts.authWorkerUrl).toBe('https://auth.ippoan.org')
+  it('AUTH_WORKER service binding 未設定なら委譲せず throw する', async () => {
+    // 方式 B では AUTH_WORKER 経由 forward が必須 (fail-closed)。
+    await expect(call(eventWith({ INTERNAL_SHARED_SECRET: 'x' }))).rejects.toThrow()
+    expect(createAuthWorkerProxyHandlerMock).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## 概要

ippoan/rust-alc-api#434 step 3 の consumer 横展開。`server/api/proxy/[...path].ts` の proxy 方式を **方式 A (`createIdentityProxyHandler`) → 方式 B (`createAuthWorkerProxyHandler`)** に切替える。carins (merged) と同型。

方式 B では introspect / ACL / OIDC mint / identity 注入をすべて auth-worker `/alc-proxy/*` に集約し、consumer は service binding (`AUTH_WORKER`) に thin-forward するだけになる。これにより consumer から Cloud Run `run.invoker` SA key を排除し、方式変更を auth-worker 1 repo に閉じ込める。

consumer が付けるのは `X-Alc-Proxy-Secret` (= `INTERNAL_SHARED_SECRET`、consumer proof) + `X-Alc-Proxy-Origin` + browser JWT のみ。auth-worker (#308) が `X-Alc-Proxy-Secret` を constant-time 検証してから JWT 検証 + ACL + OIDC mint + `X-Tenant-ID` / `X-User-*` 注入を行う。

## 変更点

- `server/api/proxy/[...path].ts`: `createAuthWorkerProxyHandler` に切替。`AUTH_WORKER` 未設定は 503 (fail-closed)。**この repo は client の path が既に `/api/trouble/...` を含むため `pathPrefix: '/'`** を渡す (default `/api/` だと二重 /api で 404)。
- `tests/server/proxy.test.ts`: 方式 B 用に書換え。`createAuthWorkerProxyHandler` の mock に対し `sharedSecret` / `authWorkerFetch` / `pathPrefix: '/'` が渡ること、`INTERNAL_SHARED_SECRET` 未設定 → 503、`AUTH_WORKER` 未設定 → 503 を assert。
- `package.json`: `@ippoan/auth-client` を `dev` dist-tag に。
- `.claude/skills/nuxt-trouble-map/SKILL.md`: proxy 説明を方式 B に更新 + `generated-from` bump。

## ローカル検証

`@ippoan/auth-client` を local `file:` link に差し替えて `npx vitest run tests/server/proxy.test.ts` → **4 passed**。lockfile は commit しない。

Refs ippoan/rust-alc-api#434

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoQNRaoDQ1NqMB8bHPMzjK)_