### PR TITLE
feat: 経過記録 Row2 表示設定をテナント共有設定に変更 (Refs #207)

### DIFF
--- a/.claude/skills/nuxt-trouble-map/SKILL.md
+++ b/.claude/skills/nuxt-trouble-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nuxt-trouble-map
-generated-from: nuxt-trouble:4c0dd6159507513764c4abc055a5d79582e7c197
+generated-from: nuxt-trouble:53ce0576d683f2063c79d0f87f61a000e969a279
 paths: [app/, server/]
 description: ippoan/nuxt-trouble (トラブル/状況管理 Nuxt 4 アプリ / Cloudflare Workers) の構造ナビゲーション。rust-alc-api `/api/troubles` を叩くチケット・タスク・ワークフロー管理 SPA。pages/composables/utils と ts-rs 生成型の配置、/api/proxy identity proxy、2 対応者フィールドの罠を 1 枚にまとめる。トリガー:「nuxt-trouble」「トラブル管理」「状況管理」「チケット」「trouble_tasks」「assigned_to」「next_action_by」「ワークフロー」「ガントチャート」「trouble.ippoan.org」「/api/proxy」等。
 ---

--- a/app/components/TicketTaskList.vue
+++ b/app/components/TicketTaskList.vue
@@ -3,6 +3,7 @@ import type { TroubleTask, TroubleWorkflowState, TroubleWorkflowTransition, Empl
 import { DEFAULT_TASK_TYPES, TASK_STATUS_LABELS } from '~/types'
 import { getTasks, getTaskTypes, createTask, updateTask, deleteTask, getEmployees, getTaskFiles, uploadTaskFile, downloadTaskFile, deleteTaskFile, restoreTaskFile, getWorkflowTransitions } from '~/utils/api'
 import { useTaskStatuses } from '~/composables/useTaskStatuses'
+import { useTicketFieldLayout } from '~/composables/useTicketFieldLayout'
 import { toDatetimeLocalInput, formatOccurredAt } from '~/utils/datetime'
 
 const { load: loadTaskStatuses, statuses: taskStatusList, byKey: taskStatusByKey, loaded: taskStatusesLoaded } = useTaskStatuses()
@@ -27,20 +28,33 @@ const addError = ref(false)
 
 // Row2 (期限/次回/詳細/次担当) 表示トグル。次担当 (next_action_by) 自体は
 // Row1 の「対応者」欄・編集モーダルにも表示されるため非表示にしても編集手段は残る。
-const ROW2_VISIBLE_KEY = 'trouble-task-row2-visible'
+// テナント全体で共有される設定 (trouble_field_layouts を流用、新規 migration 不要)。
+// ticket 入力フォーム用の key 群 (FIELD_METAS) とは名前空間を分ける。
+const ROW2_VISIBLE_KEY = 'task_row2_visible'
+const { fieldLayout, saving: row2Saving, fetchFieldLayout, saveFieldLayout } = useTicketFieldLayout()
 const showRow2 = ref(true)
 
-function loadRow2Visibility() {
-  if (typeof window === 'undefined') return
-  const saved = localStorage.getItem(ROW2_VISIBLE_KEY)
-  if (saved !== null) showRow2.value = saved === 'true'
+async function loadRow2Visibility() {
+  await fetchFieldLayout()
+  const entry = fieldLayout.value?.settings.find(e => e.key === ROW2_VISIBLE_KEY)
+  if (entry) showRow2.value = entry.visible
 }
 
-function toggleRow2() {
-  showRow2.value = !showRow2.value
-  /* v8 ignore next */
-  if (typeof window === 'undefined') return
-  localStorage.setItem(ROW2_VISIBLE_KEY, String(showRow2.value))
+async function toggleRow2() {
+  const next = !showRow2.value
+  showRow2.value = next
+  const settings = fieldLayout.value?.settings ?? []
+  const idx = settings.findIndex(e => e.key === ROW2_VISIBLE_KEY)
+  const entry = { key: ROW2_VISIBLE_KEY, visible: next, width: 'full', sort_order: 0, label: null }
+  const nextSettings = idx >= 0
+    ? settings.map((e, i) => i === idx ? entry : e)
+    : [...settings, entry]
+  try {
+    await saveFieldLayout({ settings: nextSettings })
+  } catch (e) {
+    console.error('Failed to save row2 visibility:', e)
+    showRow2.value = !next
+  }
 }
 
 const newTask = reactive({
@@ -597,7 +611,9 @@ const FORM_GRID = 'grid-cols-[6rem_17rem_1fr_1fr_8rem_2.5rem]'
           :label="showRow2 ? '下段を隠す' : '下段を表示'"
           size="xs"
           variant="outline"
+          :loading="row2Saving"
           data-testid="task-row2-toggle"
+          title="組織全体で共有される表示設定です"
           @click="toggleRow2"
         />
       </div>

--- a/tests/components/TicketTaskList.test.ts
+++ b/tests/components/TicketTaskList.test.ts
@@ -22,6 +22,8 @@ const mockUpdateTask = vi.fn().mockResolvedValue(sampleTask)
 const mockDeleteTask = vi.fn().mockResolvedValue(undefined)
 const mockGetEmployees = vi.fn().mockResolvedValue([])
 const mockGetTaskStatuses = vi.fn().mockResolvedValue([])
+const mockGetFieldLayout = vi.fn().mockResolvedValue({ settings: [] })
+const mockUpdateFieldLayout = vi.fn().mockImplementation((layout: any) => Promise.resolve(layout))
 
 vi.mock('~/utils/api', () => ({
   getTasks: (...args: any[]) => mockGetTasks(...args),
@@ -37,6 +39,8 @@ vi.mock('~/utils/api', () => ({
   deleteTaskFile: vi.fn().mockResolvedValue(undefined),
   restoreTaskFile: vi.fn().mockResolvedValue(undefined),
   getTrashFiles: vi.fn().mockResolvedValue([]),
+  getFieldLayout: (...args: any[]) => mockGetFieldLayout(...args),
+  updateFieldLayout: (...args: any[]) => mockUpdateFieldLayout(...args),
 }))
 
 const stubs = {
@@ -76,13 +80,14 @@ const stubs = {
 describe('TicketTaskList', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    localStorage.clear()
     mockGetTasks.mockResolvedValue([sampleTask])
     mockGetTaskTypes.mockResolvedValue([
       { id: '1', name: 'レッカー対応', sort_order: 0, tenant_id: 't1', created_at: '' },
     ])
     mockGetEmployees.mockResolvedValue([])
     mockGetTaskStatuses.mockResolvedValue([])
+    mockGetFieldLayout.mockResolvedValue({ settings: [] })
+    mockUpdateFieldLayout.mockImplementation((layout: any) => Promise.resolve(layout))
   })
 
   it('renders heading', async () => {
@@ -160,28 +165,71 @@ describe('TicketTaskList', () => {
       expect(toggle.exists()).toBe(true)
 
       await toggle.trigger('click')
+      await flushPromises()
       expect(wrapper.find('[data-testid="task-row2"]').exists()).toBe(false)
+      expect(mockUpdateFieldLayout).toHaveBeenCalledWith({
+        settings: [{ key: 'task_row2_visible', visible: false, width: 'full', sort_order: 0, label: null }],
+      })
 
       await wrapper.find('[data-testid="task-row2-toggle"]').trigger('click')
+      await flushPromises()
       expect(wrapper.find('[data-testid="task-row2"]').exists()).toBe(true)
     })
 
-    it('persists row2 visibility across mounts via localStorage', async () => {
+    it('reverts optimistic update when save fails', async () => {
+      mockUpdateFieldLayout.mockRejectedValueOnce(new Error('network error'))
+      const wrapper = mount(TicketTaskList, {
+        props: { ticketId: 'ticket-1', workflowStates: [], currentStatusId: null },
+        global: { stubs },
+      })
+      await flushPromises()
+
+      await wrapper.find('[data-testid="task-row2-toggle"]').trigger('click')
+      await flushPromises()
+      expect(wrapper.find('[data-testid="task-row2"]').exists()).toBe(true)
+    })
+
+    it('persists row2 visibility across mounts via tenant field-layout setting (org 設定)', async () => {
       const wrapper1 = mount(TicketTaskList, {
         props: { ticketId: 'ticket-1', workflowStates: [], currentStatusId: null },
         global: { stubs },
       })
       await flushPromises()
       await wrapper1.find('[data-testid="task-row2-toggle"]').trigger('click')
+      await flushPromises()
       expect(wrapper1.find('[data-testid="task-row2"]').exists()).toBe(false)
       wrapper1.unmount()
 
+      // 2 回目の mount は別ブラウザ (= localStorage を共有しない) を模す。
+      // 保存済みのテナント設定を API 経由で返すようモックし直す。
+      mockGetFieldLayout.mockResolvedValue({
+        settings: [{ key: 'task_row2_visible', visible: false, width: 'full', sort_order: 0, label: null }],
+      })
       const wrapper2 = mount(TicketTaskList, {
         props: { ticketId: 'ticket-1', workflowStates: [], currentStatusId: null },
         global: { stubs },
       })
       await flushPromises()
       expect(wrapper2.find('[data-testid="task-row2"]').exists()).toBe(false)
+    })
+
+    it('preserves other tenant field-layout settings when saving row2 visibility', async () => {
+      mockGetFieldLayout.mockResolvedValue({
+        settings: [{ key: 'title', visible: false, width: 'half', sort_order: 5, label: 'カスタムタイトル' }],
+      })
+      const wrapper = mount(TicketTaskList, {
+        props: { ticketId: 'ticket-1', workflowStates: [], currentStatusId: null },
+        global: { stubs },
+      })
+      await flushPromises()
+      await wrapper.find('[data-testid="task-row2-toggle"]').trigger('click')
+      await flushPromises()
+      expect(mockUpdateFieldLayout).toHaveBeenCalledWith({
+        settings: [
+          { key: 'title', visible: false, width: 'half', sort_order: 5, label: 'カスタムタイトル' },
+          { key: 'task_row2_visible', visible: false, width: 'full', sort_order: 0, label: null },
+        ],
+      })
     })
 
     it('keeps next_action_by editable via row1 when row2 is hidden', async () => {
@@ -191,6 +239,7 @@ describe('TicketTaskList', () => {
       })
       await flushPromises()
       await wrapper.find('[data-testid="task-row2-toggle"]').trigger('click')
+      await flushPromises()
       expect(wrapper.find('[data-testid="task-row2"]').exists()).toBe(false)
       // Row1 の「対応者」(next_action_by) 表示は Row2 非表示でも残る
       expect(wrapper.text()).toContain('対応者:')


### PR DESCRIPTION
## Summary

- ippoan/nuxt-trouble#206 で追加した経過記録 Row2 (期限/次回/詳細/次担当) 表示トグルは `localStorage` ベースの個人設定だったが、チーム全体で統一されるべき設定 (org 設定) にすべきというフィードバックを受けて変更
- 既存の `trouble_field_layouts` テナント設定ストア（チケット入力フォームの表示/非表示設定と同じ仕組み、新規 migration 不要）を再利用し、`useTicketFieldLayout` composable 経由で `task_row2_visible` という key で保存・取得する
- 既存のチケット入力フォーム設定 (`FIELD_METAS` の key 群) とは名前空間を分離
- 保存失敗時は楽観的更新を revert

## Test plan

- [x] `TicketTaskList.test.ts` にテナント設定経由の保存/取得・他フィールド設定を上書きしないこと・保存失敗時のrevertのテストを追加、green
- [x] `npx vitest run` (全 41 files / 337 tests) green

Refs #207

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nft47cAkNzLMynQatdc4ed)_