### PR TITLE
fix(tickets): Enter保存対応・保存中スピナー表示・並行保存の握り潰しを修正 [no-issue]

### DIFF
--- a/app/components/TicketCompactOverview.vue
+++ b/app/components/TicketCompactOverview.vue
@@ -116,7 +116,9 @@ const counterpartyLine = computed(() => {
 // 展開表示に使い、フィールド確定 (blur / select 選択 / 日付確定) のたびに
 // そのフィールドだけ即保存する) ---
 const form = ref<Record<string, unknown>>({})
-const savingField = ref(false)
+// フィールドキー単位で保存中かどうかを追跡する (単一の boolean だと、あるフィールドの
+// 保存中に別フィールドを blur した時にその commit が黙って握り潰されてしまうため)。
+const savingKeys = ref<Set<string>>(new Set())
 const fieldError = ref<string | null>(null)
 
 function buildFormFromTicket(t: TroubleTicket): Record<string, unknown> {
@@ -156,7 +158,6 @@ watch(
 )
 
 async function handleFieldCommitted(keys: string[]) {
-  if (savingField.value) return
   const payload: Record<string, unknown> = {}
   for (const key of keys) {
     if (key === 'occurred_at') {
@@ -167,7 +168,7 @@ async function handleFieldCommitted(keys: string[]) {
     payload[key] = form.value[key]
   }
   if (Object.keys(payload).length === 0) return
-  savingField.value = true
+  for (const key of keys) savingKeys.value.add(key)
   fieldError.value = null
   try {
     const updated = await updateTicket(props.ticket.id, payload as UpdateTroubleTicket)
@@ -175,7 +176,7 @@ async function handleFieldCommitted(keys: string[]) {
   } catch (e) {
     fieldError.value = e instanceof Error ? e.message : '保存に失敗しました'
   } finally {
-    savingField.value = false
+    for (const key of keys) savingKeys.value.delete(key)
   }
 }
 </script>
@@ -290,6 +291,7 @@ async function handleFieldCommitted(keys: string[]) {
         :progress-statuses="progressStatuses"
         :employees="employees"
         :field-layout="fieldLayout"
+        :saving-keys="savingKeys"
         @field-committed="handleFieldCommitted"
       />
       <p v-if="fieldError" class="text-xs text-red-600 mt-2">{{ fieldError }}</p>

--- a/app/components/TicketFormFields.vue
+++ b/app/components/TicketFormFields.vue
@@ -13,7 +13,12 @@ const props = defineProps<{
   progressStatuses?: TroubleProgressStatus[]
   employees?: Employee[]
   fieldLayout?: TroubleFieldLayout | null
+  savingKeys?: Set<string>
 }>()
+
+function isSaving(key: string): boolean {
+  return props.savingKeys?.has(key) ?? false
+}
 
 // mode === 'edit' で親が listen すると、各フィールド確定時 (select/checkbox/日付は
 // 即時、text/textarea は blur 時) に対象キーを通知する。親はこれを使って
@@ -133,6 +138,7 @@ function toggleExternal(checked: boolean) {
               :items="selectOptionsFor(field.key)"
               :placeholder="`${field.label}を選択`"
               :disabled="selectOptionsFor(field.key).length === 0"
+              :loading="isSaving(field.key)"
               @update:model-value="update(field.key, $event); commit(field.key)"
             />
 
@@ -143,8 +149,10 @@ function toggleExternal(checked: boolean) {
                 :model-value="(fieldValue('registration_number') as string) || ''"
                 placeholder="登録番号 (車検証と照合)"
                 list="ticket-form-registrations"
+                :loading="isSaving('registration_number')"
                 @update:model-value="(v: string | number) => update('registration_number', toHalfWidth(String(v ?? '')))"
                 @blur="commit('registration_number')"
+                @keydown.enter="($event.target as HTMLInputElement).blur()"
               />
               <datalist id="ticket-form-registrations">
                 <option v-for="reg in carInspectionRegistrations" :key="reg" :value="reg" />
@@ -157,8 +165,10 @@ function toggleExternal(checked: boolean) {
               class="w-full"
               :model-value="(fieldValue(field.key) as string) || ''"
               :placeholder="field.label"
+              :loading="isSaving(field.key)"
               @update:model-value="update(field.key, $event)"
               @blur="commit(field.key)"
+              @keydown.enter="($event.target as HTMLInputElement).blur()"
             />
 
             <!-- textarea -->
@@ -168,6 +178,7 @@ function toggleExternal(checked: boolean) {
               :model-value="(fieldValue(field.key) as string) || ''"
               :placeholder="field.label"
               :rows="field.key === 'description' ? 4 : 2"
+              :loading="isSaving(field.key)"
               @update:model-value="update(field.key, $event)"
               @blur="commit(field.key)"
             />
@@ -179,8 +190,10 @@ function toggleExternal(checked: boolean) {
               type="number"
               :model-value="String(fieldValue(field.key) ?? '')"
               placeholder="0"
+              :loading="isSaving(field.key)"
               @update:model-value="updateNumber(field.key, $event)"
               @blur="commit(field.key)"
+              @keydown.enter="($event.target as HTMLInputElement).blur()"
             />
 
             <!-- datetime (occurred_at) -->
@@ -204,8 +217,10 @@ function toggleExternal(checked: boolean) {
                 class="w-full"
                 :model-value="(model.person_name as string) || ''"
                 placeholder="外部当事者名（手入力）"
+                :loading="isSaving('person_name')"
                 @update:model-value="update('person_name', $event)"
                 @blur="commit('person_name')"
+                @keydown.enter="($event.target as HTMLInputElement).blur()"
               />
               <USelect
                 v-else
@@ -214,6 +229,7 @@ function toggleExternal(checked: boolean) {
                 :items="employeeOptions"
                 placeholder="従業員を選択"
                 :disabled="employeeOptions.length === 0"
+                :loading="isSaving('person_id')"
                 @update:model-value="updateEmployee($event as string)"
               />
               <label class="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400 cursor-pointer">

--- a/tests/components/TicketCompactOverviewInlineEdit.test.ts
+++ b/tests/components/TicketCompactOverviewInlineEdit.test.ts
@@ -28,8 +28,8 @@ import TicketCompactOverview from '~/components/TicketCompactOverview.vue'
 // @blur は emits 宣言しないことで Vue の attribute fallthrough によりそのまま
 // input/textarea 要素の native blur イベントへ伝播する。
 const UInputWithAttrs = {
-  template: '<input :value="modelValue" :placeholder="placeholder" :type="type || \'text\'" @input="$emit(\'update:modelValue\', $event.target.value)" />',
-  props: ['modelValue', 'placeholder', 'type', 'size'],
+  template: '<input :value="modelValue" :placeholder="placeholder" :type="type || \'text\'" :data-loading="loading" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+  props: ['modelValue', 'placeholder', 'type', 'size', 'loading'],
   emits: ['update:modelValue'],
 }
 const UTextareaWithAttrs = {
@@ -150,6 +150,50 @@ describe('TicketCompactOverview - inline auto-save form (展開表示)', () => {
     await flushPromises()
 
     expect(updateTicketMock).toHaveBeenCalledWith('ticket-1', { due_date: expectedIso })
+  })
+
+  it('shows a loading spinner on the field being saved, and clears it once saved', async () => {
+    let resolveUpdate!: (v: ReturnType<typeof makeTroubleTicket>) => void
+    updateTicketMock.mockImplementation(() => new Promise((resolve) => { resolveUpdate = resolve }))
+    const wrapper = mountOverview()
+    await flushPromises()
+    await expandDetail(wrapper)
+
+    const titleInput = wrapper.find('input[placeholder="タイトル"]')
+    await titleInput.setValue('保存中タイトル')
+    await titleInput.trigger('blur')
+    await wrapper.vm.$nextTick()
+
+    expect(titleInput.attributes('data-loading')).toBe('true')
+
+    resolveUpdate(makeTroubleTicket({ title: '保存中タイトル' }))
+    await flushPromises()
+
+    expect(titleInput.attributes('data-loading')).toBe('false')
+  })
+
+  it('does not drop a field commit made while another field is still saving', async () => {
+    let resolveFirst!: (v: ReturnType<typeof makeTroubleTicket>) => void
+    updateTicketMock.mockImplementationOnce(() => new Promise((resolve) => { resolveFirst = resolve }))
+    updateTicketMock.mockResolvedValueOnce(makeTroubleTicket({ damage_amount: '5000' }))
+    const wrapper = mountOverview()
+    await flushPromises()
+    await expandDetail(wrapper)
+
+    const titleInput = wrapper.find('input[placeholder="タイトル"]')
+    await titleInput.setValue('タイトルA')
+    await titleInput.trigger('blur') // 1件目の保存が pending のまま残る
+
+    const damageInput = wrapper.find('input[type="number"]')
+    await damageInput.setValue('5000')
+    await damageInput.trigger('blur') // 1件目が保存中でも黙って握り潰されない
+    await flushPromises()
+
+    expect(updateTicketMock).toHaveBeenCalledTimes(2)
+    expect(updateTicketMock).toHaveBeenNthCalledWith(2, 'ticket-1', { damage_amount: 5000 })
+
+    resolveFirst(makeTroubleTicket({ title: 'タイトルA' }))
+    await flushPromises()
   })
 
   it('shows an error message when saving fails', async () => {


### PR DESCRIPTION
## 概要

チケット詳細のインライン自動保存フォームで、以下3点を修正:

1. **Enterで保存されない** — 一行テキスト系入力欄 (text/number/registration_number/
   外部当事者名) は blur 時にのみ保存される仕様だったが、Enter キーを押しても blur
   されず保存されなかった。Enter で明示的に blur するようにし、既存の blur ハンドラ
   経由で保存されるようにした (textarea は改行のため対象外)。
2. **保存中かどうかが見た目で分からない** — フィールド確定 (blur/選択/日付確定) の
   たびに非同期保存が走るが、保存中である視覚的フィードバックが無かった。
   `UInput`/`USelect`/`UTextarea` の `loading` prop を使い、保存中のフィールドに
   スピナーを表示するようにした。
3. **別フィールド保存中の commit が握り潰される不具合** — 保存中フラグが単一の
   boolean だったため、あるフィールドの保存がまだ in-flight の間に別フィールドを
   blur すると、その commit がガードで黙って破棄され、二度と保存されないことがあった
   (実際に「相手方車両が保存されない」という形で顕在化)。フィールドキー単位
   (`Set<string>`) で保存中状態を追跡するようにし、並行保存を許容するよう修正。

## 変更点

- `app/components/TicketFormFields.vue` — 各入力欄に `@keydown.enter` (blur) と
  `:loading="isSaving(field.key)"` を追加、`savingKeys` prop を追加
- `app/components/TicketCompactOverview.vue` — `savingField: boolean` を
  `savingKeys: Set<string>` に変更し、単一フラグによる commit の握り潰しを解消
- テスト追加 (スピナー表示/クリア、並行保存時に commit が破棄されないことの回帰テスト)

## テスト

- `npx vitest run` — 全 302 テスト green (新規2テスト含む)
- `npx nuxi typecheck` — 既存の無関係エラー (`@ippoan/auth-client` の `uqr` 型解決) のみ

Refs ippoan/rust-alc-api#505


---
_Generated by [Claude Code](https://claude.ai/code/session_01E88D6fBJvRsxW24tQFrFCm)_