### PR TITLE
feat: 経過記録 Row2 非表示オプション + 印刷ページの日付列先頭化 (Refs #205)

### DIFF
--- a/.claude/skills/nuxt-trouble-map/SKILL.md
+++ b/.claude/skills/nuxt-trouble-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nuxt-trouble-map
-generated-from: nuxt-trouble:94caa76f82e067edfffa882510df4b0011d677b5
+generated-from: nuxt-trouble:4c0dd6159507513764c4abc055a5d79582e7c197
 paths: [app/, server/]
 description: ippoan/nuxt-trouble (トラブル/状況管理 Nuxt 4 アプリ / Cloudflare Workers) の構造ナビゲーション。rust-alc-api `/api/troubles` を叩くチケット・タスク・ワークフロー管理 SPA。pages/composables/utils と ts-rs 生成型の配置、/api/proxy identity proxy、2 対応者フィールドの罠を 1 枚にまとめる。トリガー:「nuxt-trouble」「トラブル管理」「状況管理」「チケット」「trouble_tasks」「assigned_to」「next_action_by」「ワークフロー」「ガントチャート」「trouble.ippoan.org」「/api/proxy」等。
 ---

--- a/app/components/TicketTaskList.vue
+++ b/app/components/TicketTaskList.vue
@@ -25,6 +25,24 @@ const adding = ref(false)
 const employees = ref<Employee[]>([])
 const addError = ref(false)
 
+// Row2 (期限/次回/詳細/次担当) 表示トグル。次担当 (next_action_by) 自体は
+// Row1 の「対応者」欄・編集モーダルにも表示されるため非表示にしても編集手段は残る。
+const ROW2_VISIBLE_KEY = 'trouble-task-row2-visible'
+const showRow2 = ref(true)
+
+function loadRow2Visibility() {
+  if (typeof window === 'undefined') return
+  const saved = localStorage.getItem(ROW2_VISIBLE_KEY)
+  if (saved !== null) showRow2.value = saved === 'true'
+}
+
+function toggleRow2() {
+  showRow2.value = !showRow2.value
+  /* v8 ignore next */
+  if (typeof window === 'undefined') return
+  localStorage.setItem(ROW2_VISIBLE_KEY, String(showRow2.value))
+}
+
 const newTask = reactive({
   task_type: '',
   title: '',
@@ -540,6 +558,7 @@ function formatFileSize(bytes: number | bigint): string {
 }
 
 onMounted(() => {
+  loadRow2Visibility()
   fetchTaskTypes()
   fetchEmployees()
   loadTaskStatuses()
@@ -572,6 +591,14 @@ const FORM_GRID = 'grid-cols-[6rem_17rem_1fr_1fr_8rem_2.5rem]'
           data-testid="task-edit-button"
           :disabled="tasks.length === 0"
           @click="openEditModal(0)"
+        />
+        <UButton
+          :icon="showRow2 ? 'i-lucide-rows-3' : 'i-lucide-rows-2'"
+          :label="showRow2 ? '下段を隠す' : '下段を表示'"
+          size="xs"
+          variant="outline"
+          data-testid="task-row2-toggle"
+          @click="toggleRow2"
         />
       </div>
       <slot name="actions" />
@@ -638,7 +665,11 @@ const FORM_GRID = 'grid-cols-[6rem_17rem_1fr_1fr_8rem_2.5rem]'
         </div>
 
         <!-- Row 2: _ / _ / due_date / next_action / next_action_detail / next_action_by / _ / _ / _ -->
-        <div :class="['grid gap-1 pb-2 px-1 mb-0.5 border-b border-gray-100 dark:border-gray-800 items-center hover:bg-gray-50/50 dark:hover:bg-gray-800/30 transition-colors', GRID]">
+        <div
+          v-if="showRow2"
+          data-testid="task-row2"
+          :class="['grid gap-1 pb-2 px-1 mb-0.5 border-b border-gray-100 dark:border-gray-800 items-center hover:bg-gray-50/50 dark:hover:bg-gray-800/30 transition-colors', GRID]"
+        >
           <span />
           <span />
           <!-- due_date (aligned under occurred_at) -->

--- a/app/pages/tickets/print/[id].vue
+++ b/app/pages/tickets/print/[id].vue
@@ -293,9 +293,9 @@ onMounted(() => {
             >
               <thead>
                 <tr class="border-b-2 border-black">
+                  <th class="border border-gray-400 px-2 py-1 text-left font-medium">日付</th>
                   <th class="border border-gray-400 px-2 py-1 text-left font-medium">種別</th>
                   <th class="border border-gray-400 px-2 py-1 text-left font-medium">タイトル / 内容</th>
-                  <th class="border border-gray-400 px-2 py-1 text-left font-medium">日付</th>
                   <th class="border border-gray-400 px-2 py-1 text-left font-medium">対応者</th>
                   <th class="border border-gray-400 px-2 py-1 text-left font-medium">状況</th>
                   <th class="print:hidden border border-gray-400 px-2 py-1 text-left font-medium">改ページ</th>
@@ -303,13 +303,13 @@ onMounted(() => {
               </thead>
               <tbody>
                 <tr v-for="t in segment" :key="t.id" class="break-inside-avoid">
+                  <td class="border border-gray-400 px-2 py-1 align-top">{{ ymd(t.occurred_at) }}</td>
                   <td class="border border-gray-400 px-2 py-1 align-top">{{ t.task_type }}</td>
                   <td class="border border-gray-400 px-2 py-1 align-top">
                     <div class="font-medium">{{ t.title }}</div>
                     <div v-if="t.description" class="text-gray-600">{{ t.description }}</div>
                     <div v-if="t.next_action_detail" class="text-gray-600">次回詳細: {{ t.next_action_detail }}</div>
                   </td>
-                  <td class="border border-gray-400 px-2 py-1 align-top">{{ ymd(t.occurred_at) }}</td>
                   <td class="border border-gray-400 px-2 py-1 align-top">{{ displayValue(t.next_action_by) }}</td>
                   <td class="border border-gray-400 px-2 py-1 align-top">{{ taskStatusLabel(t.status) }}</td>
                   <td class="print:hidden border border-gray-400 px-2 py-1 align-top">

--- a/tests/components/TicketTaskList.test.ts
+++ b/tests/components/TicketTaskList.test.ts
@@ -43,6 +43,7 @@ const stubs = {
   UButton: {
     template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot />{{ label }}</button>',
     props: ['label', 'icon', 'loading', 'disabled', 'size', 'variant', 'color'],
+    emits: ['click'],
   },
   UIcon: { template: '<span />', props: ['name'] },
   UBadge: { template: '<span><slot /></span>', props: ['variant', 'size'] },
@@ -75,6 +76,7 @@ const stubs = {
 describe('TicketTaskList', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    localStorage.clear()
     mockGetTasks.mockResolvedValue([sampleTask])
     mockGetTaskTypes.mockResolvedValue([
       { id: '1', name: 'レッカー対応', sort_order: 0, tenant_id: 't1', created_at: '' },
@@ -135,6 +137,64 @@ describe('TicketTaskList', () => {
     const vm = wrapper.vm as unknown as { statusOptions: Array<{ label: string; value: string }> }
     expect(vm.statusOptions.some(o => o.value === 'open')).toBe(true)
     expect(vm.statusOptions.some(o => o.value === 'done')).toBe(true)
+  })
+
+  describe('row2 visibility toggle (Refs #205)', () => {
+    it('shows row2 fields by default', async () => {
+      const wrapper = mount(TicketTaskList, {
+        props: { ticketId: 'ticket-1', workflowStates: [], currentStatusId: null },
+        global: { stubs },
+      })
+      await flushPromises()
+      expect(wrapper.find('[data-testid="task-row2"]').exists()).toBe(true)
+      expect(wrapper.text()).toContain('次回:')
+    })
+
+    it('hides row2 when toggle is clicked and shows again on second click', async () => {
+      const wrapper = mount(TicketTaskList, {
+        props: { ticketId: 'ticket-1', workflowStates: [], currentStatusId: null },
+        global: { stubs },
+      })
+      await flushPromises()
+      const toggle = wrapper.find('[data-testid="task-row2-toggle"]')
+      expect(toggle.exists()).toBe(true)
+
+      await toggle.trigger('click')
+      expect(wrapper.find('[data-testid="task-row2"]').exists()).toBe(false)
+
+      await wrapper.find('[data-testid="task-row2-toggle"]').trigger('click')
+      expect(wrapper.find('[data-testid="task-row2"]').exists()).toBe(true)
+    })
+
+    it('persists row2 visibility across mounts via localStorage', async () => {
+      const wrapper1 = mount(TicketTaskList, {
+        props: { ticketId: 'ticket-1', workflowStates: [], currentStatusId: null },
+        global: { stubs },
+      })
+      await flushPromises()
+      await wrapper1.find('[data-testid="task-row2-toggle"]').trigger('click')
+      expect(wrapper1.find('[data-testid="task-row2"]').exists()).toBe(false)
+      wrapper1.unmount()
+
+      const wrapper2 = mount(TicketTaskList, {
+        props: { ticketId: 'ticket-1', workflowStates: [], currentStatusId: null },
+        global: { stubs },
+      })
+      await flushPromises()
+      expect(wrapper2.find('[data-testid="task-row2"]').exists()).toBe(false)
+    })
+
+    it('keeps next_action_by editable via row1 when row2 is hidden', async () => {
+      const wrapper = mount(TicketTaskList, {
+        props: { ticketId: 'ticket-1', workflowStates: [], currentStatusId: null },
+        global: { stubs },
+      })
+      await flushPromises()
+      await wrapper.find('[data-testid="task-row2-toggle"]').trigger('click')
+      expect(wrapper.find('[data-testid="task-row2"]').exists()).toBe(false)
+      // Row1 の「対応者」(next_action_by) 表示は Row2 非表示でも残る
+      expect(wrapper.text()).toContain('対応者:')
+    })
   })
 
   describe('edit modal (Refs #191)', () => {

--- a/tests/pages/tickets/print.test.ts
+++ b/tests/pages/tickets/print.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { allStubs } from '../../helpers/nuxt-stubs'
+import { makeTroubleTicket, makeWorkflowState } from '../../helpers/test-data'
+import type { TroubleTask } from '~/types'
+
+vi.mock('#app/composables/router', () => ({
+  useRoute: () => ({ params: { id: 'ticket-1' } }),
+}))
+
+const getTicketMock = vi.fn()
+const getWorkflowStatesMock = vi.fn()
+const getTasksMock = vi.fn()
+const getStatusHistoryMock = vi.fn()
+const updateTaskMock = vi.fn()
+const getTaskStatusesMock = vi.fn()
+const getCarInspectionsCurrentMock = vi.fn()
+vi.mock('~/utils/api', () => ({
+  getTicket: (...args: unknown[]) => getTicketMock(...args),
+  getWorkflowStates: (...args: unknown[]) => getWorkflowStatesMock(...args),
+  getTasks: (...args: unknown[]) => getTasksMock(...args),
+  getStatusHistory: (...args: unknown[]) => getStatusHistoryMock(...args),
+  updateTask: (...args: unknown[]) => updateTaskMock(...args),
+  getTaskStatuses: (...args: unknown[]) => getTaskStatusesMock(...args),
+  getCarInspectionsCurrent: (...args: unknown[]) => getCarInspectionsCurrentMock(...args),
+}))
+
+import PrintPage from '~/pages/tickets/print/[id].vue'
+
+function makeTask(overrides: Partial<TroubleTask> = {}): TroubleTask {
+  return {
+    id: 'task-1', tenant_id: 'tenant-1', ticket_id: 'ticket-1',
+    task_type: 'レッカー対応', title: 'レッカー業者到着', description: '',
+    status: 'open', assigned_to: null, due_date: null,
+    completed_at: null, sort_order: 0,
+    next_action: '', next_action_detail: '',
+    next_action_by: '青井 健', next_action_due: null,
+    occurred_at: '2026-07-13T21:08:00', created_by: null,
+    created_at: '2026-07-13T21:08:00', updated_at: '2026-07-13T21:08:00',
+    print_page_break_before: false,
+    ...overrides,
+  }
+}
+
+describe('print/[id] page', () => {
+  beforeEach(() => {
+    getTicketMock.mockReset()
+    getWorkflowStatesMock.mockReset()
+    getTasksMock.mockReset()
+    getStatusHistoryMock.mockReset()
+    updateTaskMock.mockReset()
+    getTaskStatusesMock.mockReset()
+    getCarInspectionsCurrentMock.mockReset()
+
+    getTicketMock.mockResolvedValue(makeTroubleTicket())
+    getWorkflowStatesMock.mockResolvedValue([makeWorkflowState()])
+    getTasksMock.mockResolvedValue([makeTask()])
+    getStatusHistoryMock.mockResolvedValue([])
+    getCarInspectionsCurrentMock.mockResolvedValue([])
+    getTaskStatusesMock.mockResolvedValue([])
+  })
+
+  it('renders 経過記録 table with 日付 as the first column', async () => {
+    const wrapper = mount(PrintPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    const table = wrapper.findAll('table').find(t => t.text().includes('経過記録') || t.find('th').exists())
+    const headers = wrapper.findAll('thead th').map(th => th.text())
+    // 経過記録テーブルのヘッダーを特定 (種別/対応者を含む方)
+    const taskTableHeaders = wrapper.findAll('table').map(t => t.findAll('th').map(th => th.text()))
+      .find(hs => hs.includes('種別') && hs.includes('対応者'))
+    expect(taskTableHeaders).toBeDefined()
+    expect(taskTableHeaders![0]).toBe('日付')
+    expect(headers.length).toBeGreaterThan(0)
+    void table
+  })
+
+  it('renders task row with occurred_at date in the first cell', async () => {
+    const wrapper = mount(PrintPage, { global: { stubs: allStubs } })
+    await flushPromises()
+
+    const taskTable = wrapper.findAll('table').find(t => {
+      const hs = t.findAll('th').map(th => th.text())
+      return hs.includes('種別') && hs.includes('対応者')
+    })
+    expect(taskTable).toBeDefined()
+    const firstDataRow = taskTable!.findAll('tbody tr')[0]!
+    const firstCell = firstDataRow.findAll('td')[0]!
+    expect(firstCell.text()).toBe('2026-07-13')
+  })
+})


### PR DESCRIPTION
## Summary

- `TicketTaskList.vue` の経過記録テーブルに Row2 (期限/次回/詳細/次担当) の表示/非表示トグルを追加。トグル状態は `localStorage` に永続化
  - `next_action_by` (次担当) は Row1 の「対応者」欄と編集モーダルにも表示されるため、Row2 を非表示にしても表示・編集手段は失われない (CLAUDE.md の「2 対応者フィールド」gotcha に抵触しないことを確認済み)
- `print/[id].vue` の経過記録テーブルで日付 (`occurred_at`) 列を一番左に移動
- (副産物) テスト共有の `UButton` stub に `emits: ['click']` を追加。宣言が無いと `@click` ハンドラが「stub 内の `$emit('click')`」と「Vue の fallthrough attribute によるネイティブバインド」の両方から発火し、1 クリックで 2 回トリガーされてしまう不具合があった (Row2 トグルの e2e テストで顕在化。既存の他ボタンはべき等な操作だったため症状が表面化していなかった)

## Test plan

- [x] `TicketTaskList.test.ts` に Row2 表示/非表示トグル・localStorage 永続化・next_action_by 編集手段が残ることのテストを追加、green
- [x] `tests/pages/tickets/print.test.ts` を新規追加し、経過記録テーブルの列順 (日付が先頭) を検証、green
- [x] `npx vitest run` (全 41 files / 335 tests) green

Refs #205

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nft47cAkNzLMynQatdc4ed)_