### PR TITLE
fix(tickets): 改ページ設定行に画面上でも分かる目印を追加 (Refs #166)

### DIFF
--- a/app/pages/tickets/print/[id].vue
+++ b/app/pages/tickets/print/[id].vue
@@ -274,6 +274,7 @@ onMounted(() => {
                 v-for="t in tasks"
                 :key="t.id"
                 class="break-inside-avoid"
+                :class="t.print_page_break_before ? 'border-t-4 border-t-emerald-500 print:border-t print:border-t-gray-400' : ''"
                 :style="t.print_page_break_before ? { breakBefore: 'page', pageBreakBefore: 'always' } : undefined"
               >
                 <td class="border border-gray-400 px-2 py-1 align-top">{{ t.task_type }}</td>


### PR DESCRIPTION
## Summary

- 改ページ (`break-before: page`) は印刷/PDF化時にしか視覚効果が出ないCSSプロパティのため、状況管理の「改ページ」ボタンを押しても画面上は何も変わらず「効いていない」ように見えていた
- 該当行に太い緑の上罫線を追加し、画面上でも設定状態が一目で分かるようにした（印刷時は控えめな細線に切り替え）
- 併せて Playwright + PyMuPDF で再現 HTML を検証: 先頭行以外に `break-before:page` を指定した場合は正しく2ページに分割されることを確認（先頭行に指定した場合のみ、直前にコンテンツが無く見た目上ページが分かれないという別の既知の挙動も確認済み）

Refs #166

## Test plan

- [x] `npx nuxi typecheck` — pass
- [x] `npx vitest run` — 285 テスト全て pass (回帰なし)
- [x] 再現 HTML で `tr` の `border-top` が `border-collapse` テーブルでも正しく描画されることを確認
- [ ] staging の実チケットで、改ページトグルONの行に画面上で目印が出て、印刷結果もその行から改ページされることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01H9c9UEeap5rQfdYdR3niZX)_