### PR TITLE
状況管理を経過記録に改称、一覧の担当表記を対応者に統一

### DIFF
--- a/app/components/TicketTaskList.vue
+++ b/app/components/TicketTaskList.vue
@@ -558,7 +558,7 @@ const FORM_GRID = 'grid-cols-[6rem_17rem_1fr_1fr_8rem_2.5rem]'
   <div>
     <div class="flex items-center justify-between mb-3">
       <div class="flex items-center gap-2">
-        <h3 class="text-base font-semibold">状況管理</h3>
+        <h3 class="text-base font-semibold">経過記録</h3>
         <UBadge v-if="tasks.length > 0" variant="subtle" size="xs">
           {{ completionCount.done }}/{{ completionCount.total }} 完了
         </UBadge>
@@ -587,7 +587,7 @@ const FORM_GRID = 'grid-cols-[6rem_17rem_1fr_1fr_8rem_2.5rem]'
       <div class="overflow-x-auto">
         <div class="min-w-[54rem]">
           <div v-if="tasks.length === 0" class="text-sm text-gray-500 text-center py-4">
-            状況管理項目はありません
+            経過記録項目はありません
           </div>
 
       <!-- Task rows (2 rows per task, same 9-col grid) -->
@@ -624,7 +624,7 @@ const FORM_GRID = 'grid-cols-[6rem_17rem_1fr_1fr_8rem_2.5rem]'
           <!-- next_action_by (対応者) -->
           <input v-if="isEditing(task.id, 'next_action_by')" v-model="editingValue" list="task-employee-list" class="min-w-0 text-xs border border-blue-500 rounded px-1 py-0.5 bg-transparent" @blur="saveEdit(task.id, 'next_action_by')" @keydown.enter="($event.target as HTMLInputElement).blur()" />
           <span v-else class="text-xs text-gray-400 truncate cursor-pointer hover:text-gray-200 transition-colors" @click="startEdit(task, 'next_action_by')">
-            <span class="text-[10px] text-gray-500 inline-block w-8 mr-0.5 [text-align-last:justify]">担当:</span>{{ task.next_action_by || '-' }}
+            <span class="text-[10px] text-gray-500 inline-block w-8 mr-0.5 [text-align-last:justify]">対応者:</span>{{ task.next_action_by || '-' }}
           </span>
           <!-- status -->
           <USelect :model-value="task.status" :items="statusOptions" size="xs" class="min-w-0" @update:model-value="handleStatusChange(task.id, $event)" />
@@ -706,7 +706,7 @@ const FORM_GRID = 'grid-cols-[6rem_17rem_1fr_1fr_8rem_2.5rem]'
           </div>
           <input v-model="newTask.title" placeholder="タイトル" class="min-w-0 text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" @keydown.enter="handleAddTask" />
           <input v-model="newTask.description" placeholder="内容" class="min-w-0 text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" />
-          <input v-model="newTask.assigned_name" list="task-employee-list" placeholder="担当者" class="min-w-0 text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" />
+          <input v-model="newTask.assigned_name" list="task-employee-list" placeholder="対応者" class="min-w-0 text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" />
           <span />
         </div>
         <!-- Form Row 2: (empty) / due_date / next_action / detail / next_action_by / add-btn -->

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -39,7 +39,7 @@ const navigation: { label: string; icon: string; to: string; target?: string; de
     description: '進捗状況が「待機」のチケットのみ抽出',
   },
   {
-    label: '状況管理',
+    label: '経過記録',
     icon: 'i-lucide-list-checks',
     to: '/tasks',
     target: '_blank',

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -15,7 +15,7 @@ const activeTab = ref('categories')
 
 const tabs = [
   { label: 'カテゴリ', value: 'categories' },
-  { label: '状況管理タイプ', value: 'taskTypes' },
+  { label: '経過記録タイプ', value: 'taskTypes' },
   { label: '状況ステータス', value: 'taskStatuses' },
   { label: '営業所', value: 'offices' },
   { label: '進捗状況', value: 'progress' },
@@ -399,7 +399,7 @@ onMounted(() => {
 
       <MasterDataManager
         v-if="activeTab === 'taskTypes'"
-        title="状況管理タイプ"
+        title="経過記録タイプ"
         :items="taskTypes"
         :builtin-items="DEFAULT_TASK_TYPES as unknown as string[]"
         :loading="taskTypesLoading"

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -204,7 +204,7 @@ onMounted(async () => {
 <template>
   <div class="space-y-4">
     <div class="flex items-center justify-between">
-      <h2 class="text-xl font-bold">状況管理 一覧</h2>
+      <h2 class="text-xl font-bold">経過記録 一覧</h2>
       <UButton label="再読み込み" icon="i-lucide-refresh-cw" variant="outline" size="sm" :loading="loading" @click="load" />
     </div>
 
@@ -284,7 +284,7 @@ onMounted(async () => {
               <th class="text-left py-2 px-2 font-medium">種類</th>
               <th class="text-left py-2 px-2 font-medium">題名</th>
               <th class="text-left py-2 px-2 font-medium">内容</th>
-              <th class="text-left py-2 px-2 font-medium">担当</th>
+              <th class="text-left py-2 px-2 font-medium">対応者</th>
               <th class="text-left py-2 px-2 font-medium">発生日</th>
               <th class="text-left py-2 px-2 font-medium">期限</th>
               <th class="text-left py-2 px-2 font-medium">次のアクション</th>

--- a/app/pages/tickets/print/[id].vue
+++ b/app/pages/tickets/print/[id].vue
@@ -276,10 +276,10 @@ onMounted(() => {
         <!-- 状況管理 (タスク) -->
         <div class="mt-8">
           <h3 class="mb-2 border-b border-black pb-1 text-base font-semibold">
-            状況管理
+            経過記録
           </h3>
           <p v-if="tasks.length === 0" class="text-sm text-gray-500">
-            状況管理項目はありません
+            経過記録項目はありません
           </p>
           <template v-for="(segment, si) in taskSegments" :key="si">
             <div v-if="si > 0" class="print:hidden mt-4 mb-1 flex items-center gap-2 text-xs text-emerald-600">

--- a/tests/components/TicketTaskList.test.ts
+++ b/tests/components/TicketTaskList.test.ts
@@ -89,7 +89,7 @@ describe('TicketTaskList', () => {
       global: { stubs },
     })
     await flushPromises()
-    expect(wrapper.text()).toContain('状況管理')
+    expect(wrapper.text()).toContain('経過記録')
   })
 
   it('shows empty message when no tasks', async () => {
@@ -99,7 +99,7 @@ describe('TicketTaskList', () => {
       global: { stubs },
     })
     await flushPromises()
-    expect(wrapper.text()).toContain('状況管理項目はありません')
+    expect(wrapper.text()).toContain('経過記録項目はありません')
   })
 
   it('renders task list when tasks exist', async () => {

--- a/tests/layouts/default.test.ts
+++ b/tests/layouts/default.test.ts
@@ -19,7 +19,7 @@ describe('default layout', () => {
     expect(wrapper.text()).toContain('チケット一覧')
     expect(wrapper.text()).toContain('ステータス管理')
     expect(wrapper.text()).toContain('待機一覧')
-    expect(wrapper.text()).toContain('状況管理')
+    expect(wrapper.text()).toContain('経過記録')
     expect(wrapper.text()).toContain('設定')
     expect(wrapper.find('[data-testid="auth-toolbar"]').exists()).toBe(true)
     expect(wrapper.text()).toContain('content')

--- a/tests/pages/tasks.test.ts
+++ b/tests/pages/tasks.test.ts
@@ -230,7 +230,7 @@ describe('tasks page', () => {
     await flushPromises()
 
     // Page still renders even if masters fail
-    expect(wrapper.text()).toContain('状況管理 一覧')
+    expect(wrapper.text()).toContain('経過記録 一覧')
     errSpy.mockRestore()
   })
 


### PR DESCRIPTION
## Summary
- 「状況管理」の表示ラベルを「経過記録」に変更 (ナビゲーション、一覧見出し、タスクカード見出し、設定タブ、印刷詳細情報)
- 印刷ページの詳細情報テーブルはすでに「対応者」列を使っているため、一覧側 (TicketTaskList.vue のRow1ラベル・追加フォーム、tasks.vue の列見出し) も同じ「対応者」表記に統一
- Row2 (次のアクション対応者、「次担当」表記) は変更対象外
- `assigned_to` / `next_action_by` の2フィールド構成やDBカラム名など、データ側は変更なし

## Test plan
- [ ] `npm test` (プライベートパッケージ `@ippoan/auth-client` の認証がローカルにないため未実行。CI での確認が必要)
- [x] 変更した表示文字列と対応するテストアサーションを目視で突き合わせ済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)