### PR TITLE
fix(print): ステータス履歴の列幅を table-fixed で確定的に指定 (Refs #172)

### DIFF
--- a/app/pages/tickets/print/[id].vue
+++ b/app/pages/tickets/print/[id].vue
@@ -333,18 +333,18 @@ onMounted(() => {
         <div class="mt-8">
           <h3 class="mb-2 border-b border-black pb-1 text-base font-semibold">ステータス履歴</h3>
           <p v-if="statusHistory.length === 0" class="text-sm text-gray-500">履歴はありません</p>
-          <table v-else class="w-full border-collapse text-xs">
+          <table v-else class="w-full table-fixed border-collapse text-xs">
             <thead>
               <tr class="border-b-2 border-black">
-                <th class="w-px whitespace-nowrap border border-gray-400 px-2 py-1 text-left font-medium">日時</th>
-                <th class="w-px whitespace-nowrap border border-gray-400 px-2 py-1 text-left font-medium">変更</th>
+                <th class="w-36 border border-gray-400 px-2 py-1 text-left font-medium">日時</th>
+                <th class="w-40 border border-gray-400 px-2 py-1 text-left font-medium">変更</th>
                 <th class="border border-gray-400 px-2 py-1 text-left font-medium">コメント</th>
               </tr>
             </thead>
             <tbody>
               <tr v-for="h in statusHistory" :key="h.id" class="break-inside-avoid">
-                <td class="w-px border border-gray-400 px-2 py-1 align-top whitespace-nowrap">{{ formatOccurredAt(h.created_at) }}</td>
-                <td class="w-px border border-gray-400 px-2 py-1 align-top whitespace-nowrap">{{ stateLabel(h.from_state_id) }} → {{ stateLabel(h.to_state_id) }}</td>
+                <td class="w-36 border border-gray-400 px-2 py-1 align-top whitespace-nowrap">{{ formatOccurredAt(h.created_at) }}</td>
+                <td class="w-40 border border-gray-400 px-2 py-1 align-top">{{ stateLabel(h.from_state_id) }} → {{ stateLabel(h.to_state_id) }}</td>
                 <td class="border border-gray-400 px-2 py-1 align-top">{{ h.comment || '-' }}</td>
               </tr>
             </tbody>


### PR DESCRIPTION
## Summary

PR #174 で対応した「日時/変更列を最小幅に」が、実際の staging では反映されて見えないという報告があった。

原因: `w-px` + `whitespace-nowrap` (shrink-to-content トリック) は `table-layout: auto` の
余剰幅配分アルゴリズムに依存しており、ブラウザによっては列に余剰幅が割り振られてしまい
狙い通り縮まらない。

`table-fixed` + 「日時」「変更」列への明示的な固定幅 (`w-36` / `w-40`) に変更し、
「コメント」列だけが残り幅を使う挙動を確定的にした。

Refs #172

## Test plan

- [ ] staging デプロイ後、印刷プレビューのステータス履歴で「日時」「変更」列が狭く、
      「コメント」列が残り幅いっぱいに広がることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01X2c8g1ttR8AhYx6JrSEVCw)_