### PR TITLE
fix: 通知予約の失敗理由をモーダル内に表示する

### DIFF
--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -257,10 +257,16 @@ const notifLoading = ref(false)
 const notifError = ref<string | null>(null)
 const notifSaving = ref(false)
 const showAddNotifModal = ref(false)
+const addNotifError = ref<string | null>(null)
 const newNotifPref = ref({
   event_type: '',
   lineworks_user_ids: [] as string[],
 })
+
+function openAddNotifModal() {
+  addNotifError.value = null
+  showAddNotifModal.value = true
+}
 
 async function fetchNotifications() {
   notifLoading.value = true
@@ -289,9 +295,16 @@ function eventLabel(eventType: string): string {
 }
 
 async function handleAddNotif() {
-  if (!newNotifPref.value.event_type || newNotifPref.value.lineworks_user_ids.length === 0) return
+  if (!newNotifPref.value.event_type) {
+    addNotifError.value = 'イベント種別を選択してください'
+    return
+  }
+  if (newNotifPref.value.lineworks_user_ids.length === 0) {
+    addNotifError.value = '送信先を選択してください'
+    return
+  }
   notifSaving.value = true
-  notifError.value = null
+  addNotifError.value = null
   try {
     await upsertNotificationPref({
       event_type: newNotifPref.value.event_type,
@@ -303,7 +316,7 @@ async function handleAddNotif() {
     newNotifPref.value = { event_type: '', lineworks_user_ids: [] }
     await fetchNotifications()
   } catch (e) {
-    notifError.value = e instanceof Error ? e.message : '保存に失敗しました'
+    addNotifError.value = e instanceof Error ? e.message : '保存に失敗しました'
   } finally {
     notifSaving.value = false
   }
@@ -448,7 +461,7 @@ onMounted(() => {
             icon="i-lucide-plus"
             size="sm"
             :disabled="availableEventTypes.length === 0"
-            @click="showAddNotifModal = true"
+            @click="openAddNotifModal"
           />
         </div>
 
@@ -541,12 +554,15 @@ onMounted(() => {
             </div>
           </UFormField>
 
+          <div v-if="addNotifError" class="p-3 bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-400 rounded-lg text-sm">
+            {{ addNotifError }}
+          </div>
+
           <div class="flex justify-end gap-2">
             <UButton label="キャンセル" variant="outline" @click="showAddNotifModal = false" />
             <UButton
               label="追加"
               :loading="notifSaving"
-              :disabled="!newNotifPref.event_type || newNotifPref.lineworks_user_ids.length === 0"
               @click="handleAddNotif"
             />
           </div>

--- a/app/pages/tickets/[id].vue
+++ b/app/pages/tickets/[id].vue
@@ -26,7 +26,13 @@ const scheduleForm = ref({
   lineworks_user_ids: [] as string[],
 })
 const scheduleSaving = ref(false)
+const scheduleError = ref<string | null>(null)
 const scheduleMembers = ref<LineworksMember[]>([])
+
+function openScheduleModal() {
+  scheduleError.value = null
+  showScheduleModal.value = true
+}
 
 async function loadSchedules() {
   try {
@@ -39,8 +45,20 @@ async function loadSchedules() {
   } catch { /* ignore */ }
 }
 
+function validateScheduleForm(): string | null {
+  if (!scheduleForm.value.scheduled_at) return '通知日時を入力してください'
+  const at = new Date(scheduleForm.value.scheduled_at)
+  if (Number.isNaN(at.getTime())) return '通知日時の形式が不正です'
+  if (at.getTime() <= Date.now()) return '通知日時には現在より後の日時を指定してください'
+  if (at.getTime() > Date.now() + 30 * 24 * 60 * 60 * 1000) return '通知日時は30日先まで指定できます'
+  if (!scheduleForm.value.message.trim()) return 'メッセージを入力してください'
+  if (scheduleForm.value.lineworks_user_ids.length === 0) return '送信先を選択してください'
+  return null
+}
+
 async function handleCreateSchedule() {
-  if (!scheduleForm.value.scheduled_at || !scheduleForm.value.message.trim()) return
+  scheduleError.value = validateScheduleForm()
+  if (scheduleError.value) return
   scheduleSaving.value = true
   try {
     await createSchedule({
@@ -53,7 +71,10 @@ async function handleCreateSchedule() {
     scheduleForm.value = { scheduled_at: '', message: '', lineworks_user_ids: [] }
     await loadSchedules()
   } catch (e) {
-    error.value = e instanceof Error ? e.message : 'スケジュール作成に失敗しました'
+    const msg = e instanceof Error ? e.message : 'スケジュール作成に失敗しました'
+    scheduleError.value = msg.includes('(400)')
+      ? '予約できませんでした。通知日時が過去になっていないか確認してください'
+      : msg
   } finally {
     scheduleSaving.value = false
   }
@@ -227,7 +248,7 @@ onMounted(() => {
             icon="i-lucide-clock"
             size="sm"
             variant="outline"
-            @click="showScheduleModal = true"
+            @click="openScheduleModal"
           />
         </div>
 
@@ -315,12 +336,15 @@ onMounted(() => {
             </div>
           </UFormField>
 
+          <div v-if="scheduleError" class="p-3 bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-400 rounded-lg text-sm">
+            {{ scheduleError }}
+          </div>
+
           <div class="flex justify-end gap-2">
             <UButton label="キャンセル" variant="outline" @click="showScheduleModal = false" />
             <UButton
               label="予約"
               :loading="scheduleSaving"
-              :disabled="!scheduleForm.scheduled_at || !scheduleForm.message.trim() || scheduleForm.lineworks_user_ids.length === 0"
               @click="handleCreateSchedule"
             />
           </div>


### PR DESCRIPTION
Refs #188

## 現象

通知予約モーダルで「予約」を押しても何も起きないように見えることがある (#187 のスクロール修正後にユーザー報告)。

## 原因

1. backend (`rust-alc-api` `alc-trouble/src/schedules.rs::create_schedule`) は `scheduled_at <= now()` を body 無しの 400 で reject する。「今の時刻」をそのまま指定すると送信時点で過去になり 400 になる
2. frontend はその API エラーを `error.value` (ページ上部のバナー) にしか入れず、開いたままのモーダルの背後に隠れて見えない
3. メッセージ未入力・送信先未選択時は「予約」ボタンが無言で disabled になるだけで理由が表示されない
4. settings.vue の「通知設定を追加」モーダルも同様 (`notifError` がモーダル外に描画される)

## 変更内容

- `app/pages/tickets/[id].vue`: 予約ボタンは保存中以外常に押せるようにし、クリック時にクライアント側バリデーション (日時未入力/形式不正/過去日時/30日超/メッセージ未入力/送信先未選択) の結果を**モーダル内**に表示。API エラーもモーダル内に表示 (400 は過去日時のヒント付き)。モーダルを開くたびにエラーをクリア
- `app/pages/settings.vue`: 通知設定追加モーダルに `addNotifError` を追加し同様の扱いに変更

## 検証

- ローカルは GitHub Packages (`@ippoan/auth-client`) の認証が無く `npm install` 不可のため、typecheck / test は CI (frontend-ci) で確認
- 動作確認は本 PR の staging (https://trouble-staging.ippoan.org) で: 過去日時を指定して「予約」→ モーダル内に理由が表示されることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_018xKxrVWdkxMLuVjBE2Ao3N)_