### PR TITLE
feat(tickets): 印刷プレビューを鏡/詳細情報の2ページとして画面表示 (Refs #156)

### DIFF
--- a/app/pages/tickets/print/[id].vue
+++ b/app/pages/tickets/print/[id].vue
@@ -105,9 +105,15 @@ onMounted(() => {
       {{ error || 'チケットが見つかりません' }}
     </div>
 
-    <div v-else class="mx-auto max-w-[210mm] bg-white text-black print:max-w-none">
+    <!-- 画面プレビューでも「鏡」「詳細情報」がそれぞれ1ページ分の紙として見えるよう、
+         各 section を A4 相当のカードとして分けて表示する (印刷時は影/角丸/余白を消し、
+         break-after-page によるページ区切りだけが残る)。 -->
+    <div v-else class="px-4 py-6 print:p-0">
       <!-- ============ 鏡 (サマリー) ============ -->
-      <section class="print-sheet px-10 py-10 break-after-page" style="page-break-after: always;">
+      <section
+        class="print-sheet mx-auto mb-8 min-h-[297mm] max-w-[210mm] rounded-lg bg-white px-10 py-10 text-black shadow-lg break-after-page print:mb-0 print:min-h-0 print:max-w-none print:rounded-none print:shadow-none"
+        style="page-break-after: always;"
+      >
         <div class="flex items-start justify-between border-b-2 border-black pb-3">
           <h1 class="text-2xl font-bold tracking-wide">トラブル報告書（鏡）</h1>
           <div class="text-right text-xs text-gray-600">
@@ -170,7 +176,9 @@ onMounted(() => {
       </section>
 
       <!-- ============ 詳細情報 ============ -->
-      <section class="print-sheet px-10 py-10">
+      <section
+        class="print-sheet mx-auto min-h-[297mm] max-w-[210mm] rounded-lg bg-white px-10 py-10 text-black shadow-lg print:min-h-0 print:max-w-none print:rounded-none print:shadow-none"
+      >
         <div class="flex items-center justify-between border-b-2 border-black pb-3">
           <h2 class="text-xl font-bold tracking-wide">詳細情報</h2>
           <div class="text-right text-xs text-gray-600">No.{{ ticket.ticket_no }}（{{ ticket.category }}）</div>


### PR DESCRIPTION
## Summary

- `/tickets/print/:id` の画面プレビューが1枚の連続領域に見え、印刷結果 (鏡→詳細情報の2ページ) と見た目が乖離していた
- 鏡・詳細情報それぞれの `<section>` を A4 相当のカード (影・角丸・ページ間の余白) として画面表示し、印刷結果と同じ2ページ構成であることが見た目で分かるようにした
- 印刷時はカード演出 (影・角丸・余白・強制 min-height) を `print:` variant で無効化し、既存の `break-after-page` によるページ区切りのみが残るようにした (#155 の黒塗り修正で入れた `min-h-0`/背景上書きと組み合わせても副作用がないことを再現 HTML で確認済み)

Refs #156

## Test plan

- [x] `npx nuxi typecheck` — pass
- [x] `npx vitest run` — 285 テスト全て pass (回帰なし)
- [x] 再現 HTML (同じ class 構成) を Playwright でスクリーンショット・PDF化し、画面は2枚のカード、印刷は黒塗りなしの2ページになることを画像で確認
- [ ] staging の実チケットで画面表示・印刷結果の両方を目視確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01H9c9UEeap5rQfdYdR3niZX)_