### PR TITLE
fix(deps): @ippoan/auth-client を stable ^0.2.78 に pin (Refs ippoan/rust-alc-api#434)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@internationalized/date": "^3.12.1",
-    "@ippoan/auth-client": "dev",
+    "@ippoan/auth-client": "^0.2.78",
     "@nuxt/ui": "^4.5.1",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "frappe-gantt": "^1.2.2",


### PR DESCRIPTION
## 不具合

prod tag release が `Type Check` で全滅:
```
error TS2307: Cannot find module '@ippoan/auth-client/server'
```

## 原因

`use-auth-client-dev` action(main 済み)は **非 tag では `@dev` を overlay / `v*` tag(prod)では overlay せず package.json の stable pin を使う**設計。consumer が `"@ippoan/auth-client": "dev"` 固定だったため、prod tag ビルドで stable pin が無く、stale lockfile で `/server` export を持たない古版が入って typecheck が落ちていた。

## 修正

`package.json` の `@ippoan/auth-client` を `"dev"` → `"^0.2.78"`(`createAuthWorkerProxyHandler` 収録の stable)に。

- **staging(PR/main)**: action が `@dev` を overlay → dev チャネルのまま
- **prod(`v*` tag)**: overlay 無し → この stable pin を使用

= staging=dev / prod=v タグ(stable) の自動分岐が成立。

Refs ippoan/rust-alc-api#434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoQNRaoDQ1NqMB8bHPMzjK)_