### PR TITLE
feat(preview): preview環境にカスタムドメインを設定 (Refs ippoan/secrets-inventory#85)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ rust-alc-api `/api/troubles` を叩く。
 |---|---|---|
 | production | https://trouble.ippoan.org | `v*` タグ push |
 | staging | https://trouble-staging.ippoan.org | PR (non-draft) への push のたび (`test.yml` の `frontend-ci.yml` deploy-staging job) |
-| preview | https://nuxt-trouble-preview.m-tama-ramu.workers.dev | 任意の branch (main 以外) への push のたび (`.github/workflows/preview-deploy.yml`、test/typecheck 無し・deploy のみの軽量パイプライン) |
+| preview | https://trouble-preview.ippoan.org | 任意の branch (main 以外) への push のたび (`.github/workflows/preview-deploy.yml`、test/typecheck 無し・deploy のみの軽量パイプライン) |
 
 **preview は UI 変更の見た目確認が主目的** (backend は staging を再利用、専用 DB は持たない)。
 DB migration 等の本格的な検証が必要な変更は PR を作成して staging で確認する

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -65,6 +65,13 @@ service = "auth-worker-staging"
 # backend は staging のものをそのまま再利用する (専用インフラは持たない)。
 [env.preview]
 name = "nuxt-trouble-preview"
+# custom_domain route を使うため workers.dev URL は明示的に無効化する
+# (routes 定義時は自動的に false 推論されるが、明示して確実にする)。
+workers_dev = false
+
+[[env.preview.routes]]
+pattern = "trouble-preview.ippoan.org"
+custom_domain = true
 
 [env.preview.vars]
 NUXT_PUBLIC_API_BASE = "https://rust-alc-api-staging-566bls5vfq-an.a.run.app"


### PR DESCRIPTION
## Summary
- staging/production と同じ `custom_domain` route パターンで `trouble-preview.ippoan.org` を preview 環境に設定
- workers.dev URL は明示的に `workers_dev = false` で無効化（routes 定義時は自動 false 推論されるが、明示して確実にする）
- `CLAUDE.md` の preview URL 表記を workers.dev から `trouble-preview.ippoan.org` に更新

## Test plan
- [ ] merge 後、feature branch への push で `https://trouble-preview.ippoan.org` が更新されることを確認
- [ ] `https://nuxt-trouble-preview.m-tama-ramu.workers.dev` がアクセス不可になっていることを確認

Refs ippoan/secrets-inventory#85

---
_Generated by [Claude Code](https://claude.ai/code/session_015JQNRCpqw8JKctZ7SB3YxK)_