### PR TITLE
feat(tickets): 印刷の詳細テーブルを鏡(1ページ目)に移動 (Refs #158)

### DIFF
--- a/app/pages/tickets/print/[id].vue
+++ b/app/pages/tickets/print/[id].vue
@@ -173,18 +173,8 @@ onMounted(() => {
           <div class="mb-1 text-sm font-medium">進捗状況</div>
           <div class="border border-gray-400 p-3 text-sm">{{ displayValue(ticket.progress_notes) }}</div>
         </div>
-      </section>
 
-      <!-- ============ 詳細情報 ============ -->
-      <section
-        class="print-sheet mx-auto min-h-[297mm] max-w-[210mm] rounded-lg bg-white px-10 py-10 text-black shadow-lg print:min-h-0 print:max-w-none print:rounded-none print:shadow-none"
-      >
-        <div class="flex items-center justify-between border-b-2 border-black pb-3">
-          <h2 class="text-xl font-bold tracking-wide">詳細情報</h2>
-          <div class="text-right text-xs text-gray-600">No.{{ ticket.ticket_no }}（{{ ticket.category }}）</div>
-        </div>
-
-        <table class="mt-4 w-full border-collapse text-sm">
+        <table class="mt-6 w-full border-collapse text-sm">
           <tbody>
             <tr class="border-t border-b border-gray-400">
               <th class="w-40 border-r border-gray-400 bg-gray-50 px-3 py-2 text-left font-medium">損害額</th>
@@ -224,6 +214,16 @@ onMounted(() => {
             </tr>
           </tbody>
         </table>
+      </section>
+
+      <!-- ============ 詳細情報 ============ -->
+      <section
+        class="print-sheet mx-auto min-h-[297mm] max-w-[210mm] rounded-lg bg-white px-10 py-10 text-black shadow-lg print:min-h-0 print:max-w-none print:rounded-none print:shadow-none"
+      >
+        <div class="flex items-center justify-between border-b-2 border-black pb-3">
+          <h2 class="text-xl font-bold tracking-wide">詳細情報</h2>
+          <div class="text-right text-xs text-gray-600">No.{{ ticket.ticket_no }}（{{ ticket.category }}）</div>
+        </div>
 
         <!-- 状況管理 (タスク) -->
         <div class="mt-8">


### PR DESCRIPTION
## Summary

- `/tickets/print/:id` の詳細情報(2ページ目)にあった損害額/賠償額/ロードサービス費用/手当等/相手/相手保険会社/確認書/対応期限/処分検討内容/処分内容/作成日/更新日のテーブルを鏡(1ページ目)に移動
- 詳細情報(2ページ目)は状況管理(タスク一覧)とステータス履歴のみになる

Refs #158

## Test plan

- [x] `npx nuxi typecheck` — pass
- [x] `npx vitest run` — 285 テスト全て pass (回帰なし)
- [ ] staging の実チケットで画面表示・印刷結果を目視確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01H9c9UEeap5rQfdYdR3niZX)_