### PR TITLE
fix(tickets): 入力欄が幅いっぱいに広がらない不具合を修正 [no-issue]

### DIFF
--- a/app/components/TicketFieldLayoutManager.vue
+++ b/app/components/TicketFieldLayoutManager.vue
@@ -86,13 +86,27 @@ function moveDown(index: number) {
 }
 
 function handleSave() {
-  const settings: TroubleFieldLayoutEntry[] = rows.value.map(r => ({
-    key: r.key,
-    visible: r.visible,
-    width: r.width,
-    sort_order: r.sortOrder,
-    label: r.label.trim() && r.label.trim() !== r.defaultLabel ? r.label.trim() : null,
-  }))
+  // デフォルトから変更が無いフィールドは保存しない。全件を具体値で保存すると
+  // 「保存」を押しただけで当時のデフォルト値がテナント設定として凍結され、
+  // 以後コード側でデフォルトを変更しても反映されなくなってしまうため。
+  const settings: TroubleFieldLayoutEntry[] = rows.value
+    .filter((r) => {
+      const meta = FIELD_METAS.find(m => m.key === r.key)!
+      const label = r.label.trim() && r.label.trim() !== r.defaultLabel ? r.label.trim() : null
+      return (
+        r.visible !== meta.defaultVisible
+        || r.width !== meta.defaultWidth
+        || r.sortOrder !== meta.defaultSortOrder
+        || label !== null
+      )
+    })
+    .map(r => ({
+      key: r.key,
+      visible: r.visible,
+      width: r.width,
+      sort_order: r.sortOrder,
+      label: r.label.trim() && r.label.trim() !== r.defaultLabel ? r.label.trim() : null,
+    }))
   emit('save', { settings })
 }
 </script>

--- a/app/components/TicketFormFields.vue
+++ b/app/components/TicketFormFields.vue
@@ -128,6 +128,7 @@ function toggleExternal(checked: boolean) {
             <!-- select (category / office_name / progress_notes) -->
             <USelect
               v-if="field.type === 'select'"
+              class="w-full"
               :model-value="(fieldValue(field.key) as string) || ''"
               :items="selectOptionsFor(field.key)"
               :placeholder="`${field.label}を選択`"
@@ -138,6 +139,7 @@ function toggleExternal(checked: boolean) {
             <!-- text: registration_number (datalist 付き、半角変換、車検証マスタ照合) -->
             <template v-else-if="field.key === 'registration_number'">
               <UInput
+                class="w-full"
                 :model-value="(fieldValue('registration_number') as string) || ''"
                 placeholder="登録番号 (車検証と照合)"
                 list="ticket-form-registrations"
@@ -152,6 +154,7 @@ function toggleExternal(checked: boolean) {
             <!-- text (汎用) -->
             <UInput
               v-else-if="field.type === 'text'"
+              class="w-full"
               :model-value="(fieldValue(field.key) as string) || ''"
               :placeholder="field.label"
               @update:model-value="update(field.key, $event)"
@@ -161,6 +164,7 @@ function toggleExternal(checked: boolean) {
             <!-- textarea -->
             <UTextarea
               v-else-if="field.type === 'textarea'"
+              class="w-full"
               :model-value="(fieldValue(field.key) as string) || ''"
               :placeholder="field.label"
               :rows="field.key === 'description' ? 4 : 2"
@@ -171,6 +175,7 @@ function toggleExternal(checked: boolean) {
             <!-- number -->
             <UInput
               v-else-if="field.type === 'number'"
+              class="w-full"
               type="number"
               :model-value="String(fieldValue(field.key) ?? '')"
               placeholder="0"
@@ -196,6 +201,7 @@ function toggleExternal(checked: boolean) {
             <div v-else-if="field.type === 'person'" class="space-y-1">
               <UInput
                 v-if="model.person_is_external"
+                class="w-full"
                 :model-value="(model.person_name as string) || ''"
                 placeholder="外部当事者名（手入力）"
                 @update:model-value="update('person_name', $event)"
@@ -203,6 +209,7 @@ function toggleExternal(checked: boolean) {
               />
               <USelect
                 v-else
+                class="w-full"
                 :model-value="(model.person_id as string) || ''"
                 :items="employeeOptions"
                 placeholder="従業員を選択"

--- a/tests/components/TicketFieldLayoutManager.test.ts
+++ b/tests/components/TicketFieldLayoutManager.test.ts
@@ -52,18 +52,16 @@ describe('TicketFieldLayoutManager', () => {
     expect(wrapper.text()).toContain('相手方車両')
   })
 
-  it('emits save with default settings unchanged', () => {
+  it('emits save with an empty settings array when nothing was changed from defaults', () => {
+    // 何も変更せずに保存した場合、全フィールドを具体値で凍結してしまうと将来の
+    // コード側デフォルト変更が反映されなくなるため、差分が無ければ何も保存しない。
     const wrapper = mountManager()
-    wrapper.find('button[title], button').exists()
     const saveButton = wrapper.findAll('button').find(b => b.text().includes('保存'))!
     saveButton.trigger('click')
     const emitted = wrapper.emitted('save')
     expect(emitted).toBeTruthy()
-    const layout = emitted![0][0] as { settings: Array<{ key: string; visible: boolean; width: string; sort_order: number; label: string | null }> }
-    const title = layout.settings.find(s => s.key === 'title')!
-    expect(title.visible).toBe(true)
-    expect(title.width).toBe('full')
-    expect(title.label).toBeNull()
+    const layout = emitted![0][0] as { settings: Array<{ key: string }> }
+    expect(layout.settings).toEqual([])
   })
 
   it('moveDown swaps sort order within the same section and reflects in saved settings', async () => {


### PR DESCRIPTION
## 概要

チケット詳細フォームの入力欄 (テキスト/セレクト/テキストエリア) が、グリッドの列幅
(半分/全幅/1/3) に関わらず常にブラウザのデフォルト幅 (約170px) で表示され、右側に
大きな余白ができていた。

## 原因

`UInput`/`USelect`/`UTextarea` のルート要素は `inline-flex` かつ明示的な幅指定が無い。
内側の `<input>` 要素自体には Nuxt UI のテーマで `w-full` が付いているが、これは
`inline-flex` の親 (幅未指定=コンテンツにshrink-to-fit) を基準にした 100% なので、
実質的に何も広げていなかった。結果として `<input>` はブラウザのデフォルト幅
(約20文字分、約170px) のまま表示されていた。

## 変更点

- `app/components/TicketFormFields.vue` — 各 `UInput`/`USelect`/`UTextarea` に
  `class="w-full"` を明示指定 (ルート要素自体を親いっぱいに広げる)
- `app/components/TicketFieldLayoutManager.vue` — `handleSave()` がデフォルトから
  変更の無いフィールドまで具体値で保存し、当時のデフォルト値を凍結してしまう問題を
  修正。差分のみ保存するようにし、将来コード側のデフォルト値を変更した際に
  未カスタマイズのテナントへ反映されるようにした
- 上記に伴うテスト更新

## テスト

- `npx vitest run` — 全 300 テスト green
- `npx nuxi typecheck` — 既存の無関係エラー (`@ippoan/auth-client` の `uqr` 型解決) のみ

Refs ippoan/rust-alc-api#505


---
_Generated by [Claude Code](https://claude.ai/code/session_01E88D6fBJvRsxW24tQFrFCm)_