### PR TITLE
fix: 通知モーダルの送信先リストにスクロールを追加

### DIFF
--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -509,7 +509,7 @@ onMounted(() => {
     <!-- Add notification modal -->
     <UModal v-model:open="showAddNotifModal">
       <template #content>
-        <div class="p-6 space-y-4">
+        <div class="p-6 space-y-4 max-h-[85vh] overflow-y-auto">
           <h3 class="text-lg font-bold">通知設定を追加</h3>
 
           <UFormField label="イベント種別">
@@ -521,7 +521,7 @@ onMounted(() => {
           </UFormField>
 
           <UFormField label="送信先 (LINE WORKS メンバー)">
-            <div class="space-y-2">
+            <div class="space-y-2 max-h-60 overflow-y-auto pr-1">
               <label
                 v-for="m in notifMemberOptions"
                 :key="m.value"

--- a/app/pages/tickets/[id].vue
+++ b/app/pages/tickets/[id].vue
@@ -276,7 +276,7 @@ onMounted(() => {
     <!-- Schedule modal -->
     <UModal v-model:open="showScheduleModal">
       <template #content>
-        <div class="p-6 space-y-4">
+        <div class="p-6 space-y-4 max-h-[85vh] overflow-y-auto">
           <h3 class="text-lg font-bold">通知を予約</h3>
 
           <UFormField label="通知日時">
@@ -295,7 +295,7 @@ onMounted(() => {
           </UFormField>
 
           <UFormField label="送信先">
-            <div class="space-y-2">
+            <div class="space-y-2 max-h-60 overflow-y-auto pr-1">
               <label
                 v-for="m in scheduleMembers"
                 :key="m.user_id"


### PR DESCRIPTION
Refs #186

## 現象

チケット詳細の「通知を予約」モーダルで、送信先 (LINE WORKS メンバー) のチェックボックスリストに高さ制限・スクロールが無く、メンバー数が多いとモーダルが viewport を超えて下部のメンバーが選択できず、「予約」「キャンセル」ボタンにも到達できなかった。settings.vue の「通知設定を追加」モーダルも同じ構造で同じ問題があった。

## 変更内容

- `app/pages/tickets/[id].vue` / `app/pages/settings.vue` の送信先リストコンテナに `max-h-60 overflow-y-auto pr-1` を追加し、リスト内スクロールで全メンバーを選択可能にした
- 両モーダル本体の wrapper に `max-h-[85vh] overflow-y-auto` を追加し、小画面でもフッターのボタンに常に到達できるようにした

## 検証

- ローカルは GitHub Packages (`@ippoan/auth-client`) の認証が無く `npm install` 不可のため、typecheck / test は CI (frontend-ci) で確認
- 見た目は本 PR の staging デプロイ (https://trouble-staging.ippoan.org) で確認可能

---
_Generated by [Claude Code](https://claude.ai/code/session_018xKxrVWdkxMLuVjBE2Ao3N)_