### PR TITLE
fix(ci): pin vue-tsc to ^2.2.0 to fix Type Check failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@vue/test-utils": "^2.4.6",
     "happy-dom": "^20.8.9",
     "typescript": "^5.9.3",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.2",
+    "vue-tsc": "^2.2.0"
   }
 }


### PR DESCRIPTION
## 概要

CI の `Type Check` ジョブが `TS2322` で失敗していた ([run 28515526140](https://github.com/ippoan/nuxt-trouble/actions/runs/28515526140))。

## 原因

`npx nuxi typecheck` は `vue-tsc` を devDependency に持たないため、npx が毎回最新 (`vue-tsc@3.3.6`) を取得していた (ログ: `The following package was not found and will be installed: vue-tsc@3.3.6`)。

vue-tsc 3.3.x は inline の `@click` 代入ハンドラ (例: `@click="showBulkImport = true"`) を「`(event) => boolean` は `void | Promise<void>` に代入不可」として新たに弾くようになり、18 箇所で `TS2322` が発生していた。

CI ログには Node 24 も出ているが、これは根本原因ではなく、決定要因は vue-tsc のバージョン。

## 修正

`vue-tsc: ^2.2.0` を devDependencies に pin (ippoan/nuxt-egov と同じ known-good 構成)。これで `npx nuxi typecheck` が再現可能な既知バージョンをローカルの node_modules から使い、最新版の勝手な取得を防ぐ。

`[no-issue]`


---
_Generated by [Claude Code](https://claude.ai/code/session_01NMt3fcRvRNNeRwCXdWotxd)_