### PR TITLE
feat: 編集モーダルの対応者入力欄に × クリアボタンを追加 (Refs #211)

### DIFF
--- a/.claude/skills/nuxt-trouble-map/SKILL.md
+++ b/.claude/skills/nuxt-trouble-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nuxt-trouble-map
-generated-from: nuxt-trouble:707c8e3e126aadebaf7e1ad9871089ca079fbae8
+generated-from: nuxt-trouble:1be50ddd779fc5bdbde95edb2b5227f81155d92e
 paths: [app/, server/]
 description: ippoan/nuxt-trouble (トラブル/状況管理 Nuxt 4 アプリ / Cloudflare Workers) の構造ナビゲーション。rust-alc-api `/api/troubles` を叩くチケット・タスク・ワークフロー管理 SPA。pages/composables/utils と ts-rs 生成型の配置、/api/proxy identity proxy、2 対応者フィールドの罠を 1 枚にまとめる。トリガー:「nuxt-trouble」「トラブル管理」「状況管理」「チケット」「trouble_tasks」「assigned_to」「next_action_by」「ワークフロー」「ガントチャート」「trouble.ippoan.org」「/api/proxy」等。
 ---

--- a/app/components/TicketTaskList.vue
+++ b/app/components/TicketTaskList.vue
@@ -846,7 +846,19 @@ const FORM_GRID = 'grid-cols-[6rem_17rem_1fr_1fr_8rem_2.5rem]'
 
           <div class="grid grid-cols-2 gap-3">
             <UFormField label="対応者">
-              <input v-model="editForm.assigned_name" list="task-employee-list" data-testid="edit-assigned" class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" />
+              <div class="relative">
+                <input v-model="editForm.assigned_name" list="task-employee-list" data-testid="edit-assigned" class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 pr-7 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500 [&::-webkit-calendar-picker-indicator]:hidden" />
+                <button
+                  v-if="editForm.assigned_name"
+                  type="button"
+                  data-testid="edit-assigned-clear"
+                  aria-label="対応者をクリア"
+                  class="absolute right-1.5 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200 transition-colors"
+                  @click="editForm.assigned_name = ''"
+                >
+                  <UIcon name="i-lucide-x" class="size-4" />
+                </button>
+              </div>
             </UFormField>
             <UFormField label="期限">
               <YmdtInput
@@ -866,7 +878,19 @@ const FORM_GRID = 'grid-cols-[6rem_17rem_1fr_1fr_8rem_2.5rem]'
 
           <div class="grid grid-cols-2 gap-3">
             <UFormField label="次のアクション対応者">
-              <input v-model="editForm.next_action_by" list="task-employee-list" data-testid="edit-next-action-by" class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" />
+              <div class="relative">
+                <input v-model="editForm.next_action_by" list="task-employee-list" data-testid="edit-next-action-by" class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 pr-7 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500 [&::-webkit-calendar-picker-indicator]:hidden" />
+                <button
+                  v-if="editForm.next_action_by"
+                  type="button"
+                  data-testid="edit-next-action-by-clear"
+                  aria-label="次のアクション対応者をクリア"
+                  class="absolute right-1.5 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200 transition-colors"
+                  @click="editForm.next_action_by = ''"
+                >
+                  <UIcon name="i-lucide-x" class="size-4" />
+                </button>
+              </div>
             </UFormField>
             <UFormField label="次のアクション期限">
               <YmdInput

--- a/tests/components/TicketTaskList.test.ts
+++ b/tests/components/TicketTaskList.test.ts
@@ -254,6 +254,30 @@ describe('TicketTaskList', () => {
       expect(wrapper.find('[data-testid="edit-next-action-by"]').exists()).toBe(true)
     })
 
+    it('対応者欄のクリアボタンは値がある時だけ表示され、クリックで空にする (Refs #211)', async () => {
+      const wrapper = await mountWithTwoTasks()
+      await wrapper.find('[data-testid="task-edit-button"]').trigger('click')
+      await flushPromises()
+      // task-1 (先頭行) は assigned_to/next_action_by が無いので初期状態でクリアボタン非表示
+      expect(wrapper.find('[data-testid="edit-assigned-clear"]').exists()).toBe(false)
+      expect(wrapper.find('[data-testid="edit-next-action-by-clear"]').exists()).toBe(false)
+
+      const vm = wrapper.vm as any
+      vm.editForm.assigned_name = '松江 寛人'
+      vm.editForm.next_action_by = '山田'
+      await flushPromises()
+      expect(wrapper.find('[data-testid="edit-assigned-clear"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="edit-next-action-by-clear"]').exists()).toBe(true)
+
+      await wrapper.find('[data-testid="edit-assigned-clear"]').trigger('click')
+      expect(vm.editForm.assigned_name).toBe('')
+      expect(wrapper.find('[data-testid="edit-assigned-clear"]').exists()).toBe(false)
+
+      await wrapper.find('[data-testid="edit-next-action-by-clear"]').trigger('click')
+      expect(vm.editForm.next_action_by).toBe('')
+      expect(wrapper.find('[data-testid="edit-next-action-by-clear"]').exists()).toBe(false)
+    })
+
     it('保存で updateTask が呼ばれ、対応者名は employee id に変換される', async () => {
       const wrapper = await mountWithTwoTasks()
       await wrapper.find('[data-testid="task-edit-button"]').trigger('click')


### PR DESCRIPTION
## Summary

- `TicketTaskList.vue` の1件編集モーダルにある「対応者」(`assigned_name`)・「次のアクション対応者」(`next_action_by`) の datalist 付き入力欄に、値がある時だけ表示される × クリアボタンを追加
- ネイティブ datalist 矢印を CSS (`::-webkit-calendar-picker-indicator`) で非表示化
- 対象は編集モーダルの2箇所のみ(インライン編集・新規追加フォームの同様の入力欄はスコープ外)

## Test plan

- [x] クリアボタンが値がある時だけ表示され、クリックで即座に空になることを確認するテストを追加、green
- [x] `npx vitest run` (全 41 files / 336 tests) green

Refs #211

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nft47cAkNzLMynQatdc4ed)_