### PR TITLE
feat(preview): push トリガーの軽量プレビュー環境を追加 (Refs ippoan/secrets-inventory#85)

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,23 @@
+name: Preview Deploy
+
+# push のたびに軽量プレビュー環境 (nuxt-trouble-preview) を更新する。
+# test/typecheck は回さない (UI 変更の見た目確認が主目的)。
+# staging (nuxt-trouble-staging) は既存どおり test.yml の PR trigger で更新される。
+#
+# Refs ippoan/secrets-inventory#85
+
+on:
+  push:
+    branches-ignore: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  preview:
+    uses: ippoan/ci-workflows/.github/workflows/preview-deploy.yml@main
+    with:
+      install_command: 'npm install'
+      post_install_script: 'npx nuxt prepare && npx wrangler types'
+      use_auth_client_dev: true
+    secrets: inherit

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   preview:
@@ -20,4 +21,5 @@ jobs:
       install_command: 'npm install'
       post_install_script: 'npx nuxt prepare && npx wrangler types'
       use_auth_client_dev: true
+      npm_scope: '@ippoan'
     secrets: inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,18 @@
 トラブル管理 (状況管理) アプリ。Nuxt 4 + Cloudflare Workers (`wrangler.toml`)。
 rust-alc-api `/api/troubles` を叩く。
 
+## 環境と URL
+
+| 環境 | URL | 更新タイミング |
+|---|---|---|
+| production | https://trouble.ippoan.org | `v*` タグ push |
+| staging | https://trouble-staging.ippoan.org | PR (non-draft) への push のたび (`test.yml` の `frontend-ci.yml` deploy-staging job) |
+| preview | https://nuxt-trouble-preview.m-tama-ramu.workers.dev | 任意の branch (main 以外) への push のたび (`.github/workflows/preview-deploy.yml`、test/typecheck 無し・deploy のみの軽量パイプライン) |
+
+**preview は UI 変更の見た目確認が主目的** (backend は staging を再利用、専用 DB は持たない)。
+DB migration 等の本格的な検証が必要な変更は PR を作成して staging で確認する
+(Refs ippoan/secrets-inventory#85)。
+
 <!-- migrated from memory/feedback_*.md (2026-05-11) -->
 
 ## ドメインモデル上の罠

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -58,3 +58,25 @@ secret_name = "INTERNAL_SHARED_SECRET"
 [[env.staging.services]]
 binding = "AUTH_WORKER"
 service = "auth-worker-staging"
+
+# push のたびに更新される軽量プレビュー環境 (Refs ippoan/secrets-inventory#85)。
+# staging とは別の Worker resource として固定 URL を持たせ、staging 自体は
+# 「PR がある時だけ更新される、DB 変更を伴う本格検証用」の位置づけを保つ。
+# backend は staging のものをそのまま再利用する (専用インフラは持たない)。
+[env.preview]
+name = "nuxt-trouble-preview"
+
+[env.preview.vars]
+NUXT_PUBLIC_API_BASE = "https://rust-alc-api-staging-566bls5vfq-an.a.run.app"
+NUXT_PUBLIC_AUTH_WORKER_URL = "https://auth-staging.ippoan.org"
+NUXT_PUBLIC_STAGING_TENANT_ID = ""
+NUXT_ALC_API_URL = "https://rust-alc-api-staging-566bls5vfq-an.a.run.app"
+
+[[env.preview.secrets_store_secrets]]
+binding = "INTERNAL_SHARED_SECRET"
+store_id = "bd7bc91a3e5f4111add4acf6cb4b8733"
+secret_name = "INTERNAL_SHARED_SECRET"
+
+[[env.preview.services]]
+binding = "AUTH_WORKER"
+service = "auth-worker-staging"


### PR DESCRIPTION
## Summary
- `wrangler.toml` に `[env.preview]` を新設（staging backend を再利用、`name = "nuxt-trouble-preview"` で固定 URL）
- `.github/workflows/preview-deploy.yml` を新設。任意 branch (main 以外) への push のたびに [ci-workflows#148](https://github.com/ippoan/ci-workflows/pull/148) の軽量 `preview-deploy.yml`（test/typecheck 無し・deploy のみ）を呼び出す
- staging（PR trigger、DB 変更を伴う本格検証用）とは役割を分離。preview は UI 変更の見た目確認に特化
- `CLAUDE.md` に production/staging/preview の URL 一覧と更新タイミングを明記

## Test plan
- [ ] merge 後、feature branch への push で `nuxt-trouble-preview.m-tama-ramu.workers.dev` が更新されることを確認

Refs ippoan/secrets-inventory#85

---
_Generated by [Claude Code](https://claude.ai/code/session_015JQNRCpqw8JKctZ7SB3YxK)_