### PR TITLE
fix(tickets): 印刷プレビューの余白に出る黒塗りを解消 (Refs #154)

### DIFF
--- a/app/pages/tickets/print/[id].vue
+++ b/app/pages/tickets/print/[id].vue
@@ -87,7 +87,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="min-h-screen bg-gray-100 print:bg-white">
+  <div class="min-h-screen print:min-h-0 bg-gray-100 print:bg-white">
     <!-- Toolbar: screen only -->
     <div class="print:hidden sticky top-0 z-10 flex items-center justify-between gap-3 border-b border-gray-200 bg-white px-4 py-3 shadow-sm">
       <span class="text-sm text-gray-500">印刷プレビュー{{ ticket ? ` — No.${ticket.ticket_no}` : '' }}</span>
@@ -279,11 +279,26 @@ onMounted(() => {
 
 <style>
 /* 印刷時の用紙設定。都度印刷 (Ctrl+P / 印刷ボタン) の度に同じページ割りを再現するため
-   ページ区切りは要素の style/class 側 (break-after-page) にも重複指定してある。 */
+   ページ区切りは要素の style/class 側 (break-after-page) にも重複指定してある。
+   ダークモード時、鏡/詳細情報の実コンテンツ末尾より紙面が余ると @nuxt/ui の
+   --ui-bg (ダークモードでは neutral-900 = ほぼ黒) が html/body の背景として
+   透けて見え、印刷結果の余白部分が黒く出てしまう。print 時はライトモードの
+   背景で強制的に上書きする。 */
 @media print {
   @page {
     size: A4;
     margin: 15mm;
+  }
+  html, body {
+    background: #ffffff !important;
+    color: #000000 !important;
+  }
+  :root, .dark {
+    --ui-bg: #ffffff !important;
+    --ui-bg-muted: #ffffff !important;
+    --ui-bg-elevated: #ffffff !important;
+    --ui-bg-accented: #ffffff !important;
+    color-scheme: light !important;
   }
 }
 </style>


### PR DESCRIPTION
## Summary

- `/tickets/print/:id` をダークモードで印刷すると、鏡→詳細情報のページ区切り
  以降でコンテンツが用紙を満たしきらない場合に、余白部分が黒塗りになっていた
  (`@nuxt/ui` の `--ui-bg` = ダークモードでは `neutral-900` ≒ 黒 が html/body の
  背景として透けていたため)
- `@media print` で html/body の背景色・文字色と `--ui-bg` 系 CSS variable を
  白/黒に強制上書きし、外側ラッパーの `min-h-screen` も print 時のみ無効化した
- 最小再現 HTML を Playwright + PyMuPDF で PDF 化して before/after を比較し、
  黒塗りが解消することを確認済み

Refs #154

## Test plan

- [x] `npx nuxi typecheck` — pass
- [x] `npx vitest run` — 285 テスト全て pass (回帰なし)
- [x] 最小再現 HTML (鏡 ページ区切り + 短い詳細情報 + dark 背景) を Playwright で
      PDF 化し、修正前は黒塗り・修正後は白になることを画像で確認
- [ ] staging の実チケットで実際に印刷し、目視で黒塗りが出ないことを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01H9c9UEeap5rQfdYdR3niZX)_