### PR TITLE
feat(tickets): staging限定のダミーチケット生成ボタンを追加 (Refs #152)

### DIFF
--- a/app/composables/useDummySeed.ts
+++ b/app/composables/useDummySeed.ts
@@ -1,0 +1,148 @@
+import {
+  getWorkflowStates, setupDefaultWorkflow, getWorkflowTransitions,
+  getCategories, getOffices, getTaskTypes,
+  createTicket, updateTicket, transitionTicket, createTask,
+} from '~/utils/api'
+import { TICKET_CATEGORIES, DEFAULT_TASK_TYPES } from '~/types'
+import type { CreateTroubleTicket, TroubleWorkflowState, TroubleWorkflowTransition } from '~/types'
+
+// staging 用ダミーチケット生成 (rust-alc-api 側の変更は不要、既存 REST API を
+// ループで叩くだけ)。rust-alc-api staging はアイドル時に DB が揮発するため、
+// UI から都度呼び直せる形にしてある (Refs #391 系の staging 揮発性メモ)。
+
+const COMPANIES = ['大石運輸', '北海運送', '一番星物流', '扇興運輸', '丸和運送']
+const OFFICES = ['本社営業所', '札幌営業所', '仙台営業所', '福岡営業所']
+const DEPARTMENTS = ['第一運行課', '第二運行課', '配送課']
+const PERSONS = ['田中太郎', '佐藤花子', '鈴木一郎', '高橋次郎', '伊藤三郎', '渡辺四郎']
+const LOCATIONS = ['国道1号線', '東名高速道路', '営業所構内', '得意先駐車場', '交差点付近']
+const DESCRIPTIONS = [
+  'バック中に電柱と接触し、車両左後部を損傷した。',
+  '交差点で対向車と接触した。双方軽傷。',
+  '荷降ろし中に商品を落下させ、破損させた。',
+  '駐車場内で他社車両とこすれ、双方に傷がついた。',
+  '積み込み中の不備について得意先からクレームを受けた。',
+]
+const PROGRESS_NOTES = ['対応中', '保険会社連絡済み', '示談交渉中', '完了報告待ち', '調査中']
+const COUNTERPARTIES = ['', '相手方個人', '相手方運送会社', '得意先']
+const TASK_TITLES = ['現場確認', '保険会社への連絡', '相手方との示談交渉', '再発防止策の検討', '始末書提出']
+
+function pick<T>(items: readonly T[]): T {
+  return items[Math.floor(Math.random() * items.length)] as T
+}
+
+function randomInt(min: number, max: number): number {
+  return min + Math.floor(Math.random() * (max - min + 1))
+}
+
+function randomPastDate(maxDaysAgo: number): { occurred_at: string; occurred_date: string } {
+  const now = new Date()
+  const daysAgo = randomInt(0, maxDaysAgo)
+  const d = new Date(now.getTime() - daysAgo * 24 * 60 * 60 * 1000)
+  d.setHours(randomInt(6, 20), pick([0, 15, 30, 45]), 0, 0)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return {
+    occurred_at: d.toISOString(),
+    occurred_date: `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`,
+  }
+}
+
+function buildDummyTicket(categoryNames: string[], officeNames: string[]): CreateTroubleTicket {
+  const { occurred_at, occurred_date } = randomPastDate(120)
+  const hasMoney = Math.random() < 0.6
+  const counterparty = pick(COUNTERPARTIES)
+  return {
+    category: pick(categoryNames),
+    occurred_at,
+    occurred_date,
+    company_name: pick(COMPANIES),
+    office_name: pick(officeNames),
+    department: pick(DEPARTMENTS),
+    person_name: pick(PERSONS),
+    location: pick(LOCATIONS),
+    description: pick(DESCRIPTIONS),
+    damage_amount: hasMoney ? randomInt(1, 50) * 10000 : null,
+    compensation_amount: hasMoney && Math.random() < 0.5 ? randomInt(1, 30) * 10000 : null,
+    counterparty: counterparty || null,
+    counterparty_insurance: counterparty ? pick(['あいおいニッセイ同和', '東京海上日動', '損保ジャパン', '']) || null : null,
+  }
+}
+
+/** 初期状態から遷移グラフをランダムに 0〜2 ホック辿ってステータスにばらつきを持たせる */
+async function randomizeStatus(
+  ticketId: string,
+  states: TroubleWorkflowState[],
+  transitions: TroubleWorkflowTransition[],
+): Promise<void> {
+  const initial = states.find(s => s.is_initial)
+  if (!initial) return
+  let currentId = initial.id
+  const hops = randomInt(0, 2)
+  for (let i = 0; i < hops; i++) {
+    const candidates = transitions.filter(t => t.from_state_id === currentId)
+    if (candidates.length === 0) break
+    const next = pick(candidates)
+    await transitionTicket(ticketId, { to_state_id: next.to_state_id, comment: null })
+    currentId = next.to_state_id
+  }
+}
+
+async function addDummyTasks(ticketId: string, taskTypes: string[]): Promise<void> {
+  const count = randomInt(0, 2)
+  for (let i = 0; i < count; i++) {
+    const { occurred_at } = randomPastDate(30)
+    await createTask(ticketId, {
+      task_type: pick(taskTypes),
+      title: pick(TASK_TITLES),
+      description: '',
+      next_action: '',
+      next_action_detail: '',
+      due_date: null,
+      occurred_at,
+      assigned_to: null,
+      next_action_by: pick(PERSONS),
+    })
+  }
+}
+
+export function useDummySeed() {
+  const seeding = ref(false)
+  const progress = ref({ done: 0, total: 0 })
+  const error = ref<string | null>(null)
+
+  async function seedDummyTickets(count: number): Promise<void> {
+    if (seeding.value || count <= 0) return
+    seeding.value = true
+    error.value = null
+    progress.value = { done: 0, total: count }
+    try {
+      let states = await getWorkflowStates().catch(() => [] as TroubleWorkflowState[])
+      if (states.length === 0) {
+        states = await setupDefaultWorkflow()
+      }
+      const transitions = await getWorkflowTransitions().catch(() => [] as TroubleWorkflowTransition[])
+      const categories = await getCategories().catch(() => [])
+      const offices = await getOffices().catch(() => [])
+      const taskTypes = await getTaskTypes().catch(() => [])
+
+      const categoryNames = categories.length > 0 ? categories.map(c => c.name) : [...TICKET_CATEGORIES]
+      const officeNames = offices.length > 0 ? offices.map(o => o.name) : OFFICES
+      const taskTypeNames = taskTypes.length > 0 ? taskTypes.map(t => t.name) : [...DEFAULT_TASK_TYPES]
+
+      for (let i = 0; i < count; i++) {
+        const ticket = await createTicket(buildDummyTicket(categoryNames, officeNames))
+        if (Math.random() < 0.7) {
+          await updateTicket(ticket.id, { progress_notes: pick(PROGRESS_NOTES) })
+        }
+        await randomizeStatus(ticket.id, states, transitions)
+        await addDummyTasks(ticket.id, taskTypeNames)
+        progress.value = { done: i + 1, total: count }
+      }
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'ダミーチケットの生成に失敗しました'
+    } finally {
+      seeding.value = false
+    }
+  }
+
+  return { seeding, progress, error, seedDummyTickets }
+}

--- a/app/pages/tickets/index.vue
+++ b/app/pages/tickets/index.vue
@@ -29,6 +29,17 @@ function handleBulkImportDone() {
   fetchTickets()
 }
 
+// staging 限定のダミーチケット生成 (rust-alc-api staging は揮発性のため都度呼び直せる形にしてある)
+const config = useRuntimeConfig()
+const isStaging = (config.public.apiBase as string).includes('staging')
+const dummySeedCount = ref('20')
+const { seeding: dummySeeding, progress: dummySeedProgress, error: dummySeedError, seedDummyTickets } = useDummySeed()
+
+async function handleSeedDummy() {
+  await seedDummyTickets(Number(dummySeedCount.value) || 20)
+  await fetchTickets()
+}
+
 // 保存中チケットID set（Enter + blur 重複発火を防ぐため in-flight 判定も兼ねる）
 const savingRegistrationIds = reactive(new Set<string>())
 
@@ -82,6 +93,24 @@ watch(() => ({ ...filter }), () => { fetchTickets() }, { deep: true })
         <UButton label="CSV出力" icon="i-lucide-download" variant="outline" size="sm" @click="handleExportCsv" />
         <UButton label="一括登録" icon="i-lucide-upload" variant="outline" size="sm" @click="showBulkImport = true" />
       </div>
+    </div>
+
+    <!-- Dummy seed: staging only -->
+    <div v-if="isStaging" class="flex items-center gap-2 rounded-lg border border-dashed border-yellow-400 bg-yellow-50 dark:bg-yellow-950/30 px-3 py-2 text-sm">
+      <span class="font-medium text-yellow-800 dark:text-yellow-300">STAGING</span>
+      <UInput v-model="dummySeedCount" type="number" size="sm" class="w-20" />
+      <UButton
+        label="ダミーチケット生成"
+        icon="i-lucide-sparkles"
+        size="sm"
+        variant="outline"
+        :loading="dummySeeding"
+        @click="handleSeedDummy"
+      />
+      <span v-if="dummySeeding" class="text-yellow-700 dark:text-yellow-400">
+        生成中... {{ dummySeedProgress.done }}/{{ dummySeedProgress.total }}
+      </span>
+      <span v-if="dummySeedError" class="text-red-600">{{ dummySeedError }}</span>
     </div>
 
     <!-- Filters: single row -->

--- a/tests/composables/useDummySeed.test.ts
+++ b/tests/composables/useDummySeed.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const getWorkflowStatesMock = vi.fn()
+const setupDefaultWorkflowMock = vi.fn()
+const getWorkflowTransitionsMock = vi.fn()
+const getCategoriesMock = vi.fn()
+const getOfficesMock = vi.fn()
+const getTaskTypesMock = vi.fn()
+const createTicketMock = vi.fn()
+const updateTicketMock = vi.fn()
+const transitionTicketMock = vi.fn()
+const createTaskMock = vi.fn()
+
+vi.mock('~/utils/api', async (importOriginal) => ({
+  ...(await importOriginal()),
+  getWorkflowStates: (...args: unknown[]) => getWorkflowStatesMock(...args),
+  setupDefaultWorkflow: (...args: unknown[]) => setupDefaultWorkflowMock(...args),
+  getWorkflowTransitions: (...args: unknown[]) => getWorkflowTransitionsMock(...args),
+  getCategories: (...args: unknown[]) => getCategoriesMock(...args),
+  getOffices: (...args: unknown[]) => getOfficesMock(...args),
+  getTaskTypes: (...args: unknown[]) => getTaskTypesMock(...args),
+  createTicket: (...args: unknown[]) => createTicketMock(...args),
+  updateTicket: (...args: unknown[]) => updateTicketMock(...args),
+  transitionTicket: (...args: unknown[]) => transitionTicketMock(...args),
+  createTask: (...args: unknown[]) => createTaskMock(...args),
+}))
+
+import { useDummySeed } from '~/composables/useDummySeed'
+
+const STATES = [
+  { id: 's1', tenant_id: 't', name: '新規', label: '新規', color: '#3B82F6', sort_order: 0, is_initial: true, is_terminal: false, created_at: '' },
+  { id: 's2', tenant_id: 't', name: '対応中', label: '対応中', color: '#F59E0B', sort_order: 1, is_initial: false, is_terminal: false, created_at: '' },
+]
+
+const TRANSITIONS = [
+  { id: 'tr1', tenant_id: 't', from_state_id: 's1', to_state_id: 's2', label: '対応開始', created_at: '' },
+]
+
+function resetMocks() {
+  getWorkflowStatesMock.mockReset()
+  setupDefaultWorkflowMock.mockReset()
+  getWorkflowTransitionsMock.mockReset()
+  getCategoriesMock.mockReset()
+  getOfficesMock.mockReset()
+  getTaskTypesMock.mockReset()
+  createTicketMock.mockReset()
+  updateTicketMock.mockReset()
+  transitionTicketMock.mockReset()
+  createTaskMock.mockReset()
+
+  getWorkflowStatesMock.mockResolvedValue(STATES)
+  getWorkflowTransitionsMock.mockResolvedValue(TRANSITIONS)
+  getCategoriesMock.mockResolvedValue([{ id: 'c1', tenant_id: 't', name: '貨物事故', sort_order: 0, created_at: '' }])
+  getOfficesMock.mockResolvedValue([{ id: 'o1', tenant_id: 't', name: 'テスト営業所', sort_order: 0, created_at: '' }])
+  getTaskTypesMock.mockResolvedValue([{ id: 'tt1', tenant_id: 't', name: 'テスト種別', sort_order: 0, created_at: '' }])
+  createTicketMock.mockImplementation(async () => ({ id: `ticket-${createTicketMock.mock.calls.length}` }))
+  updateTicketMock.mockResolvedValue({})
+  transitionTicketMock.mockResolvedValue(undefined)
+  createTaskMock.mockResolvedValue({ id: 'task-1' })
+}
+
+describe('useDummySeed', () => {
+  let randomSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    resetMocks()
+  })
+
+  afterEach(() => {
+    randomSpy?.mockRestore()
+  })
+
+  it('does nothing when count is 0', async () => {
+    const { seedDummyTickets } = useDummySeed()
+    await seedDummyTickets(0)
+    expect(createTicketMock).not.toHaveBeenCalled()
+  })
+
+  it('creates the requested number of tickets using existing workflow/master data', async () => {
+    randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0)
+    const { seeding, progress, error, seedDummyTickets } = useDummySeed()
+
+    await seedDummyTickets(2)
+
+    expect(setupDefaultWorkflowMock).not.toHaveBeenCalled()
+    expect(createTicketMock).toHaveBeenCalledTimes(2)
+    const payload = createTicketMock.mock.calls[0]![0]
+    expect(payload.category).toBe('貨物事故')
+    expect(payload.office_name).toBe('テスト営業所')
+    expect(seeding.value).toBe(false)
+    expect(error.value).toBeNull()
+    expect(progress.value).toEqual({ done: 2, total: 2 })
+    // Math.random() = 0 -> hops = 0 / task count = 0 -> no transition/task calls
+    expect(transitionTicketMock).not.toHaveBeenCalled()
+    expect(createTaskMock).not.toHaveBeenCalled()
+    // Math.random() < 0.7 branch (progress_notes) is taken
+    expect(updateTicketMock).toHaveBeenCalledWith('ticket-1', { progress_notes: expect.any(String) })
+  })
+
+  it('sets up the default workflow when none exists', async () => {
+    randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0)
+    getWorkflowStatesMock.mockResolvedValueOnce([])
+    setupDefaultWorkflowMock.mockResolvedValue(STATES)
+
+    const { seedDummyTickets } = useDummySeed()
+    await seedDummyTickets(1)
+
+    expect(setupDefaultWorkflowMock).toHaveBeenCalled()
+    expect(createTicketMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to built-in category/office/task-type names when masters are empty', async () => {
+    randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0)
+    getCategoriesMock.mockResolvedValue([])
+    getOfficesMock.mockResolvedValue([])
+    getTaskTypesMock.mockResolvedValue([])
+
+    const { seedDummyTickets } = useDummySeed()
+    await seedDummyTickets(1)
+
+    const payload = createTicketMock.mock.calls[0]![0]
+    expect(payload.category).toBe('苦情・トラブル')
+    expect(payload.office_name).toBe('本社営業所')
+  })
+
+  it('walks the transition graph and adds tasks when random hops/counts are high', async () => {
+    randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.99)
+    const { seedDummyTickets } = useDummySeed()
+
+    await seedDummyTickets(1)
+
+    // Only one edge (s1 -> s2) exists in TRANSITIONS, so the walk stops after 1 hop
+    // even though the random hop count resolves to 2.
+    expect(transitionTicketMock).toHaveBeenCalledTimes(1)
+    expect(transitionTicketMock).toHaveBeenCalledWith('ticket-1', { to_state_id: 's2', comment: null })
+    expect(createTaskMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops the transition walk when the current state has no outgoing edges', async () => {
+    randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.99)
+    getWorkflowTransitionsMock.mockResolvedValue([])
+
+    const { seedDummyTickets } = useDummySeed()
+    await seedDummyTickets(1)
+
+    expect(transitionTicketMock).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when there is no initial workflow state', async () => {
+    randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.99)
+    getWorkflowStatesMock.mockResolvedValue([{ ...STATES[0], is_initial: false }])
+
+    const { seedDummyTickets } = useDummySeed()
+    await seedDummyTickets(1)
+
+    expect(transitionTicketMock).not.toHaveBeenCalled()
+  })
+
+  it('records the error and resets seeding state on failure', async () => {
+    randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0)
+    createTicketMock.mockRejectedValueOnce(new Error('boom'))
+
+    const { seeding, error, seedDummyTickets } = useDummySeed()
+    await seedDummyTickets(1)
+
+    expect(error.value).toBe('boom')
+    expect(seeding.value).toBe(false)
+  })
+
+  it('records a fallback error message for non-Error rejections', async () => {
+    randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0)
+    createTicketMock.mockRejectedValueOnce('nope')
+
+    const { error, seedDummyTickets } = useDummySeed()
+    await seedDummyTickets(1)
+
+    expect(error.value).toBe('ダミーチケットの生成に失敗しました')
+  })
+
+  it('ignores concurrent calls while already seeding', async () => {
+    randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0)
+    const { seedDummyTickets } = useDummySeed()
+
+    // `seeding.value = true` is set synchronously before the first `await`
+    // inside seedDummyTickets, so a second call issued right after the first
+    // (still in the same synchronous tick) is guaranteed to see it and no-op.
+    const first = seedDummyTickets(1)
+    const second = seedDummyTickets(1)
+    await Promise.all([first, second])
+
+    expect(createTicketMock).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

- `/tickets` 一覧に staging 限定 (`NUXT_PUBLIC_API_BASE` に `staging` を含む場合のみ表示) の「ダミーチケット生成」UI を追加
- 新規 `useDummySeed` composable が既存の `createTicket` / `updateTicket` / `transitionTicket` / `createTask` API をループで叩いてダミーデータを投入する。rust-alc-api 側の変更は不要
- カテゴリ・営業所・タスク種別・ワークフロー状態は既存マスタがあればそれを使い、無ければ組み込みのフォールバック値を使う (`setupDefaultWorkflow` も未設定なら自動実行)
- 生成されるチケットはカテゴリ・会社名・営業所・発生日時・金額・相手方・ステータス(ワークフローの遷移グラフをランダムに辿る)・状況管理タスクにばらつきを持たせている
- rust-alc-api staging は アイドル時に DB が揮発するため、ボタンから都度シードし直せる

Refs #152

## Test plan

- [x] `npx nuxi typecheck` — pass
- [x] `npx vitest run` — 285 テスト全て pass (新規 `useDummySeed.test.ts` 10 件含む、既存分の回帰なし)
- [ ] staging (`trouble-staging.ippoan.org`) で実際にボタンを押し、ダミーチケットが一覧に反映されることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01H9c9UEeap5rQfdYdR3niZX)_