### PR TITLE
fix(auth): recover session from shared cookie to stop /login bounce

### DIFF
--- a/app/composables/useAppInit.ts
+++ b/app/composables/useAppInit.ts
@@ -2,7 +2,8 @@ import { initApi } from '~/utils/api'
 
 export function useAppInit() {
   const config = useRuntimeConfig()
-  const { loadFromStorage, token, isLoading, clearAuth } = useAuth()
+  const { loadFromStorage, recoverFromCookie, isAuthenticated, token, isLoading, clearAuth } =
+    useAuth()
   const apiBase = config.public.apiBase as string
   const stagingTenantId = (config.public.stagingTenantId as string) || ''
 
@@ -21,7 +22,14 @@ export function useAppInit() {
         navigateTo('/login')
       },
     )
+    // localStorage から復元 → 未認証なら共有 cookie (Domain=.ippoan.org の
+    // logi_auth_token) から復旧する。トップページや他アプリで既にログイン済みの
+    // 場合に、trouble へ遷移しただけで /login にバウンスするのを防ぐ
+    // (initAuthSession の step 2 + 2.5 相当、Refs ippoan/auth-worker#257)。
     loadFromStorage()
+    if (!isAuthenticated.value) {
+      recoverFromCookie()
+    }
   }
 
   return { apiBase, stagingTenantId, isLoading, setup }

--- a/tests/composables/useAppInit.test.ts
+++ b/tests/composables/useAppInit.test.ts
@@ -1,18 +1,24 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
+import { ref } from 'vue'
+
 const initApiMock = vi.fn()
 const loadFromStorageMock = vi.fn()
+const recoverFromCookieMock = vi.fn()
 const clearAuthMock = vi.fn()
+// テストごとに認証状態を切り替えられるよう mutable ref を外に持つ
+const isAuthenticatedRef = ref(false)
 
 vi.mock('~/utils/api', () => ({
   initApi: (...args: unknown[]) => initApiMock(...args),
 }))
 
 vi.mock('~/composables/useAuth', () => {
-  const { ref } = require('vue')
   return {
     useAuth: () => ({
       loadFromStorage: loadFromStorageMock,
+      recoverFromCookie: recoverFromCookieMock,
+      isAuthenticated: isAuthenticatedRef,
       clearAuth: clearAuthMock,
       token: ref('test-token'),
       orgId: ref('test-org'),
@@ -41,7 +47,9 @@ describe('useAppInit', () => {
   beforeEach(() => {
     initApiMock.mockReset()
     loadFromStorageMock.mockReset()
+    recoverFromCookieMock.mockReset()
     clearAuthMock.mockReset()
+    isAuthenticatedRef.value = false
   })
 
   it('returns apiBase and stagingTenantId from config', () => {
@@ -67,6 +75,20 @@ describe('useAppInit', () => {
 
     const tokenGetter = initApiMock.mock.calls[0][1]
     expect(tokenGetter()).toBe('test-token')
+  })
+
+  it('setup recovers from shared cookie when not authenticated (top からの遷移で /login バウンス防止)', async () => {
+    isAuthenticatedRef.value = false
+    const { setup } = useAppInit()
+    await setup()
+    expect(recoverFromCookieMock).toHaveBeenCalled()
+  })
+
+  it('setup skips cookie recovery when already authenticated (localStorage で復元済み)', async () => {
+    isAuthenticatedRef.value = true
+    const { setup } = useAppInit()
+    await setup()
+    expect(recoverFromCookieMock).not.toHaveBeenCalled()
   })
 
   it('returns isLoading ref', () => {


### PR DESCRIPTION
## 概要

auth.ippoan.org のランチャー（トップ）でログイン済みの状態から「トラブル管理」タイルを押すと、trouble 側が自前の `/login` にバウンスしていた問題を修正。

## 原因

`app/composables/useAppInit.ts` の `setup()` が `loadFromStorage()`（localStorage）だけを呼び、`recoverFromCookie()`（共有 `logi_auth_token` cookie, `Domain=.ippoan.org`）を呼んでいなかった。localStorage は origin ごとに独立するため、trouble へ初めて遷移した時点では空 → `authMiddleware` が未認証と判定 → `/login` へバウンスしていた。

他のランチャーアプリ（nuxt-pwa-carins / nuxt-items / nuxt-dtako-admin / nuxt_dtako_logs / nuxt-notify 等）は `initAuthSession()`（内部で `recoverFromCookie()` を実行）を使っており、この復旧を行っている。trouble だけがこの経路を欠いていた。

## 修正

`loadFromStorage()` の後、未認証なら `recoverFromCookie()` を呼んで共有 cookie から session を復旧する（`initAuthSession()` の step 2 + 2.5 相当）。既存 `useAppInit` の構造を保った最小変更。

- `app/composables/useAppInit.ts`: `recoverFromCookie` / `isAuthenticated` を追加取得し、未認証時に cookie 復旧
- `tests/composables/useAppInit.test.ts`: mock に `recoverFromCookie` / `isAuthenticated` を追加し、認証済み/未認証の両分岐を検証

Refs ippoan/auth-worker#257

`[no-issue]`

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMt3fcRvRNNeRwCXdWotxd)_