### PR TITLE
fix(tickets): 保存スピナーの最低表示時間・印刷の賞罰委員会値を修正 [no-issue]

### DIFF
--- a/app/components/TicketCompactOverview.vue
+++ b/app/components/TicketCompactOverview.vue
@@ -120,6 +120,8 @@ const form = ref<Record<string, unknown>>({})
 // 保存中に別フィールドを blur した時にその commit が黙って握り潰されてしまうため)。
 const savingKeys = ref<Set<string>>(new Set())
 const fieldError = ref<string | null>(null)
+// 保存が一瞬で終わるとスピナーが点滅するだけで視認できないため、最低でもこの時間は表示する。
+const MIN_SAVING_SPINNER_MS = 1000
 
 function buildFormFromTicket(t: TroubleTicket): Record<string, unknown> {
   return {
@@ -170,12 +172,15 @@ async function handleFieldCommitted(keys: string[]) {
   if (Object.keys(payload).length === 0) return
   for (const key of keys) savingKeys.value.add(key)
   fieldError.value = null
+  const startedAt = Date.now()
   try {
     const updated = await updateTicket(props.ticket.id, payload as UpdateTroubleTicket)
     emit('updated', updated)
   } catch (e) {
     fieldError.value = e instanceof Error ? e.message : '保存に失敗しました'
   } finally {
+    const remaining = MIN_SAVING_SPINNER_MS - (Date.now() - startedAt)
+    if (remaining > 0) await new Promise(resolve => setTimeout(resolve, remaining))
     for (const key of keys) savingKeys.value.delete(key)
   }
 }

--- a/app/pages/tickets/print/[id].vue
+++ b/app/pages/tickets/print/[id].vue
@@ -246,7 +246,7 @@ onMounted(() => {
               <th class="border-r border-gray-400 bg-gray-50 px-3 py-2 text-left font-medium">確認書</th>
               <td class="border-r border-gray-400 px-3 py-2">{{ displayValue(ticket.confirmation_notice) }}</td>
               <th class="border-r border-gray-400 bg-gray-50 px-3 py-2 text-left font-medium">賞罰委員会</th>
-              <td class="px-3 py-2">{{ ymd(ticket.due_date) }}</td>
+              <td class="px-3 py-2">{{ displayValue(ticket.disciplinary_committee) }}</td>
             </tr>
             <tr class="border-b border-gray-400">
               <th class="border-r border-gray-400 bg-gray-50 px-3 py-2 text-left font-medium">処分検討内容</th>

--- a/tests/components/TicketCompactOverviewInlineEdit.test.ts
+++ b/tests/components/TicketCompactOverviewInlineEdit.test.ts
@@ -153,23 +153,35 @@ describe('TicketCompactOverview - inline auto-save form (展開表示)', () => {
   })
 
   it('shows a loading spinner on the field being saved, and clears it once saved', async () => {
-    let resolveUpdate!: (v: ReturnType<typeof makeTroubleTicket>) => void
-    updateTicketMock.mockImplementation(() => new Promise((resolve) => { resolveUpdate = resolve }))
-    const wrapper = mountOverview()
-    await flushPromises()
-    await expandDetail(wrapper)
+    vi.useFakeTimers()
+    try {
+      let resolveUpdate!: (v: ReturnType<typeof makeTroubleTicket>) => void
+      updateTicketMock.mockImplementation(() => new Promise((resolve) => { resolveUpdate = resolve }))
+      const wrapper = mountOverview()
+      await flushPromises()
+      await expandDetail(wrapper)
 
-    const titleInput = wrapper.find('input[placeholder="タイトル"]')
-    await titleInput.setValue('保存中タイトル')
-    await titleInput.trigger('blur')
-    await wrapper.vm.$nextTick()
+      const titleInput = wrapper.find('input[placeholder="タイトル"]')
+      await titleInput.setValue('保存中タイトル')
+      await titleInput.trigger('blur')
+      await wrapper.vm.$nextTick()
 
-    expect(titleInput.attributes('data-loading')).toBe('true')
+      expect(titleInput.attributes('data-loading')).toBe('true')
 
-    resolveUpdate(makeTroubleTicket({ title: '保存中タイトル' }))
-    await flushPromises()
+      resolveUpdate(makeTroubleTicket({ title: '保存中タイトル' }))
+      await flushPromises()
 
-    expect(titleInput.attributes('data-loading')).toBe('false')
+      // API 応答が一瞬で返ってもスピナーが点滅するだけで視認できないよう、
+      // 最低表示時間 (1秒) が経過するまでは保存中のまま維持される。
+      expect(titleInput.attributes('data-loading')).toBe('true')
+
+      await vi.advanceTimersByTimeAsync(1000)
+      await flushPromises()
+
+      expect(titleInput.attributes('data-loading')).toBe('false')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('does not drop a field commit made while another field is still saving', async () => {


### PR DESCRIPTION
## 概要

1. **保存スピナーが速すぎて見えない** — API 応答が一瞬で返るとスピナーが点滅するだけで
   視認できなかったため、最低 1 秒は保存中スピナーを表示するようにした (実際の保存完了
   自体は待たせない、表示のクリアだけを遅延させる)。
2. **印刷ページの「賞罰委員会」に値が表示されない** — 印刷ページ (鏡) は以前
   「対応期限」ラベルを「賞罰委員会」に付け替え済みだった (Refs #172) が、値は旧フィールド
   `due_date` を参照したままだったため、実際に入力した賞罰委員会の内容が反映されず
   常に「-」と表示されていた。`disciplinary_committee` フィールドを参照するよう修正。

## 変更点

- `app/components/TicketCompactOverview.vue` — `MIN_SAVING_SPINNER_MS` (1000ms) を
  導入し、保存完了後もこの時間が経過するまで保存中スピナーを維持
- `app/pages/tickets/print/[id].vue` — 「賞罰委員会」セルの値参照を
  `ticket.due_date` → `ticket.disciplinary_committee` に修正
- テスト更新 (fake timers でスピナーの最低表示時間を検証)

## テスト

- `npx vitest run` — 全 302 テスト green
- `npx nuxi typecheck` — 既存の無関係エラー (`@ippoan/auth-client` の `uqr` 型解決) のみ

Refs ippoan/rust-alc-api#505


---
_Generated by [Claude Code](https://claude.ai/code/session_01E88D6fBJvRsxW24tQFrFCm)_