### PR TITLE
infra: preview_urls opt-in — release no-traffic version の preview URL を有効化

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,6 +4,13 @@ compatibility_date = "2025-03-10"
 compatibility_flags = ["nodejs_compat"]
 main = ".output/server/index.mjs"
 assets = { directory = ".output/public/", binding = "ASSETS" }
+# release tag の `wrangler versions upload` (no-traffic) が version ごとの
+# preview URL (`<hash>-nuxt-trouble.<subdomain>.workers.dev`) を出力するよう
+# opt-in する (auth-worker と同型)。frontend-ci がこの URL を pending-release
+# webhook で ci-dashboard に報告し、/release-wave の Pending releases と
+# preview-trouble.ippoan.org router (flip 前 E2E) が使う。production traffic
+# は下の custom domain route のままで独立 (Refs ippoan/ci-dashboard#472)。
+preview_urls = true
 
 [[routes]]
 pattern = "trouble.ippoan.org"


### PR DESCRIPTION
## 概要

flip 前 preview E2E (Refs ippoan/ci-dashboard#472、plan: ci-dashboard `docs/plan-pre-flip-preview-e2e.md`) の Phase 0。

release tag の `wrangler versions upload` (no-traffic) が version 固有の preview URL (`<hash>-nuxt-trouble.<subdomain>.workers.dev`) を出力するよう、wrangler.toml top-level に `preview_urls = true` を opt-in する (auth-worker `wrangler.toml` と同型)。

## 変更点

- `wrangler.toml`: `preview_urls = true` を追加 (1 行 + コメント)

## 効果 / 影響

- frontend-ci の pending-release webhook に `preview_url` が載り、ci-dashboard `/release-wave` の Pending releases リンクと `preview-trouble.ippoan.org` router (flip 前 E2E) が機能する
- production traffic は custom domain route (`trouble.ippoan.org`) のままで独立 — 影響なし

## 動作確認

- 次回 tag release で `/release-wave` の Pending releases に preview リンクが出ることを実機確認 (出なければ Cloudflare account 側の preview URLs 設定を疑う — plan doc「未確定 / リスク」参照)

Refs ippoan/ci-dashboard#472

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ijYf11nXsaRsB9hr2ot3e

---
_Generated by [Claude Code](https://claude.ai/code/session_012ijYf11nXsaRsB9hr2ot3e)_