### PR TITLE
fix(tickets): 相手方車両フィールドを全幅表示に変更 [no-issue]

### DIFF
--- a/app/utils/ticketFieldLayout.ts
+++ b/app/utils/ticketFieldLayout.ts
@@ -44,7 +44,7 @@ export const FIELD_METAS: FieldMeta[] = [
 
   { key: 'counterparty', label: '相手方', section: '相手方', type: 'text', defaultWidth: 'half', defaultVisible: true, defaultSortOrder: 10 },
   { key: 'counterparty_insurance', label: '相手方保険', section: '相手方', type: 'text', defaultWidth: 'half', defaultVisible: true, defaultSortOrder: 20 },
-  { key: 'counterparty_vehicle', label: '相手方車両', section: '相手方', type: 'text', defaultWidth: 'half', defaultVisible: true, defaultSortOrder: 30 },
+  { key: 'counterparty_vehicle', label: '相手方車両', section: '相手方', type: 'text', defaultWidth: 'full', defaultVisible: true, defaultSortOrder: 30 },
 
   { key: 'disciplinary_content', label: '処分検討内容', section: '管理', type: 'textarea', defaultWidth: 'half', defaultVisible: true, defaultSortOrder: 10 },
   { key: 'disciplinary_action', label: '処分内容', section: '管理', type: 'textarea', defaultWidth: 'half', defaultVisible: true, defaultSortOrder: 20 },


### PR DESCRIPTION
## 概要

相手方セクションは半幅フィールドが3つ (相手方 / 相手方保険 / 相手方車両) あり、grid 上で3つ目 (相手方車両) だけが2列レイアウトの端数として単独行になり、右側に大きな空白ができていた。

## 変更点

- `app/utils/ticketFieldLayout.ts` — `counterparty_vehicle` の `defaultWidth` を `half` → `full` に変更

## テスト

- `npx vitest run` — 全 300 テスト green


---
_Generated by [Claude Code](https://claude.ai/code/session_01E88D6fBJvRsxW24tQFrFCm)_