### PR TITLE
fix(tickets): 保存スピナーの最低表示時間を1秒→0.5秒に短縮 [no-issue]

### DIFF
--- a/app/components/TicketCompactOverview.vue
+++ b/app/components/TicketCompactOverview.vue
@@ -121,7 +121,7 @@ const form = ref<Record<string, unknown>>({})
 const savingKeys = ref<Set<string>>(new Set())
 const fieldError = ref<string | null>(null)
 // 保存が一瞬で終わるとスピナーが点滅するだけで視認できないため、最低でもこの時間は表示する。
-const MIN_SAVING_SPINNER_MS = 1000
+const MIN_SAVING_SPINNER_MS = 500
 
 function buildFormFromTicket(t: TroubleTicket): Record<string, unknown> {
   return {

--- a/tests/components/TicketCompactOverviewInlineEdit.test.ts
+++ b/tests/components/TicketCompactOverviewInlineEdit.test.ts
@@ -172,10 +172,10 @@ describe('TicketCompactOverview - inline auto-save form (展開表示)', () => {
       await flushPromises()
 
       // API 応答が一瞬で返ってもスピナーが点滅するだけで視認できないよう、
-      // 最低表示時間 (1秒) が経過するまでは保存中のまま維持される。
+      // 最低表示時間 (0.5秒) が経過するまでは保存中のまま維持される。
       expect(titleInput.attributes('data-loading')).toBe('true')
 
-      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(500)
       await flushPromises()
 
       expect(titleInput.attributes('data-loading')).toBe('false')


### PR DESCRIPTION
## 概要

前回 PR #181 で導入した保存中スピナーの最低表示時間 (1秒) が長すぎるとのフィードバックを受け、0.5秒に短縮。

## 変更点

- `app/components/TicketCompactOverview.vue` — `MIN_SAVING_SPINNER_MS` を `1000` → `500` に変更
- テスト更新

## テスト

- `npx vitest run` — 全 302 テスト green
- `npx nuxi typecheck` — 既存の無関係エラー (`@ippoan/auth-client` の `uqr` 型解決) のみ

Refs ippoan/rust-alc-api#505


---
_Generated by [Claude Code](https://claude.ai/code/session_01E88D6fBJvRsxW24tQFrFCm)_