### PR TITLE
feat(tickets): チケット詳細の展開表示をinline自動保存フォームに変更 [no-issue]

### DIFF
--- a/app/components/TicketCompactOverview.vue
+++ b/app/components/TicketCompactOverview.vue
@@ -1,13 +1,17 @@
 <script setup lang="ts">
-import type { TroubleTicket, TroubleWorkflowState } from '~/types'
+import type { TroubleTicket, TroubleWorkflowState, TroubleCategory, TroubleOffice, TroubleProgressStatus, Employee, UpdateTroubleTicket } from '~/types'
 import { updateTicket } from '~/utils/api'
 import { toHalfWidth } from '~/utils/normalize'
-import { formatOccurredAt } from '~/utils/datetime'
+import { formatOccurredAt, toDatetimeLocalInput, fromDatetimeLocalInput } from '~/utils/datetime'
 import { formatExpiry, getExpiryStatus } from '~/utils/carInspection'
 
 const props = defineProps<{
   ticket: TroubleTicket
   workflowStates: TroubleWorkflowState[]
+  categories?: TroubleCategory[]
+  offices?: TroubleOffice[]
+  progressStatuses?: TroubleProgressStatus[]
+  employees?: Employee[]
 }>()
 
 const emit = defineEmits<{
@@ -107,34 +111,68 @@ const counterpartyLine = computed(() => {
   return line
 })
 
-const fields: Array<{ label: string; key: string }> = [
-  { label: 'カテゴリ', key: 'category' },
-  { label: 'タイトル', key: 'title' },
-  { label: '説明', key: 'description' },
-  { label: '発生日時', key: 'occurred_at' },
-  { label: '会社名', key: 'company_name' },
-  { label: '営業所名', key: 'office_name' },
-  { label: '部署名', key: 'department' },
-  { label: '氏名', key: 'person_name' },
-  { label: '登録番号', key: 'registration_number' },
-  { label: '場所', key: 'location' },
-  { label: '損害額', key: 'damage_amount' },
-  { label: '補償額', key: 'compensation_amount' },
-  { label: 'ロードサービス費', key: 'road_service_cost' },
-  { label: '相手方', key: 'counterparty' },
-  { label: '相手方保険', key: 'counterparty_insurance' },
-  { label: '対応期限', key: 'due_date' },
-]
+// --- Expanded: inline auto-save form (元の編集画面と同じ TicketFormFields を
+// 展開表示に使い、フィールド確定 (blur / select 選択 / 日付確定) のたびに
+// そのフィールドだけ即保存する) ---
+const form = ref<Record<string, unknown>>({})
+const savingField = ref(false)
+const fieldError = ref<string | null>(null)
 
-function displayValue(key: string): string {
-  if (key === 'occurred_at') {
-    return formatOccurredAt(props.ticket.occurred_at, props.ticket.occurred_date)
+function buildFormFromTicket(t: TroubleTicket): Record<string, unknown> {
+  return {
+    category: t.category,
+    title: t.title,
+    description: t.description,
+    occurred_at: toDatetimeLocalInput(t.occurred_at, t.occurred_date),
+    company_name: t.company_name,
+    office_name: t.office_name,
+    department: t.department,
+    person_name: t.person_name,
+    person_id: t.person_id,
+    person_is_external: t.person_is_external,
+    registration_number: t.registration_number,
+    location: t.location,
+    progress_notes: t.progress_notes,
+    allowance: t.allowance,
+    damage_amount: t.damage_amount != null ? Number(t.damage_amount) : null,
+    compensation_amount: t.compensation_amount != null ? Number(t.compensation_amount) : null,
+    road_service_cost: t.road_service_cost != null ? Number(t.road_service_cost) : null,
+    counterparty: t.counterparty,
+    counterparty_insurance: t.counterparty_insurance,
+    disciplinary_content: t.disciplinary_content,
+    disciplinary_action: t.disciplinary_action,
+    due_date: t.due_date,
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const val = (props.ticket as any)[key]
-  if (val == null || val === '') return '-'
-  if (key === 'due_date') return String(val).substring(0, 10)
-  return String(val)
+}
+
+watch(
+  () => props.ticket,
+  (t) => { form.value = buildFormFromTicket(t) },
+  { immediate: true },
+)
+
+async function handleFieldCommitted(keys: string[]) {
+  if (savingField.value) return
+  const payload: Record<string, unknown> = {}
+  for (const key of keys) {
+    if (key === 'occurred_at') {
+      const occurred = fromDatetimeLocalInput(form.value.occurred_at as string | undefined)
+      if (occurred) Object.assign(payload, occurred)
+      continue
+    }
+    payload[key] = form.value[key]
+  }
+  if (Object.keys(payload).length === 0) return
+  savingField.value = true
+  fieldError.value = null
+  try {
+    const updated = await updateTicket(props.ticket.id, payload as UpdateTroubleTicket)
+    emit('updated', updated)
+  } catch (e) {
+    fieldError.value = e instanceof Error ? e.message : '保存に失敗しました'
+  } finally {
+    savingField.value = false
+  }
 }
 </script>
 
@@ -238,16 +276,19 @@ function displayValue(key: string): string {
       <UIcon :name="expanded ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" class="size-3" />
     </button>
 
-    <!-- Expanded full grid -->
-    <dl v-if="expanded" class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
-      <div v-for="field in fields" :key="field.key" class="space-y-1">
-        <dt class="text-xs text-gray-500 dark:text-gray-400">{{ field.label }}</dt>
-        <dd class="text-sm">{{ displayValue(field.key) }}</dd>
-      </div>
-      <div class="space-y-1">
-        <dt class="text-xs text-gray-500 dark:text-gray-400">作成日</dt>
-        <dd class="text-sm">{{ ticket.created_at.substring(0, 10) }}</dd>
-      </div>
-    </dl>
+    <!-- Expanded: 元の編集画面と同じフォームをそのまま表示し、その場で編集・自動保存する -->
+    <div v-if="expanded" class="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
+      <TicketFormFields
+        v-model="form"
+        mode="edit"
+        :categories="categories"
+        :offices="offices"
+        :progress-statuses="progressStatuses"
+        :employees="employees"
+        @field-committed="handleFieldCommitted"
+      />
+      <p v-if="fieldError" class="text-xs text-red-600 mt-2">{{ fieldError }}</p>
+      <p class="text-xs text-gray-400 mt-3">作成日: {{ ticket.created_at.substring(0, 10) }}</p>
+    </div>
   </div>
 </template>

--- a/app/components/TicketFormFields.vue
+++ b/app/components/TicketFormFields.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { TroubleCategory, TroubleOffice, TroubleProgressStatus, Employee } from '~/types'
-import { TICKET_CATEGORIES } from '~/types'
 import { toHalfWidth } from '~/utils/normalize'
+import { buildCategoryOptions, buildOfficeOptions, buildProgressOptions, buildEmployeeOptions } from '~/utils/ticketFieldOptions'
 
 const model = defineModel<Record<string, unknown>>({ required: true })
 
@@ -12,6 +12,17 @@ const props = defineProps<{
   progressStatuses?: TroubleProgressStatus[]
   employees?: Employee[]
 }>()
+
+// mode === 'edit' で親が listen すると、各フィールド確定時 (select/checkbox/日付は
+// 即時、text/textarea は blur 時) に対象キーを通知する。親はこれを使って
+// フィールド単位で自動保存できる (new.vue のような一括作成フローでは無視すればよい)。
+const commitEmit = defineEmits<{
+  (e: 'field-committed', keys: string[]): void
+}>()
+
+function commit(...keys: string[]) {
+  commitEmit('field-committed', keys)
+}
 
 const {
   load: loadCarInspections,
@@ -33,32 +44,10 @@ function formatExpiry(v: string): string {
   return v.length > 10 ? v.substring(0, 10) : v
 }
 
-const categoryOptions = computed(() => {
-  if (props.categories && props.categories.length > 0) {
-    const dbNames = new Set(props.categories.map(c => c.name))
-    const hardcoded = ([...TICKET_CATEGORIES] as string[]).filter(c => !dbNames.has(c))
-    return [...props.categories.map(c => c.name), ...hardcoded].map(c => ({ label: c, value: c }))
-  }
-  return TICKET_CATEGORIES.map(c => ({ label: c, value: c as string }))
-})
-
-const officeOptions = computed(() => {
-  if (!props.offices || props.offices.length === 0) return []
-  return props.offices.map(o => ({ label: o.name, value: o.name }))
-})
-
-const progressOptions = computed(() => {
-  if (!props.progressStatuses || props.progressStatuses.length === 0) return []
-  return props.progressStatuses.map(p => ({ label: p.name, value: p.name }))
-})
-
-const employeeOptions = computed(() => {
-  if (!props.employees || props.employees.length === 0) return []
-  return props.employees.map(e => ({
-    label: e.code ? `${e.name} (${e.code})` : e.name,
-    value: e.id,
-  }))
-})
+const categoryOptions = computed(() => buildCategoryOptions(props.categories))
+const officeOptions = computed(() => buildOfficeOptions(props.offices))
+const progressOptions = computed(() => buildProgressOptions(props.progressStatuses))
+const employeeOptions = computed(() => buildEmployeeOptions(props.employees))
 
 function update(key: string, value: unknown) {
   model.value = { ...model.value, [key]: value }
@@ -68,6 +57,7 @@ function updateEmployee(employeeId: string) {
   const emp = props.employees?.find(e => e.id === employeeId)
   if (emp) {
     model.value = { ...model.value, person_name: emp.name, person_id: emp.id }
+    commit('person_name', 'person_id')
   }
 }
 
@@ -94,6 +84,7 @@ function toggleExternal(checked: boolean) {
   } else {
     model.value = { ...model.value, person_is_external: false, person_id: null, person_name: '' }
   }
+  commit('person_is_external', 'person_id', 'person_name')
 }
 </script>
 
@@ -108,7 +99,7 @@ function toggleExternal(checked: boolean) {
           :model-value="(model.category as string) || ''"
           :items="categoryOptions"
           placeholder="カテゴリを選択"
-          @update:model-value="update('category', $event)"
+          @update:model-value="update('category', $event); commit('category')"
         />
       </UFormField>
 
@@ -117,6 +108,7 @@ function toggleExternal(checked: boolean) {
           :model-value="(model.title as string) || ''"
           placeholder="タイトル"
           @update:model-value="update('title', $event)"
+          @blur="commit('title')"
         />
       </UFormField>
 
@@ -126,13 +118,14 @@ function toggleExternal(checked: boolean) {
           placeholder="詳細な説明"
           :rows="4"
           @update:model-value="update('description', $event)"
+          @blur="commit('description')"
         />
       </UFormField>
 
       <UFormField label="発生日時">
         <YmdtInput
           :model-value="(model.occurred_at as string) || undefined"
-          @update:model-value="(v: string | undefined) => update('occurred_at', v ?? '')"
+          @update:model-value="(v: string | undefined) => { update('occurred_at', v ?? ''); commit('occurred_at') }"
         />
       </UFormField>
     </fieldset>
@@ -147,6 +140,7 @@ function toggleExternal(checked: boolean) {
             :model-value="(model.company_name as string) || ''"
             placeholder="会社名"
             @update:model-value="update('company_name', $event)"
+            @blur="commit('company_name')"
           />
         </UFormField>
 
@@ -156,7 +150,7 @@ function toggleExternal(checked: boolean) {
             :items="officeOptions"
             placeholder="営業所を選択"
             :disabled="officeOptions.length === 0"
-            @update:model-value="update('office_name', $event)"
+            @update:model-value="update('office_name', $event); commit('office_name')"
           />
         </UFormField>
 
@@ -165,6 +159,7 @@ function toggleExternal(checked: boolean) {
             :model-value="(model.department as string) || ''"
             placeholder="部署名"
             @update:model-value="update('department', $event)"
+            @blur="commit('department')"
           />
         </UFormField>
 
@@ -175,6 +170,7 @@ function toggleExternal(checked: boolean) {
               :model-value="(model.person_name as string) || ''"
               placeholder="外部当事者名（手入力）"
               @update:model-value="update('person_name', $event)"
+              @blur="commit('person_name')"
             />
             <USelect
               v-else
@@ -209,6 +205,7 @@ function toggleExternal(checked: boolean) {
             placeholder="登録番号 (車検証と照合)"
             list="ticket-form-registrations"
             @update:model-value="(v: string | number) => update('registration_number', toHalfWidth(String(v ?? '')))"
+            @blur="commit('registration_number')"
           />
           <datalist id="ticket-form-registrations">
             <option
@@ -224,6 +221,7 @@ function toggleExternal(checked: boolean) {
             :model-value="(model.location as string) || ''"
             placeholder="発生場所"
             @update:model-value="update('location', $event)"
+            @blur="commit('location')"
           />
         </UFormField>
       </div>
@@ -264,7 +262,7 @@ function toggleExternal(checked: boolean) {
             :items="progressOptions"
             placeholder="進捗状況を選択"
             :disabled="progressOptions.length === 0"
-            @update:model-value="update('progress_notes', $event)"
+            @update:model-value="update('progress_notes', $event); commit('progress_notes')"
           />
         </UFormField>
 
@@ -273,6 +271,7 @@ function toggleExternal(checked: boolean) {
             :model-value="(model.allowance as string) || ''"
             placeholder="手当等"
             @update:model-value="update('allowance', $event)"
+            @blur="commit('allowance')"
           />
         </UFormField>
       </div>
@@ -289,6 +288,7 @@ function toggleExternal(checked: boolean) {
             :model-value="String(model.damage_amount ?? '')"
             placeholder="0"
             @update:model-value="update('damage_amount', $event ? Number($event) : null)"
+            @blur="commit('damage_amount')"
           />
         </UFormField>
 
@@ -298,6 +298,7 @@ function toggleExternal(checked: boolean) {
             :model-value="String(model.compensation_amount ?? '')"
             placeholder="0"
             @update:model-value="update('compensation_amount', $event ? Number($event) : null)"
+            @blur="commit('compensation_amount')"
           />
         </UFormField>
 
@@ -307,6 +308,7 @@ function toggleExternal(checked: boolean) {
             :model-value="String(model.road_service_cost ?? '')"
             placeholder="0"
             @update:model-value="update('road_service_cost', $event ? Number($event) : null)"
+            @blur="commit('road_service_cost')"
           />
         </UFormField>
       </div>
@@ -322,6 +324,7 @@ function toggleExternal(checked: boolean) {
             :model-value="(model.counterparty as string) || ''"
             placeholder="相手方"
             @update:model-value="update('counterparty', $event)"
+            @blur="commit('counterparty')"
           />
         </UFormField>
 
@@ -330,6 +333,7 @@ function toggleExternal(checked: boolean) {
             :model-value="(model.counterparty_insurance as string) || ''"
             placeholder="相手方保険"
             @update:model-value="update('counterparty_insurance', $event)"
+            @blur="commit('counterparty_insurance')"
           />
         </UFormField>
       </div>
@@ -346,6 +350,7 @@ function toggleExternal(checked: boolean) {
             placeholder="処分検討内容"
             :rows="2"
             @update:model-value="update('disciplinary_content', $event)"
+            @blur="commit('disciplinary_content')"
           />
         </UFormField>
 
@@ -355,6 +360,7 @@ function toggleExternal(checked: boolean) {
             placeholder="処分内容"
             :rows="2"
             @update:model-value="update('disciplinary_action', $event)"
+            @blur="commit('disciplinary_action')"
           />
         </UFormField>
       </div>
@@ -362,7 +368,7 @@ function toggleExternal(checked: boolean) {
       <UFormField label="対応期限">
         <YmdInput
           :model-value="((model.due_date as string) || '').slice(0, 10) || undefined"
-          @update:model-value="(v: string | undefined) => update('due_date', v ? new Date(v).toISOString() : null)"
+          @update:model-value="(v: string | undefined) => { update('due_date', v ? new Date(v).toISOString() : null); commit('due_date') }"
         />
       </UFormField>
     </fieldset>

--- a/app/composables/useTicketDetail.ts
+++ b/app/composables/useTicketDetail.ts
@@ -1,102 +1,19 @@
-import { getTicket, updateTicket, deleteTicket, getWorkflowStates } from '~/utils/api'
-import type { TroubleTicket, TroubleWorkflowState, UpdateTroubleTicket } from '~/types'
-import { toDatetimeLocalInput, fromDatetimeLocalInput, formatOccurredAt } from '~/utils/datetime'
+import { getTicket, deleteTicket, getWorkflowStates } from '~/utils/api'
+import type { TroubleTicket, TroubleWorkflowState } from '~/types'
 
 export function useTicketDetail(ticketId: string) {
   const router = useRouter()
 
   const ticket = shallowRef<TroubleTicket | null>(null)
   const workflowStates = shallowRef<TroubleWorkflowState[]>([])
-  const editing = ref(false)
-  const saving = ref(false)
   const error = ref<string | null>(null)
   const showDeleteModal = ref(false)
-  const form = ref<Record<string, unknown>>({})
 
   const statusLabel = computed(() => {
     const sid = ticket.value?.status_id
     if (!sid) return undefined
     return workflowStates.value.find(s => s.id === sid)
   })
-
-  const fields: Array<{ label: string; key: string }> = [
-    { label: 'カテゴリ', key: 'category' },
-    { label: 'タイトル', key: 'title' },
-    { label: '説明', key: 'description' },
-    { label: '発生日時', key: 'occurred_at' },
-    { label: '会社名', key: 'company_name' },
-    { label: '営業所名', key: 'office_name' },
-    { label: '部署名', key: 'department' },
-    { label: '氏名', key: 'person_name' },
-    { label: '登録番号', key: 'registration_number' },
-    { label: '場所', key: 'location' },
-    { label: '損害額', key: 'damage_amount' },
-    { label: '補償額', key: 'compensation_amount' },
-    { label: 'ロードサービス費', key: 'road_service_cost' },
-    { label: '相手方', key: 'counterparty' },
-    { label: '相手方保険', key: 'counterparty_insurance' },
-  ]
-
-  function displayValue(key: string): string {
-    if (!ticket.value) return '-'
-    if (key === 'occurred_at') {
-      return formatOccurredAt(ticket.value.occurred_at, ticket.value.occurred_date)
-    }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const val = (ticket.value as any)[key]
-    if (val == null || val === '') return '-'
-    return String(val)
-  }
-
-  function startEdit() {
-    if (!ticket.value) return
-    form.value = {
-      category: ticket.value.category,
-      title: ticket.value.title,
-      description: ticket.value.description,
-      occurred_at: toDatetimeLocalInput(ticket.value.occurred_at, ticket.value.occurred_date),
-      company_name: ticket.value.company_name,
-      office_name: ticket.value.office_name,
-      department: ticket.value.department,
-      person_name: ticket.value.person_name,
-      person_id: ticket.value.person_id,
-      person_is_external: ticket.value.person_is_external,
-      registration_number: ticket.value.registration_number,
-      location: ticket.value.location,
-      damage_amount: ticket.value.damage_amount ? Number(ticket.value.damage_amount) : null,
-      compensation_amount: ticket.value.compensation_amount ? Number(ticket.value.compensation_amount) : null,
-      road_service_cost: ticket.value.road_service_cost ? Number(ticket.value.road_service_cost) : null,
-      counterparty: ticket.value.counterparty,
-      counterparty_insurance: ticket.value.counterparty_insurance,
-      due_date: ticket.value.due_date ? ticket.value.due_date.substring(0, 10) : '',
-    }
-    editing.value = true
-  }
-
-  async function handleSave() {
-    saving.value = true
-    error.value = null
-    try {
-      const data: Record<string, unknown> = {}
-      for (const [key, value] of Object.entries(form.value)) {
-        if (key === 'occurred_at') continue
-        if (value != null && value !== '') {
-          data[key] = value
-        }
-      }
-      const occurred = fromDatetimeLocalInput(form.value.occurred_at as string | undefined)
-      if (occurred) {
-        data.occurred_at = occurred.occurred_at
-        data.occurred_date = occurred.occurred_date
-      }
-      ticket.value = await updateTicket(ticketId, data as UpdateTroubleTicket)
-      editing.value = false
-    } catch (e) {
-      error.value = e instanceof Error ? e.message : '更新に失敗しました'
-    } finally {
-      saving.value = false
-    }
-  }
 
   async function handleDelete() {
     try {
@@ -121,8 +38,8 @@ export function useTicketDetail(ticketId: string) {
   }
 
   return {
-    ticket, workflowStates, editing, saving, error,
-    showDeleteModal, form, statusLabel, fields,
-    displayValue, startEdit, handleSave, handleDelete, load,
+    ticket, workflowStates, statusLabel, error,
+    showDeleteModal,
+    handleDelete, load,
   }
 }

--- a/app/pages/tickets/[id].vue
+++ b/app/pages/tickets/[id].vue
@@ -6,9 +6,8 @@ const route = useRoute()
 const ticketId = route.params.id as string
 
 const {
-  ticket, workflowStates, editing, saving, error,
-  showDeleteModal, form, fields,
-  displayValue, startEdit, handleSave, handleDelete, load,
+  ticket, workflowStates, error,
+  showDeleteModal, handleDelete, load,
 } = useTicketDetail(ticketId)
 
 const categories = ref<TroubleCategory[]>([])
@@ -144,10 +143,7 @@ onMounted(() => {
         </div>
         <div class="flex gap-2">
           <UButton label="印刷" icon="i-lucide-printer" variant="outline" @click="openPrintView" />
-          <template v-if="!editing">
-            <UButton label="編集" icon="i-lucide-pencil" variant="outline" @click="startEdit" />
-            <UButton label="削除" icon="i-lucide-trash-2" variant="outline" color="error" @click="showDeleteModal = true" />
-          </template>
+          <UButton label="削除" icon="i-lucide-trash-2" variant="outline" color="error" @click="showDeleteModal = true" />
         </div>
       </div>
 
@@ -155,25 +151,14 @@ onMounted(() => {
         {{ error }}
       </div>
 
-      <UCard v-if="editing">
-        <TicketFormFields
-          v-model="form"
-          mode="edit"
+      <UCard>
+        <TicketCompactOverview
+          :ticket="ticket"
+          :workflow-states="workflowStates"
           :categories="categories"
           :offices="offices"
           :progress-statuses="progressStatuses"
           :employees="employees"
-        />
-        <div class="flex justify-end gap-2 mt-6">
-          <UButton label="キャンセル" variant="outline" @click="editing = false" />
-          <UButton label="保存" :loading="saving" @click="handleSave" />
-        </div>
-      </UCard>
-
-      <UCard v-else>
-        <TicketCompactOverview
-          :ticket="ticket"
-          :workflow-states="workflowStates"
           @updated="ticket = $event"
         />
       </UCard>

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -43,6 +43,7 @@ export interface UpdateTroubleTicket {
   department?: string | null
   person_name?: string | null
   person_id?: string | null
+  person_is_external?: boolean | null
   registration_number?: string | null
   location?: string | null
   description?: string | null

--- a/app/utils/ticketFieldOptions.ts
+++ b/app/utils/ticketFieldOptions.ts
@@ -1,0 +1,34 @@
+import type { TroubleCategory, TroubleOffice, TroubleProgressStatus, Employee } from '~/types'
+import { TICKET_CATEGORIES } from '~/types'
+
+export interface SelectOption {
+  label: string
+  value: string
+}
+
+export function buildCategoryOptions(categories: TroubleCategory[] | undefined): SelectOption[] {
+  if (categories && categories.length > 0) {
+    const dbNames = new Set(categories.map(c => c.name))
+    const hardcoded = ([...TICKET_CATEGORIES] as string[]).filter(c => !dbNames.has(c))
+    return [...categories.map(c => c.name), ...hardcoded].map(c => ({ label: c, value: c }))
+  }
+  return TICKET_CATEGORIES.map(c => ({ label: c, value: c as string }))
+}
+
+export function buildOfficeOptions(offices: TroubleOffice[] | undefined): SelectOption[] {
+  if (!offices || offices.length === 0) return []
+  return offices.map(o => ({ label: o.name, value: o.name }))
+}
+
+export function buildProgressOptions(progressStatuses: TroubleProgressStatus[] | undefined): SelectOption[] {
+  if (!progressStatuses || progressStatuses.length === 0) return []
+  return progressStatuses.map(p => ({ label: p.name, value: p.name }))
+}
+
+export function buildEmployeeOptions(employees: Employee[] | undefined): SelectOption[] {
+  if (!employees || employees.length === 0) return []
+  return employees.map(e => ({
+    label: e.code ? `${e.name} (${e.code})` : e.name,
+    value: e.id,
+  }))
+}

--- a/tests/components/TicketCompactOverviewInlineEdit.test.ts
+++ b/tests/components/TicketCompactOverviewInlineEdit.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { allStubs } from '../helpers/nuxt-stubs'
+import { makeTroubleTicket } from '../helpers/test-data'
+
+// ----- Mocks -------------------------------------------------------------
+const lookupMock = vi.fn()
+const loadMock = vi.fn().mockResolvedValue(undefined)
+const updateTicketMock = vi.fn()
+
+vi.mock('~/composables/useCarInspections', () => ({
+  useCarInspections: () => ({
+    load: loadMock,
+    lookupByRegistration: lookupMock,
+    registrationOptions: { value: [] },
+  }),
+}))
+
+vi.mock('~/utils/api', () => ({
+  updateTicket: (...args: unknown[]) => updateTicketMock(...args),
+}))
+
+import TicketCompactOverview from '~/components/TicketCompactOverview.vue'
+
+// nuxt-stubs.ts の UInput/UTextarea/USelect は modelValue/placeholder 等を実際の
+// DOM 属性に反映しないため (props 宣言のみで fallthrough しない)、セレクタで要素を
+// 拾えるようこのファイルだけローカルで属性を反映するスタブに差し替える。
+// @blur は emits 宣言しないことで Vue の attribute fallthrough によりそのまま
+// input/textarea 要素の native blur イベントへ伝播する。
+const UInputWithAttrs = {
+  template: '<input :value="modelValue" :placeholder="placeholder" :type="type || \'text\'" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+  props: ['modelValue', 'placeholder', 'type', 'size'],
+  emits: ['update:modelValue'],
+}
+const UTextareaWithAttrs = {
+  template: '<textarea :value="modelValue" :placeholder="placeholder" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+  props: ['modelValue', 'placeholder', 'rows'],
+  emits: ['update:modelValue'],
+}
+const USelectWithOptions = {
+  template: `<select :value="modelValue" @change="$emit('update:modelValue', $event.target.value)">
+    <option v-for="opt in items" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+  </select>`,
+  props: ['modelValue', 'items', 'placeholder', 'size'],
+  emits: ['update:modelValue'],
+}
+
+const stubs = {
+  ...allStubs,
+  UInput: UInputWithAttrs,
+  UTextarea: UTextareaWithAttrs,
+  USelect: USelectWithOptions,
+}
+// TicketFormFields は実体をレンダリングしたいので stub を外す
+delete (stubs as Record<string, unknown>).TicketFormFields
+
+function mountOverview(opts: { ticket?: Parameters<typeof makeTroubleTicket>[0] } = {}) {
+  return mount(TicketCompactOverview, {
+    props: {
+      ticket: makeTroubleTicket(opts.ticket),
+      workflowStates: [],
+      categories: [],
+      offices: [{ id: 'o1', tenant_id: 't1', name: '本社営業所', sort_order: 1, created_at: '' }],
+      progressStatuses: [],
+      employees: [],
+    },
+    global: { stubs },
+  })
+}
+
+async function expandDetail(wrapper: ReturnType<typeof mount>) {
+  const toggle = wrapper.findAll('button').find(b => b.text().includes('詳細を表示'))
+  expect(toggle).toBeTruthy()
+  await toggle!.trigger('click')
+  await flushPromises()
+}
+
+describe('TicketCompactOverview - inline auto-save form (展開表示)', () => {
+  beforeEach(() => {
+    lookupMock.mockReset()
+    lookupMock.mockReturnValue(undefined)
+    loadMock.mockClear()
+    updateTicketMock.mockReset()
+  })
+
+  it('renders the same field groups as the create/edit form when expanded', async () => {
+    const wrapper = mountOverview()
+    await flushPromises()
+    await expandDetail(wrapper)
+
+    expect(wrapper.text()).toContain('基本情報')
+    expect(wrapper.text()).toContain('関係者情報')
+    expect(wrapper.text()).toContain('車両・場所')
+    expect(wrapper.text()).toContain('金額')
+    expect(wrapper.text()).toContain('相手方')
+    expect(wrapper.text()).toContain('管理')
+  })
+
+  it('auto-saves title on blur', async () => {
+    updateTicketMock.mockResolvedValue(makeTroubleTicket({ title: '新タイトル' }))
+    const wrapper = mountOverview()
+    await flushPromises()
+    await expandDetail(wrapper)
+
+    const titleInput = wrapper.find('input[placeholder="タイトル"]')
+    await titleInput.setValue('新タイトル')
+    await titleInput.trigger('blur')
+    await flushPromises()
+
+    expect(updateTicketMock).toHaveBeenCalledWith('ticket-1', { title: '新タイトル' })
+    expect(wrapper.emitted('updated')).toBeTruthy()
+  })
+
+  it('auto-saves category immediately on select change', async () => {
+    updateTicketMock.mockResolvedValue(makeTroubleTicket({ category: '対物事故(自損)' }))
+    const wrapper = mountOverview()
+    await flushPromises()
+    await expandDetail(wrapper)
+
+    const categorySelect = wrapper.findAll('select')[0]!
+    await categorySelect.setValue('対物事故(自損)')
+    await flushPromises()
+
+    expect(updateTicketMock).toHaveBeenCalledWith('ticket-1', { category: '対物事故(自損)' })
+  })
+
+  it('auto-saves damage_amount as a number on blur', async () => {
+    updateTicketMock.mockResolvedValue(makeTroubleTicket({ damage_amount: '20000' }))
+    const wrapper = mountOverview()
+    await flushPromises()
+    await expandDetail(wrapper)
+
+    const damageInput = wrapper.find('input[type="number"]')
+    await damageInput.setValue('20000')
+    await damageInput.trigger('blur')
+    await flushPromises()
+
+    expect(updateTicketMock).toHaveBeenCalledWith('ticket-1', { damage_amount: 20000 })
+  })
+
+  it('auto-saves due_date immediately when the date input resolves', async () => {
+    const expectedIso = new Date('2026-03-01').toISOString()
+    updateTicketMock.mockResolvedValue(makeTroubleTicket({ due_date: expectedIso }))
+    const wrapper = mountOverview()
+    await flushPromises()
+    await expandDetail(wrapper)
+
+    const dueDateInput = wrapper.find('input[data-ymd-input]')
+    await dueDateInput.setValue('2026-03-01')
+    await flushPromises()
+
+    expect(updateTicketMock).toHaveBeenCalledWith('ticket-1', { due_date: expectedIso })
+  })
+
+  it('shows an error message when saving fails', async () => {
+    updateTicketMock.mockRejectedValue(new Error('保存に失敗しました'))
+    const wrapper = mountOverview()
+    await flushPromises()
+    await expandDetail(wrapper)
+
+    const titleInput = wrapper.find('input[placeholder="タイトル"]')
+    await titleInput.setValue('失敗するタイトル')
+    await titleInput.trigger('blur')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('保存に失敗しました')
+    expect(wrapper.emitted('updated')).toBeFalsy()
+  })
+})

--- a/tests/composables/useTicketDetail.test.ts
+++ b/tests/composables/useTicketDetail.test.ts
@@ -5,7 +5,6 @@ import { createTicket, deleteTicket } from '~/utils/api'
 
 const pushMock = vi.fn()
 const getTicketMock = vi.fn()
-const updateTicketMock = vi.fn()
 const deleteTicketMock = vi.fn()
 const getWorkflowStatesMock = vi.fn()
 
@@ -14,7 +13,6 @@ vi.mock('~/utils/api', async (importOriginal) => {
   return {
     ...(await importOriginal()),
     getTicket: (...args: unknown[]) => getTicketMock(...args),
-    updateTicket: (...args: unknown[]) => updateTicketMock(...args),
     deleteTicket: (...args: unknown[]) => deleteTicketMock(...args),
     getWorkflowStates: (...args: unknown[]) => getWorkflowStatesMock(...args),
   }
@@ -37,7 +35,6 @@ describe('useTicketDetail', () => {
     await setupApi()
     pushMock.mockReset()
     getTicketMock.mockReset()
-    updateTicketMock.mockReset()
     deleteTicketMock.mockReset()
     getWorkflowStatesMock.mockReset()
     if (isLive && !liveTicketId) {
@@ -109,109 +106,6 @@ describe('useTicketDetail', () => {
     expect(d.statusLabel.value).toBeUndefined()
   })
 
-  it('displayValue returns value or dash', async () => {
-    if (!isLive) { getTicketMock.mockResolvedValue(ticket); getWorkflowStatesMock.mockResolvedValue([]) }
-    const d = useTicketDetail(tid())
-    await d.load()
-    expect(d.displayValue('category')).toBe('貨物事故')
-  })
-
-  it('displayValue returns dash when ticket is null', () => {
-    expect(useTicketDetail('x').displayValue('category')).toBe('-')
-  })
-
-  it('displayValue formats occurred_at via formatOccurredAt', async () => {
-    if (isLive) return
-    getTicketMock.mockResolvedValue(makeTroubleTicket({ occurred_at: null, occurred_date: '2026-01-15' }))
-    getWorkflowStatesMock.mockResolvedValue([])
-    const d = useTicketDetail('test-id')
-    await d.load()
-    expect(d.displayValue('occurred_at')).toBe('2026-01-15')
-  })
-
-  it('startEdit populates form', async () => {
-    if (!isLive) { getTicketMock.mockResolvedValue(ticket); getWorkflowStatesMock.mockResolvedValue([]) }
-    const d = useTicketDetail(tid())
-    await d.load()
-    d.startEdit()
-    expect(d.editing.value).toBe(true)
-    expect(d.form.value.category).toBe('貨物事故')
-  })
-
-  it('startEdit with null amounts and no due_date', async () => {
-    if (isLive) return
-    getTicketMock.mockResolvedValue(makeTroubleTicket({
-      damage_amount: null, compensation_amount: null, road_service_cost: null,
-      due_date: null, occurred_date: null,
-    }))
-    getWorkflowStatesMock.mockResolvedValue([])
-    const d = useTicketDetail('test-id')
-    await d.load()
-    d.startEdit()
-    expect(d.form.value.damage_amount).toBeNull()
-    expect(d.form.value.due_date).toBe('')
-  })
-
-  it('startEdit does nothing when ticket is null', () => {
-    const d = useTicketDetail('test-id')
-    d.startEdit()
-    expect(d.editing.value).toBe(false)
-  })
-
-  it('handleSave updates ticket', async () => {
-    if (!isLive) {
-      getTicketMock.mockResolvedValue(ticket)
-      getWorkflowStatesMock.mockResolvedValue([])
-      updateTicketMock.mockResolvedValue(makeTroubleTicket({ title: '更新済み' }))
-    }
-    const d = useTicketDetail(tid())
-    await d.load()
-    d.startEdit()
-    d.form.value.title = '更新済み'
-    await d.handleSave()
-    expect(d.editing.value).toBe(false)
-    if (isLive) expect(d.ticket.value!.title).toBe('更新済み')
-  })
-
-  it('handleSave filters empty values', async () => {
-    if (isLive) return
-    getTicketMock.mockResolvedValue(ticket)
-    getWorkflowStatesMock.mockResolvedValue([])
-    updateTicketMock.mockResolvedValue(ticket)
-    const d = useTicketDetail('test-id')
-    await d.load()
-    d.startEdit()
-    d.form.value.title = ''
-    d.form.value.description = null
-    await d.handleSave()
-    const data = updateTicketMock.mock.calls[0][1]
-    expect(data).not.toHaveProperty('title')
-  })
-
-  it('handleSave sets error on Error', async () => {
-    if (isLive) return
-    getTicketMock.mockResolvedValue(ticket)
-    getWorkflowStatesMock.mockResolvedValue([])
-    updateTicketMock.mockRejectedValue(new Error('update failed'))
-    const d = useTicketDetail('test-id')
-    await d.load()
-    d.startEdit()
-    await d.handleSave()
-    expect(d.error.value).toBe('update failed')
-  })
-
-  it('handleSave sets fallback error on non-Error', async () => {
-    if (isLive) return
-    getTicketMock.mockResolvedValue(ticket)
-    getWorkflowStatesMock.mockResolvedValue([])
-    updateTicketMock.mockRejectedValue('str')
-    const d = useTicketDetail('test-id')
-    await d.load()
-    d.startEdit()
-    await d.handleSave()
-    expect(d.error.value).toBe('更新に失敗しました')
-  })
-
   it('handleDelete navigates to /tickets', async () => {
     if (isLive) return
     deleteTicketMock.mockResolvedValue(undefined)
@@ -235,9 +129,5 @@ describe('useTicketDetail', () => {
     const d = useTicketDetail('test-id')
     await d.handleDelete()
     expect(d.error.value).toBe('削除に失敗しました')
-  })
-
-  it('exposes fields array', () => {
-    expect(useTicketDetail('x').fields.length).toBe(15)
   })
 })


### PR DESCRIPTION
## Summary

- チケット詳細画面の「詳細を表示」展開部分を、元の編集フォーム (`TicketFormFields`) と同じ見た目のフォームに変更し、各フィールドをその場で編集・自動保存できるようにした
  - text/textarea 系はフィールドから離れた (blur) タイミングで保存
  - select/checkbox/日付系は選択・確定した瞬間に即保存
- 従来の「編集」ボタン + 一括保存フォーム (別モード) は廃止し、常に展開フォームで直接編集する形に一本化
- category/office/progress/employee の select option 生成ロジックを `app/utils/ticketFieldOptions.ts` に切り出して `TicketFormFields` と共有

## Test plan

- [x] `npx vitest run` — 全280件 green (新規 `TicketCompactOverviewInlineEdit.test.ts` 6件含む)
- [x] `npx nuxi typecheck` — `@ippoan/auth-client` 内の既存無関係エラー (`uqr` 型定義、file: リンク特有の環境問題) のみで、変更前でも同じ状態であることを確認済み
- [ ] staging deploy 後、実際に `/tickets/:id` で「詳細を表示」→各フィールド編集→保存されることを目視確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01E88D6fBJvRsxW24tQFrFCm)_