### PR TITLE
fix: 経過記録一覧 Row1 の対応者欄を assigned_to に修正 (next_action_by とのテレコ解消) (Refs #214)

### DIFF
--- a/app/components/EmployeeNameInput.vue
+++ b/app/components/EmployeeNameInput.vue
@@ -123,11 +123,17 @@ onUnmounted(() => {
       @blur="onBlur"
     />
     <Teleport to="body">
+      <!-- pointer-events-auto: モーダル (Reka UI Dialog) が open の間 body には
+           pointer-events: none が付くため、body 直下に Teleport する menu は明示的に
+           継承を断たないとクリックが素通りする (Refs #215)。
+           @pointerdown.stop: Dialog の「外側クリックで閉じる」判定 (document の
+           pointerdown listener) に届かせず、候補クリックでモーダルが閉じるのを防ぐ。 -->
       <div
         v-if="open && candidates.length > 0"
         data-testid="employee-name-menu"
         :style="menuStyle"
-        class="z-[60] max-h-48 overflow-y-auto rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg py-0.5"
+        class="z-[60] pointer-events-auto max-h-48 overflow-y-auto rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg py-0.5"
+        @pointerdown.stop
       >
         <!-- mousedown.prevent: 選択クリックで input の blur を発火させない -->
         <button

--- a/app/components/EmployeeNameInput.vue
+++ b/app/components/EmployeeNameInput.vue
@@ -1,0 +1,148 @@
+<script setup lang="ts">
+import type { Employee } from '~/types'
+
+// 従業員名のオートコンプリート入力 (Refs #215 レビュー指摘)。
+// native の <datalist> は日本語 IME 入力中に候補が出ない/出ても選べないことが
+// あるため、フィルタとドロップダウンを自前で描画する。
+// - 値 (v-model) は名前の自由テキスト。マスタ照合 (一致しない名前の扱い) は親の責務
+// - 候補クリック / Enter で名前を確定し select を emit する
+// - ドロップダウンは overflow コンテナに clip されないよう body へ Teleport + fixed 配置
+const model = defineModel<string>({ required: true })
+
+const props = defineProps<{
+  employees: Employee[]
+}>()
+
+const emit = defineEmits<{
+  select: [employee: Employee]
+  blur: []
+}>()
+
+defineOptions({ inheritAttrs: false })
+
+const open = ref(false)
+const highlighted = ref(-1)
+const inputRef = ref<HTMLInputElement | null>(null)
+const menuStyle = ref<Record<string, string>>({})
+
+const candidates = computed(() => {
+  const q = model.value.trim()
+  const list = q
+    ? props.employees.filter(e => e.name.includes(q) || (e.code ?? '').includes(q))
+    : props.employees
+  return list.slice(0, 50)
+})
+
+function positionMenu() {
+  /* v8 ignore next */
+  const rect = inputRef.value?.getBoundingClientRect()
+  /* v8 ignore next */
+  if (!rect) return
+  menuStyle.value = {
+    position: 'fixed',
+    top: `${rect.bottom + 2}px`,
+    left: `${rect.left}px`,
+    minWidth: `${Math.max(rect.width, 160)}px`,
+  }
+}
+
+function openMenu() {
+  if (props.employees.length === 0) return
+  positionMenu()
+  open.value = true
+}
+
+function closeMenu() {
+  open.value = false
+  highlighted.value = -1
+}
+
+function onInput() {
+  openMenu()
+  highlighted.value = -1
+}
+
+function selectEmployee(e: Employee) {
+  model.value = e.name
+  closeMenu()
+  emit('select', e)
+}
+
+function onKeydown(ev: KeyboardEvent) {
+  if (ev.key === 'ArrowDown') {
+    ev.preventDefault()
+    if (!open.value) openMenu()
+    else highlighted.value = Math.min(highlighted.value + 1, candidates.value.length - 1)
+  } else if (ev.key === 'ArrowUp') {
+    ev.preventDefault()
+    highlighted.value = Math.max(highlighted.value - 1, 0)
+  } else if (ev.key === 'Enter') {
+    const picked = open.value && highlighted.value >= 0 ? candidates.value[highlighted.value] : undefined
+    if (picked) {
+      ev.preventDefault()
+      selectEmployee(picked)
+    } else {
+      closeMenu()
+      ;(ev.target as HTMLInputElement).blur()
+    }
+  } else if (ev.key === 'Escape') {
+    closeMenu()
+  }
+}
+
+function onBlur() {
+  closeMenu()
+  emit('blur')
+}
+
+// fixed 配置なのでスクロールで入力欄とズレる前に閉じる
+function onWindowScroll() {
+  /* v8 ignore next */
+  if (open.value) closeMenu()
+}
+
+onMounted(() => {
+  window.addEventListener('scroll', onWindowScroll, { capture: true, passive: true })
+})
+
+onUnmounted(() => {
+  window.removeEventListener('scroll', onWindowScroll, { capture: true })
+})
+</script>
+
+<template>
+  <div class="relative w-full min-w-0">
+    <input
+      ref="inputRef"
+      v-model="model"
+      v-bind="$attrs"
+      autocomplete="off"
+      @input="onInput"
+      @focus="openMenu"
+      @keydown="onKeydown"
+      @blur="onBlur"
+    />
+    <Teleport to="body">
+      <div
+        v-if="open && candidates.length > 0"
+        data-testid="employee-name-menu"
+        :style="menuStyle"
+        class="z-[60] max-h-48 overflow-y-auto rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg py-0.5"
+      >
+        <!-- mousedown.prevent: 選択クリックで input の blur を発火させない -->
+        <button
+          v-for="(e, i) in candidates"
+          :key="e.id"
+          type="button"
+          data-testid="employee-name-option"
+          class="block w-full text-left text-xs px-2 py-1 hover:bg-blue-50 dark:hover:bg-blue-950"
+          :class="i === highlighted ? 'bg-blue-50 dark:bg-blue-950' : ''"
+          @mousedown.prevent
+          @click="selectEmployee(e)"
+        >
+          {{ e.name }}<span v-if="e.code" class="ml-1 text-gray-400">({{ e.code }})</span>
+        </button>
+      </div>
+    </Teleport>
+  </div>
+</template>

--- a/app/components/TicketTaskList.vue
+++ b/app/components/TicketTaskList.vue
@@ -25,8 +25,9 @@ const adding = ref(false)
 const employees = ref<Employee[]>([])
 const addError = ref(false)
 
-// Row2 (期限/次回/詳細/次担当) 表示トグル。次担当 (next_action_by) 自体は
-// Row1 の「対応者」欄・編集モーダルにも表示されるため非表示にしても編集手段は残る。
+// Row2 (期限/次回/詳細/次担当) 表示トグル。次担当 (next_action_by) は Row2 を
+// 非表示にしても編集モーダルで編集できる。Row1 の「対応者」は assigned_to
+// (タスク対応者) であり next_action_by とは別フィールド (Refs #214)。
 // 個人のブラウザ単位の設定 (localStorage)。
 const ROW2_VISIBLE_KEY = 'trouble-task-row2-visible'
 const showRow2 = ref(true)
@@ -220,6 +221,9 @@ function startEdit(task: TroubleTask, field: string) {
   const val = (task as any)[field]
   if (field === 'occurred_at' || field === 'due_date') {
     editingValue.value = val?.substring(0, 10) || ''
+  } else if (field === 'assigned_to') {
+    // assigned_to は employee id で持つため、インライン編集は名前で行い保存時に id へ戻す
+    editingValue.value = employeeNameById(val)
   } else {
     editingValue.value = val || ''
   }
@@ -231,7 +235,9 @@ async function saveEdit(taskId: string, field: string) {
   if (!original) return
   const oldVal = (field === 'occurred_at' || field === 'due_date')
     ? ((original as any)[field]?.substring(0, 10) || '')
-    : ((original as any)[field] || '')
+    : field === 'assigned_to'
+      ? employeeNameById((original as any)[field])
+      : ((original as any)[field] || '')
   if (editingValue.value === oldVal) return
   const payload: Record<string, any> = {}
   if (field === 'occurred_at') {
@@ -254,6 +260,11 @@ async function saveEdit(taskId: string, field: string) {
     } else {
       payload.due_date = null
     }
+  } else if (field === 'assigned_to') {
+    // 名前 → employee id 変換 (追加フォーム・編集モーダルと同じ規則。一致しなければ null)
+    const name = editingValue.value.trim()
+    const matchedEmployee = name ? employees.value.find(e => e.name === name) : null
+    payload.assigned_to = matchedEmployee?.id || null
   } else {
     payload[field] = editingValue.value || null
   }
@@ -620,7 +631,7 @@ const FORM_GRID = 'grid-cols-[6rem_17rem_1fr_1fr_8rem_2.5rem]'
 
       <!-- Task rows (2 rows per task, same 9-col grid) -->
       <template v-for="(task, idx) in tasks" :key="task.id">
-        <!-- Row 1: reorder / task_type / occurred_at / title / description / next_action_by / status / file / delete -->
+        <!-- Row 1: reorder / task_type / occurred_at / title / description / assigned_to / status / file / delete -->
         <div :data-task-id="task.id" :class="['grid gap-1 pt-2 pb-0.5 px-1 items-center hover:bg-gray-50/50 dark:hover:bg-gray-800/30 transition-colors', GRID]">
           <div class="flex flex-col items-center">
             <button class="text-gray-400 hover:text-gray-200 disabled:opacity-20 transition-colors" :disabled="idx === 0" @click="handleMoveUp(idx)"><UIcon name="i-lucide-chevron-up" class="size-3" /></button>
@@ -649,10 +660,10 @@ const FORM_GRID = 'grid-cols-[6rem_17rem_1fr_1fr_8rem_2.5rem]'
           <span v-else class="text-xs text-gray-400 truncate cursor-pointer hover:text-gray-200 transition-colors" @click="startEdit(task, 'description')">
             <span class="text-[10px] text-gray-500 inline-block w-8 mr-0.5 [text-align-last:justify]">内容:</span>{{ task.description || '-' }}
           </span>
-          <!-- next_action_by (対応者) -->
-          <input v-if="isEditing(task.id, 'next_action_by')" v-model="editingValue" list="task-employee-list" class="min-w-0 text-xs border border-blue-500 rounded px-1 py-0.5 bg-transparent" @blur="saveEdit(task.id, 'next_action_by')" @keydown.enter="($event.target as HTMLInputElement).blur()" />
-          <span v-else class="text-xs text-gray-400 truncate cursor-pointer hover:text-gray-200 transition-colors" @click="startEdit(task, 'next_action_by')">
-            <span class="text-[10px] text-gray-500 inline-block w-8 mr-0.5 [text-align-last:justify]">対応者:</span>{{ task.next_action_by || '-' }}
+          <!-- assigned_to (対応者。インライン編集は名前入力 → employee id 変換、Refs #214) -->
+          <input v-if="isEditing(task.id, 'assigned_to')" v-model="editingValue" list="task-employee-list" data-testid="task-assigned-edit" class="min-w-0 text-xs border border-blue-500 rounded px-1 py-0.5 bg-transparent" @blur="saveEdit(task.id, 'assigned_to')" @keydown.enter="($event.target as HTMLInputElement).blur()" />
+          <span v-else data-testid="task-assigned" class="text-xs text-gray-400 truncate cursor-pointer hover:text-gray-200 transition-colors" @click="startEdit(task, 'assigned_to')">
+            <span class="text-[10px] text-gray-500 inline-block w-8 mr-0.5 [text-align-last:justify]">対応者:</span>{{ employeeNameById(task.assigned_to) || '-' }}
           </span>
           <!-- status -->
           <USelect :model-value="task.status" :items="statusOptions" size="xs" class="min-w-0" @update:model-value="handleStatusChange(task.id, $event)" />
@@ -693,9 +704,9 @@ const FORM_GRID = 'grid-cols-[6rem_17rem_1fr_1fr_8rem_2.5rem]'
           <span v-else class="text-xs text-gray-400 truncate cursor-pointer hover:text-gray-200 transition-colors" @click="startEdit(task, 'next_action_detail')">
             <span class="text-[10px] text-gray-500 inline-block w-8 mr-0.5 [text-align-last:justify]">詳細:</span>{{ task.next_action_detail || '-' }}
           </span>
-          <!-- next_action_by (aligned under 対応者) -->
+          <!-- next_action_by (次担当、対応者の下に揃える) -->
           <input v-if="isEditing(task.id, 'next_action_by')" v-model="editingValue" list="task-employee-list" class="min-w-0 text-xs border border-blue-500 rounded px-1 py-0.5 bg-transparent" @blur="saveEdit(task.id, 'next_action_by')" @keydown.enter="($event.target as HTMLInputElement).blur()" />
-          <span v-else class="text-xs text-gray-400 truncate cursor-pointer hover:text-gray-200 transition-colors" @click="startEdit(task, 'next_action_by')">
+          <span v-else data-testid="task-next-action-by" class="text-xs text-gray-400 truncate cursor-pointer hover:text-gray-200 transition-colors" @click="startEdit(task, 'next_action_by')">
             <span class="text-[10px] text-gray-500 inline-block w-8 mr-0.5 [text-align-last:justify]">次担当:</span>{{ task.next_action_by || '-' }}
           </span>
           <span />

--- a/app/components/TicketTaskList.vue
+++ b/app/components/TicketTaskList.vue
@@ -24,6 +24,13 @@ const taskTypes = ref<string[]>([])
 const adding = ref(false)
 const employees = ref<Employee[]>([])
 const addError = ref(false)
+// 対応者 (assigned_to) にマスタ不一致の名前が入った時のエラー。保存せず入力を
+// 保持してユーザーに知らせる (無言で null に落とさない、Refs #217)
+const addAssignedError = ref<string | null>(null)
+
+function assignedMismatchMessage(name: string): string {
+  return `対応者「${name}」は従業員マスタに登録がありません。候補から選択するか空にしてください`
+}
 
 // Row2 (期限/次回/詳細/次担当) 表示トグル。次担当 (next_action_by) は Row2 を
 // 非表示にしても編集モーダルで編集できる。Row1 の「対応者」は assigned_to
@@ -67,6 +74,7 @@ function resetForm() {
   newTask.assigned_name = ''
   newTask.next_action_by_name = ''
   addError.value = false
+  addAssignedError.value = null
 }
 
 async function fetchEmployees() {
@@ -156,11 +164,17 @@ function checkSuggestions() {
 
 async function handleAddTask() {
   if (!newTask.title.trim()) return
+  const name = newTask.assigned_name.trim()
+  const matchedEmployee = name ? employees.value.find(e => e.name === name) : null
+  if (name && !matchedEmployee) {
+    // 保存せず入力を保持してエラー表示 (Refs #217)
+    addAssignedError.value = assignedMismatchMessage(name)
+    return
+  }
+  addAssignedError.value = null
   adding.value = true
   addError.value = false
   try {
-    const name = newTask.assigned_name.trim()
-    const matchedEmployee = name ? employees.value.find(e => e.name === name) : null
     await createTask(props.ticketId, {
       task_type: newTask.task_type,
       title: newTask.title.trim(),
@@ -214,10 +228,12 @@ const statusOptions = computed<{ label: string; value: string }[]>(() => {
 const editingId = ref<string | null>(null)
 const editingField = ref<string | null>(null)
 const editingValue = ref('')
+const inlineEditError = ref<string | null>(null)
 
 function startEdit(task: TroubleTask, field: string) {
   editingId.value = task.id
   editingField.value = field
+  inlineEditError.value = null
   const val = (task as any)[field]
   if (field === 'occurred_at' || field === 'due_date') {
     editingValue.value = val?.substring(0, 10) || ''
@@ -230,15 +246,21 @@ function startEdit(task: TroubleTask, field: string) {
 }
 
 async function saveEdit(taskId: string, field: string) {
-  editingId.value = null
   const original = tasks.value.find(t => t.id === taskId)
-  if (!original) return
+  if (!original) {
+    editingId.value = null
+    return
+  }
   const oldVal = (field === 'occurred_at' || field === 'due_date')
     ? ((original as any)[field]?.substring(0, 10) || '')
     : field === 'assigned_to'
       ? employeeNameById((original as any)[field])
       : ((original as any)[field] || '')
-  if (editingValue.value === oldVal) return
+  if (editingValue.value === oldVal) {
+    editingId.value = null
+    inlineEditError.value = null
+    return
+  }
   const payload: Record<string, any> = {}
   if (field === 'occurred_at') {
     // インラインは日付のみ編集。既存の時刻部分 (追加/編集モーダルで入れた HH:mm)
@@ -261,13 +283,20 @@ async function saveEdit(taskId: string, field: string) {
       payload.due_date = null
     }
   } else if (field === 'assigned_to') {
-    // 名前 → employee id 変換 (追加フォーム・編集モーダルと同じ規則。一致しなければ null)
+    // 名前 → employee id 変換 (追加フォーム・編集モーダルと同じ規則)。
+    // マスタ不一致は保存せず入力を保持してエラー表示 (Refs #217)
     const name = editingValue.value.trim()
     const matchedEmployee = name ? employees.value.find(e => e.name === name) : null
+    if (name && !matchedEmployee) {
+      inlineEditError.value = assignedMismatchMessage(name)
+      return
+    }
     payload.assigned_to = matchedEmployee?.id || null
   } else {
     payload[field] = editingValue.value || null
   }
+  editingId.value = null
+  inlineEditError.value = null
   try {
     await updateTask(taskId, payload)
     await loadTasks()
@@ -342,11 +371,16 @@ async function saveEditModal(): Promise<boolean> {
     editError.value = 'タイトルを入力してください'
     return false
   }
+  const name = editForm.assigned_name.trim()
+  const matchedEmployee = name ? employees.value.find(e => e.name === name) : null
+  if (name && !matchedEmployee) {
+    // 保存せず入力を保持してエラー表示 (Refs #217)
+    editError.value = assignedMismatchMessage(name)
+    return false
+  }
   editSaving.value = true
   editError.value = null
   try {
-    const name = editForm.assigned_name.trim()
-    const matchedEmployee = name ? employees.value.find(e => e.name === name) : null
     await updateTask(task.id, {
       task_type: editForm.task_type,
       title: editForm.title.trim(),
@@ -661,7 +695,7 @@ const FORM_GRID = 'grid-cols-[6rem_17rem_1fr_1fr_8rem_2.5rem]'
             <span class="text-[10px] text-gray-500 inline-block w-8 mr-0.5 [text-align-last:justify]">内容:</span>{{ task.description || '-' }}
           </span>
           <!-- assigned_to (対応者。インライン編集は名前入力 → employee id 変換、Refs #214) -->
-          <input v-if="isEditing(task.id, 'assigned_to')" v-model="editingValue" list="task-employee-list" data-testid="task-assigned-edit" class="min-w-0 text-xs border border-blue-500 rounded px-1 py-0.5 bg-transparent" @blur="saveEdit(task.id, 'assigned_to')" @keydown.enter="($event.target as HTMLInputElement).blur()" />
+          <EmployeeNameInput v-if="isEditing(task.id, 'assigned_to')" v-model="editingValue" :employees="employees" data-testid="task-assigned-edit" class="w-full text-xs border border-blue-500 rounded px-1 py-0.5 bg-transparent" @select="saveEdit(task.id, 'assigned_to')" @blur="saveEdit(task.id, 'assigned_to')" />
           <span v-else data-testid="task-assigned" class="text-xs text-gray-400 truncate cursor-pointer hover:text-gray-200 transition-colors" @click="startEdit(task, 'assigned_to')">
             <span class="text-[10px] text-gray-500 inline-block w-8 mr-0.5 [text-align-last:justify]">対応者:</span>{{ employeeNameById(task.assigned_to) || '-' }}
           </span>
@@ -704,14 +738,19 @@ const FORM_GRID = 'grid-cols-[6rem_17rem_1fr_1fr_8rem_2.5rem]'
           <span v-else class="text-xs text-gray-400 truncate cursor-pointer hover:text-gray-200 transition-colors" @click="startEdit(task, 'next_action_detail')">
             <span class="text-[10px] text-gray-500 inline-block w-8 mr-0.5 [text-align-last:justify]">詳細:</span>{{ task.next_action_detail || '-' }}
           </span>
-          <!-- next_action_by (次担当、対応者の下に揃える) -->
-          <input v-if="isEditing(task.id, 'next_action_by')" v-model="editingValue" list="task-employee-list" class="min-w-0 text-xs border border-blue-500 rounded px-1 py-0.5 bg-transparent" @blur="saveEdit(task.id, 'next_action_by')" @keydown.enter="($event.target as HTMLInputElement).blur()" />
+          <!-- next_action_by (次担当、対応者の下に揃える。自由テキスト + 従業員サジェスト) -->
+          <EmployeeNameInput v-if="isEditing(task.id, 'next_action_by')" v-model="editingValue" :employees="employees" class="w-full text-xs border border-blue-500 rounded px-1 py-0.5 bg-transparent" @select="saveEdit(task.id, 'next_action_by')" @blur="saveEdit(task.id, 'next_action_by')" />
           <span v-else data-testid="task-next-action-by" class="text-xs text-gray-400 truncate cursor-pointer hover:text-gray-200 transition-colors" @click="startEdit(task, 'next_action_by')">
             <span class="text-[10px] text-gray-500 inline-block w-8 mr-0.5 [text-align-last:justify]">次担当:</span>{{ task.next_action_by || '-' }}
           </span>
           <span />
           <span />
           <span />
+        </div>
+
+        <!-- インライン編集の対応者マスタ不一致エラー (保存せず入力保持、Refs #217) -->
+        <div v-if="editingId === task.id && inlineEditError" data-testid="task-inline-error" class="px-1 pb-1 text-xs text-red-500">
+          {{ inlineEditError }}
         </div>
 
         <!-- File panel -->
@@ -749,7 +788,7 @@ const FORM_GRID = 'grid-cols-[6rem_17rem_1fr_1fr_8rem_2.5rem]'
           </div>
           <input v-model="newTask.title" placeholder="タイトル" class="min-w-0 text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" @keydown.enter="handleAddTask" />
           <input v-model="newTask.description" placeholder="内容" class="min-w-0 text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" />
-          <input v-model="newTask.assigned_name" list="task-employee-list" placeholder="対応者" class="min-w-0 text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" />
+          <EmployeeNameInput v-model="newTask.assigned_name" :employees="employees" data-testid="add-assigned" placeholder="対応者" class="w-full text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" />
           <span />
         </div>
         <!-- Form Row 2: (empty) / due_date / next_action / detail / next_action_by / add-btn -->
@@ -765,12 +804,13 @@ const FORM_GRID = 'grid-cols-[6rem_17rem_1fr_1fr_8rem_2.5rem]'
           </div>
           <input v-model="newTask.next_action" placeholder="次のアクション" class="min-w-0 text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" />
           <input v-model="newTask.next_action_detail" placeholder="詳細" class="min-w-0 text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" />
-          <input v-model="newTask.next_action_by_name" list="task-employee-list" placeholder="次の対応者" class="min-w-0 text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" />
+          <EmployeeNameInput v-model="newTask.next_action_by_name" :employees="employees" placeholder="次の対応者" class="w-full text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" />
           <UButton icon="i-lucide-plus" size="xs" :loading="adding" :disabled="!newTask.title.trim()" @click="handleAddTask" />
         </div>
-        <datalist id="task-employee-list">
-          <option v-for="e in employees" :key="e.id" :value="e.name" />
-        </datalist>
+        <!-- 追加フォームの対応者マスタ不一致エラー (保存せず入力保持、Refs #217) -->
+        <div v-if="addAssignedError" data-testid="add-assigned-error" class="px-1 mt-1 text-xs text-red-500">
+          {{ addAssignedError }}
+        </div>
       </div>
         </div>
       </div>
@@ -858,7 +898,7 @@ const FORM_GRID = 'grid-cols-[6rem_17rem_1fr_1fr_8rem_2.5rem]'
           <div class="grid grid-cols-2 gap-3">
             <UFormField label="対応者">
               <div class="relative">
-                <input v-model="editForm.assigned_name" list="task-employee-list" data-testid="edit-assigned" class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 pr-7 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500 [&::-webkit-calendar-picker-indicator]:hidden" />
+                <EmployeeNameInput v-model="editForm.assigned_name" :employees="employees" data-testid="edit-assigned" class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 pr-7 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" />
                 <button
                   v-if="editForm.assigned_name"
                   type="button"
@@ -890,7 +930,7 @@ const FORM_GRID = 'grid-cols-[6rem_17rem_1fr_1fr_8rem_2.5rem]'
           <div class="grid grid-cols-2 gap-3">
             <UFormField label="次のアクション対応者">
               <div class="relative">
-                <input v-model="editForm.next_action_by" list="task-employee-list" data-testid="edit-next-action-by" class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 pr-7 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500 [&::-webkit-calendar-picker-indicator]:hidden" />
+                <EmployeeNameInput v-model="editForm.next_action_by" :employees="employees" data-testid="edit-next-action-by" class="w-full text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 pr-7 bg-transparent focus:outline-none focus:ring-1 focus:ring-blue-500" />
                 <button
                   v-if="editForm.next_action_by"
                   type="button"

--- a/app/composables/useDummySeed.ts
+++ b/app/composables/useDummySeed.ts
@@ -1,10 +1,10 @@
 import {
   getWorkflowStates, setupDefaultWorkflow, getWorkflowTransitions,
-  getCategories, getOffices, getTaskTypes,
+  getCategories, getOffices, getTaskTypes, getEmployees, createEmployee,
   createTicket, updateTicket, transitionTicket, createTask,
 } from '~/utils/api'
 import { TICKET_CATEGORIES, DEFAULT_TASK_TYPES } from '~/types'
-import type { CreateTroubleTicket, TroubleWorkflowState, TroubleWorkflowTransition } from '~/types'
+import type { CreateTroubleTicket, Employee, TroubleWorkflowState, TroubleWorkflowTransition } from '~/types'
 
 // staging 用ダミーチケット生成 (rust-alc-api 側の変更は不要、既存 REST API を
 // ループで叩くだけ)。rust-alc-api staging はアイドル時に DB が揮発するため、
@@ -86,7 +86,28 @@ async function randomizeStatus(
   }
 }
 
-async function addDummyTasks(ticketId: string, taskTypes: string[]): Promise<void> {
+// 従業員マスタが空だと Row1 対応者 (assigned_to) の表示・保存を検証できない
+// (Refs #218)。PERSONS を employee として投入する。既存名はスキップ (冪等)。
+async function ensureEmployees(): Promise<Employee[]> {
+  let existing: Employee[] = []
+  try {
+    existing = await getEmployees()
+  } catch {
+    existing = []
+  }
+  const names = new Set(existing.map(e => e.name))
+  for (const name of PERSONS) {
+    if (names.has(name)) continue
+    try {
+      existing.push(await createEmployee({ name }))
+    } catch {
+      // 個別失敗は無視して次の名前へ (シード全体は止めない)
+    }
+  }
+  return existing
+}
+
+async function addDummyTasks(ticketId: string, taskTypes: string[], employees: Employee[]): Promise<void> {
   const count = randomInt(0, 2)
   for (let i = 0; i < count; i++) {
     const { occurred_at } = randomPastDate(30)
@@ -98,7 +119,8 @@ async function addDummyTasks(ticketId: string, taskTypes: string[]): Promise<voi
       next_action_detail: '',
       due_date: null,
       occurred_at,
-      assigned_to: null,
+      // Row1 対応者 (employee id)。7 割で設定し、未設定行も混ぜる
+      assigned_to: employees.length > 0 && Math.random() < 0.7 ? pick(employees).id : null,
       next_action_by: pick(PERSONS),
     })
   }
@@ -127,6 +149,7 @@ export function useDummySeed() {
       const categoryNames = categories.length > 0 ? categories.map(c => c.name) : [...TICKET_CATEGORIES]
       const officeNames = offices.length > 0 ? offices.map(o => o.name) : OFFICES
       const taskTypeNames = taskTypes.length > 0 ? taskTypes.map(t => t.name) : [...DEFAULT_TASK_TYPES]
+      const employees = await ensureEmployees()
 
       for (let i = 0; i < count; i++) {
         const ticket = await createTicket(buildDummyTicket(categoryNames, officeNames))
@@ -134,7 +157,7 @@ export function useDummySeed() {
           await updateTicket(ticket.id, { progress_notes: pick(PROGRESS_NOTES) })
         }
         await randomizeStatus(ticket.id, states, transitions)
-        await addDummyTasks(ticket.id, taskTypeNames)
+        await addDummyTasks(ticket.id, taskTypeNames, employees)
         progress.value = { done: i + 1, total: count }
       }
     } catch (e) {

--- a/app/pages/tickets/print/[id].vue
+++ b/app/pages/tickets/print/[id].vue
@@ -296,7 +296,7 @@ onMounted(() => {
                   <th class="border border-gray-400 px-2 py-1 text-left font-medium">日付</th>
                   <th class="border border-gray-400 px-2 py-1 text-left font-medium">種別</th>
                   <th class="border border-gray-400 px-2 py-1 text-left font-medium">タイトル / 内容</th>
-                  <th class="border border-gray-400 px-2 py-1 text-left font-medium">対応者</th>
+                  <th class="border border-gray-400 px-2 py-1 text-left font-medium">次の対応者</th>
                   <th class="border border-gray-400 px-2 py-1 text-left font-medium">状況</th>
                   <th class="print:hidden border border-gray-400 px-2 py-1 text-left font-medium">改ページ</th>
                 </tr>

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -146,6 +146,13 @@ export interface Employee {
   code: string | null
 }
 
+// rust-alc-api POST /api/employees の body (alc_core::models::CreateEmployee)。
+// code / nfc_id は省略可、role は backend 側 default ["driver"]
+export interface CreateEmployeeInput {
+  name: string
+  code?: string | null
+}
+
 // Re-export generated types used by new components
 export type { CreateWorkflowState, CreateWorkflowTransition } from './generated'
 

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -15,6 +15,7 @@ import type {
   TroubleProgressStatus,
   CreateTroubleProgressStatus,
   Employee,
+  CreateEmployeeInput,
   CreateWorkflowState,
   CreateWorkflowTransition,
   TransitionRequest,
@@ -240,6 +241,13 @@ export async function updateFieldLayout(data: TroubleFieldLayout): Promise<Troub
 
 export async function getEmployees(): Promise<Employee[]> {
   return request<Employee[]>('/api/employees')
+}
+
+export async function createEmployee(data: CreateEmployeeInput): Promise<Employee> {
+  return request<Employee>('/api/employees', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  })
 }
 
 // --- Car Inspection (車検証) ---

--- a/tests/components/EmployeeNameInput.test.ts
+++ b/tests/components/EmployeeNameInput.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { mount, enableAutoUnmount } from '@vue/test-utils'
 import EmployeeNameInput from '~/components/EmployeeNameInput.vue'
 
@@ -113,5 +113,29 @@ describe('EmployeeNameInput', () => {
     const wrapper = mountInput('', [])
     await wrapper.find('input').trigger('focus')
     expect(menu()).toBeNull()
+  })
+
+  // モーダル (Reka UI Dialog) 内で使われるケースの回帰ガード (Refs #215):
+  // body に pointer-events: none が付いても menu 側で継承を断ってクリック可能にし、
+  // pointerdown が document (= Dialog の外側クリック判定) まで伝播しないこと。
+  describe('モーダル内での利用 (body pointer-events: none 環境)', () => {
+    it('menu は pointer-events-auto で継承を断つ', async () => {
+      const wrapper = mountInput()
+      await wrapper.find('input').trigger('focus')
+      expect(menu()!.className).toContain('pointer-events-auto')
+    })
+
+    it('menu 上の pointerdown は document へ伝播しない (モーダルが閉じない)', async () => {
+      const wrapper = mountInput()
+      await wrapper.find('input').trigger('focus')
+      const outsideDetector = vi.fn()
+      document.addEventListener('pointerdown', outsideDetector)
+      menu()!.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+      expect(outsideDetector).not.toHaveBeenCalled()
+      // input 自身への pointerdown は素通しされる (通常のフォーカス動作を妨げない)
+      wrapper.find('input').element.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+      expect(outsideDetector).toHaveBeenCalledTimes(1)
+      document.removeEventListener('pointerdown', outsideDetector)
+    })
   })
 })

--- a/tests/components/EmployeeNameInput.test.ts
+++ b/tests/components/EmployeeNameInput.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mount, enableAutoUnmount } from '@vue/test-utils'
+import EmployeeNameInput from '~/components/EmployeeNameInput.vue'
+
+// Teleport した menu が document.body に残留しないよう毎テスト unmount する
+enableAutoUnmount(afterEach)
+
+const EMPLOYEES = [
+  { id: 'emp-1', tenant_id: 't1', name: '松江 寛人', code: '001' },
+  { id: 'emp-2', tenant_id: 't1', name: '青井 健', code: null },
+  { id: 'emp-3', tenant_id: 't1', name: '青山 太郎', code: null },
+]
+
+function mountInput(modelValue = '', employees = EMPLOYEES) {
+  return mount(EmployeeNameInput, {
+    props: { modelValue, employees },
+    attrs: { 'data-testid': 'target' },
+    attachTo: document.body,
+  })
+}
+
+function menu(): HTMLElement | null {
+  return document.body.querySelector('[data-testid="employee-name-menu"]')
+}
+
+function options(): HTMLElement[] {
+  return Array.from(document.body.querySelectorAll('[data-testid="employee-name-option"]'))
+}
+
+describe('EmployeeNameInput', () => {
+  it('focus で全候補の menu を開き、data-testid 等の attrs は inner input に付く', async () => {
+    const wrapper = mountInput()
+    const input = wrapper.find('[data-testid="target"]')
+    expect(input.element.tagName).toBe('INPUT')
+    await input.trigger('focus')
+    expect(menu()).not.toBeNull()
+    expect(options().length).toBe(3)
+  })
+
+  it('入力で部分一致フィルタされる (名前 / code どちらでも)', async () => {
+    const wrapper = mountInput()
+    const input = wrapper.find('input')
+    await input.setValue('青')
+    expect(options().map(o => o.textContent)).toEqual([
+      expect.stringContaining('青井 健'),
+      expect.stringContaining('青山 太郎'),
+    ])
+    await input.setValue('001')
+    expect(options().length).toBe(1)
+    expect(options()[0]!.textContent).toContain('松江 寛人')
+  })
+
+  it('候補クリックで名前を確定し select を emit、menu を閉じる', async () => {
+    const wrapper = mountInput()
+    await wrapper.find('input').setValue('青井')
+    options()[0]!.click()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('update:modelValue')!.at(-1)).toEqual(['青井 健'])
+    expect(wrapper.emitted('select')!.at(-1)).toEqual([EMPLOYEES[1]])
+    expect(menu()).toBeNull()
+  })
+
+  it('ArrowDown + Enter でハイライト中の候補を選択する', async () => {
+    const wrapper = mountInput()
+    const input = wrapper.find('input')
+    await input.trigger('focus')
+    await input.trigger('keydown', { key: 'ArrowDown' })
+    await input.trigger('keydown', { key: 'ArrowDown' })
+    await input.trigger('keydown', { key: 'ArrowUp' })
+    await input.trigger('keydown', { key: 'ArrowDown' })
+    await input.trigger('keydown', { key: 'Enter' })
+    expect(wrapper.emitted('update:modelValue')!.at(-1)).toEqual(['青井 健'])
+    expect(menu()).toBeNull()
+  })
+
+  it('menu を閉じた状態の ArrowDown は menu を開く', async () => {
+    const wrapper = mountInput()
+    const input = wrapper.find('input')
+    await input.trigger('keydown', { key: 'Escape' })
+    expect(menu()).toBeNull()
+    await input.trigger('keydown', { key: 'ArrowDown' })
+    expect(menu()).not.toBeNull()
+  })
+
+  it('ハイライト無しの Enter は menu を閉じて blur する (自由テキスト確定)', async () => {
+    const wrapper = mountInput()
+    const input = wrapper.find('input')
+    await input.setValue('マスタ外の名前')
+    expect(menu()).toBeNull() // 一致 0 件なので menu は出ない
+    await input.trigger('keydown', { key: 'Enter' })
+    expect(wrapper.emitted('select')).toBeUndefined()
+  })
+
+  it('Escape で menu が閉じる', async () => {
+    const wrapper = mountInput()
+    const input = wrapper.find('input')
+    await input.trigger('focus')
+    expect(menu()).not.toBeNull()
+    await input.trigger('keydown', { key: 'Escape' })
+    expect(menu()).toBeNull()
+  })
+
+  it('blur で menu を閉じ blur を emit する', async () => {
+    const wrapper = mountInput()
+    const input = wrapper.find('input')
+    await input.trigger('focus')
+    await input.trigger('blur')
+    expect(menu()).toBeNull()
+    expect(wrapper.emitted('blur')).toHaveLength(1)
+  })
+
+  it('従業員が空なら menu を開かない', async () => {
+    const wrapper = mountInput('', [])
+    await wrapper.find('input').trigger('focus')
+    expect(menu()).toBeNull()
+  })
+})

--- a/tests/components/TicketTaskList.test.ts
+++ b/tests/components/TicketTaskList.test.ts
@@ -252,15 +252,61 @@ describe('TicketTaskList', () => {
       expect((input.element as HTMLInputElement).value).toBe('松江 寛人')
     })
 
-    it('一致しない名前で保存すると assigned_to は null になる', async () => {
+    it('一致しない名前では保存せず、入力を保持してエラーを表示する (Refs #217)', async () => {
       const wrapper = await mountWithAssignees({ assigned_to: 'emp-1' })
       await wrapper.find('[data-testid="task-assigned"]').trigger('click')
       const input = wrapper.find('[data-testid="task-assigned-edit"]')
       await input.setValue('存在しない名前')
       await input.trigger('blur')
       await flushPromises()
+      expect(mockUpdateTask).not.toHaveBeenCalled()
+      // 編集状態と入力値が維持され、エラーが表示される
+      const kept = wrapper.find('[data-testid="task-assigned-edit"]')
+      expect(kept.exists()).toBe(true)
+      expect((kept.element as HTMLInputElement).value).toBe('存在しない名前')
+      expect(wrapper.find('[data-testid="task-inline-error"]').text()).toContain('従業員マスタ')
+    })
+
+    it('空にして保存すると assigned_to は null になる (意図的なクリアは許可)', async () => {
+      const wrapper = await mountWithAssignees({ assigned_to: 'emp-1' })
+      await wrapper.find('[data-testid="task-assigned"]').trigger('click')
+      const input = wrapper.find('[data-testid="task-assigned-edit"]')
+      await input.setValue('')
+      await input.trigger('blur')
+      await flushPromises()
       expect(mockUpdateTask).toHaveBeenCalledTimes(1)
       expect(mockUpdateTask.mock.calls[0]![1]).toEqual({ assigned_to: null })
+      expect(wrapper.find('[data-testid="task-inline-error"]').exists()).toBe(false)
+    })
+
+    it('追加フォームの対応者がマスタ不一致なら createTask を呼ばずエラー表示、入力は保持 (Refs #217)', async () => {
+      const wrapper = await mountWithAssignees({})
+      await wrapper.find('input[placeholder="タイトル"]').setValue('新タスク')
+      const assigned = wrapper.find('[data-testid="add-assigned"]')
+      await assigned.setValue('存在しない名前')
+      await wrapper.find('input[placeholder="タイトル"]').trigger('keydown.enter')
+      await flushPromises()
+      expect(mockCreateTask).not.toHaveBeenCalled()
+      expect(wrapper.find('[data-testid="add-assigned-error"]').text()).toContain('存在しない名前')
+      expect((wrapper.find('[data-testid="add-assigned"]').element as HTMLInputElement).value).toBe('存在しない名前')
+    })
+
+    it('追加フォームの対応者がマスタ一致なら assigned_to を id で送りエラーをクリアする', async () => {
+      const wrapper = await mountWithAssignees({})
+      await wrapper.find('input[placeholder="タイトル"]').setValue('新タスク')
+      const assigned = wrapper.find('[data-testid="add-assigned"]')
+      await assigned.setValue('存在しない名前')
+      await wrapper.find('input[placeholder="タイトル"]').trigger('keydown.enter')
+      await flushPromises()
+      expect(wrapper.find('[data-testid="add-assigned-error"]').exists()).toBe(true)
+
+      await wrapper.find('[data-testid="add-assigned"]').setValue('松江 寛人')
+      mockCreateTask.mockResolvedValue({ ...sampleTask, id: 'task-new' })
+      await wrapper.find('input[placeholder="タイトル"]').trigger('keydown.enter')
+      await flushPromises()
+      expect(mockCreateTask).toHaveBeenCalledTimes(1)
+      expect(mockCreateTask.mock.calls[0]![1].assigned_to).toBe('emp-1')
+      expect(wrapper.find('[data-testid="add-assigned-error"]').exists()).toBe(false)
     })
 
     it('値が変わらなければ updateTask を呼ばない', async () => {
@@ -372,6 +418,19 @@ describe('TicketTaskList', () => {
       expect(payload.next_action_by).toBe('山田')
       expect(payload.due_date).toBeNull()
       expect(vm.editModalOpen).toBe(false)
+    })
+
+    it('編集モーダルの対応者がマスタ不一致なら保存せずエラー表示、入力は保持 (Refs #217)', async () => {
+      const wrapper = await mountWithTwoTasks()
+      await wrapper.find('[data-testid="task-edit-button"]').trigger('click')
+      await flushPromises()
+      const vm = wrapper.vm as any
+      vm.editForm.assigned_name = '存在しない名前'
+      await vm.handleEditSaveAndClose()
+      expect(mockUpdateTask).not.toHaveBeenCalled()
+      expect(vm.editError).toContain('従業員マスタ')
+      expect(vm.editModalOpen).toBe(true)
+      expect(vm.editForm.assigned_name).toBe('存在しない名前')
     })
 
     it('タイトル空では保存せずモーダル内にエラーを出す', async () => {

--- a/tests/components/TicketTaskList.test.ts
+++ b/tests/components/TicketTaskList.test.ts
@@ -184,7 +184,7 @@ describe('TicketTaskList', () => {
       expect(wrapper2.find('[data-testid="task-row2"]').exists()).toBe(false)
     })
 
-    it('keeps next_action_by editable via row1 when row2 is hidden', async () => {
+    it('keeps assigned_to (対応者) visible via row1 when row2 is hidden', async () => {
       const wrapper = mount(TicketTaskList, {
         props: { ticketId: 'ticket-1', workflowStates: [], currentStatusId: null },
         global: { stubs },
@@ -192,8 +192,84 @@ describe('TicketTaskList', () => {
       await flushPromises()
       await wrapper.find('[data-testid="task-row2-toggle"]').trigger('click')
       expect(wrapper.find('[data-testid="task-row2"]').exists()).toBe(false)
-      // Row1 の「対応者」(next_action_by) 表示は Row2 非表示でも残る
+      // Row1 の「対応者」(assigned_to) 表示は Row2 非表示でも残る
       expect(wrapper.text()).toContain('対応者:')
+    })
+  })
+
+  describe('Row1 対応者 = assigned_to / Row2 次担当 = next_action_by (テレコ修正, Refs #214)', () => {
+    const employees = [
+      { id: 'emp-1', tenant_id: 't1', name: '松江 寛人', code: null },
+      { id: 'emp-2', tenant_id: 't1', name: '青井 健', code: null },
+    ]
+
+    async function mountWithAssignees(taskOverrides: Record<string, unknown> = {}) {
+      mockGetTasks.mockResolvedValue([{ ...sampleTask, ...taskOverrides }])
+      mockGetEmployees.mockResolvedValue(employees)
+      const wrapper = mount(TicketTaskList, {
+        props: { ticketId: 'ticket-1', workflowStates: [], currentStatusId: null },
+        global: { stubs },
+      })
+      await flushPromises()
+      return wrapper
+    }
+
+    it('Row1 対応者は assigned_to を名前解決して表示し、Row2 次担当は next_action_by を表示する', async () => {
+      const wrapper = await mountWithAssignees({ assigned_to: 'emp-1', next_action_by: '青井 健' })
+      const row1 = wrapper.find('[data-testid="task-assigned"]')
+      expect(row1.text()).toContain('対応者:')
+      expect(row1.text()).toContain('松江 寛人')
+      expect(row1.text()).not.toContain('青井 健')
+      const row2 = wrapper.find('[data-testid="task-next-action-by"]')
+      expect(row2.text()).toContain('次担当:')
+      expect(row2.text()).toContain('青井 健')
+    })
+
+    it('assigned_to が空なら Row1 対応者は "-" 表示 (next_action_by の値が漏れない)', async () => {
+      const wrapper = await mountWithAssignees({ assigned_to: null, next_action_by: '青井 健' })
+      const row1 = wrapper.find('[data-testid="task-assigned"]')
+      expect(row1.text()).toContain('-')
+      expect(row1.text()).not.toContain('青井 健')
+    })
+
+    it('Row1 対応者のインライン編集は名前を employee id に変換して assigned_to を保存する', async () => {
+      const wrapper = await mountWithAssignees({ assigned_to: null })
+      await wrapper.find('[data-testid="task-assigned"]').trigger('click')
+      const input = wrapper.find('[data-testid="task-assigned-edit"]')
+      expect(input.exists()).toBe(true)
+      await input.setValue('松江 寛人')
+      await input.trigger('blur')
+      await flushPromises()
+      expect(mockUpdateTask).toHaveBeenCalledTimes(1)
+      expect(mockUpdateTask.mock.calls[0]![0]).toBe('task-1')
+      expect(mockUpdateTask.mock.calls[0]![1]).toEqual({ assigned_to: 'emp-1' })
+    })
+
+    it('Row1 対応者のインライン編集開始時は既存 assigned_to を名前に解決して入れる', async () => {
+      const wrapper = await mountWithAssignees({ assigned_to: 'emp-1' })
+      await wrapper.find('[data-testid="task-assigned"]').trigger('click')
+      const input = wrapper.find('[data-testid="task-assigned-edit"]')
+      expect((input.element as HTMLInputElement).value).toBe('松江 寛人')
+    })
+
+    it('一致しない名前で保存すると assigned_to は null になる', async () => {
+      const wrapper = await mountWithAssignees({ assigned_to: 'emp-1' })
+      await wrapper.find('[data-testid="task-assigned"]').trigger('click')
+      const input = wrapper.find('[data-testid="task-assigned-edit"]')
+      await input.setValue('存在しない名前')
+      await input.trigger('blur')
+      await flushPromises()
+      expect(mockUpdateTask).toHaveBeenCalledTimes(1)
+      expect(mockUpdateTask.mock.calls[0]![1]).toEqual({ assigned_to: null })
+    })
+
+    it('値が変わらなければ updateTask を呼ばない', async () => {
+      const wrapper = await mountWithAssignees({ assigned_to: 'emp-1' })
+      await wrapper.find('[data-testid="task-assigned"]').trigger('click')
+      const input = wrapper.find('[data-testid="task-assigned-edit"]')
+      await input.trigger('blur')
+      await flushPromises()
+      expect(mockUpdateTask).not.toHaveBeenCalled()
     })
   })
 

--- a/tests/composables/useDummySeed.test.ts
+++ b/tests/composables/useDummySeed.test.ts
@@ -10,6 +10,8 @@ const createTicketMock = vi.fn()
 const updateTicketMock = vi.fn()
 const transitionTicketMock = vi.fn()
 const createTaskMock = vi.fn()
+const getEmployeesMock = vi.fn()
+const createEmployeeMock = vi.fn()
 
 vi.mock('~/utils/api', async (importOriginal) => ({
   ...(await importOriginal()),
@@ -23,6 +25,8 @@ vi.mock('~/utils/api', async (importOriginal) => ({
   updateTicket: (...args: unknown[]) => updateTicketMock(...args),
   transitionTicket: (...args: unknown[]) => transitionTicketMock(...args),
   createTask: (...args: unknown[]) => createTaskMock(...args),
+  getEmployees: (...args: unknown[]) => getEmployeesMock(...args),
+  createEmployee: (...args: unknown[]) => createEmployeeMock(...args),
 }))
 
 import { useDummySeed } from '~/composables/useDummySeed'
@@ -47,7 +51,13 @@ function resetMocks() {
   updateTicketMock.mockReset()
   transitionTicketMock.mockReset()
   createTaskMock.mockReset()
+  getEmployeesMock.mockReset()
+  createEmployeeMock.mockReset()
 
+  getEmployeesMock.mockResolvedValue([])
+  createEmployeeMock.mockImplementation(async ({ name }: { name: string }) => ({
+    id: `emp-${name}`, tenant_id: 't', name, code: null,
+  }))
   getWorkflowStatesMock.mockResolvedValue(STATES)
   getWorkflowTransitionsMock.mockResolvedValue(TRANSITIONS)
   getCategoriesMock.mockResolvedValue([{ id: 'c1', tenant_id: 't', name: '貨物事故', sort_order: 0, created_at: '' }])
@@ -165,6 +175,58 @@ describe('useDummySeed', () => {
 
     expect(error.value).toBe('boom')
     expect(seeding.value).toBe(false)
+  })
+
+  it('seeds missing employees before creating tickets (existing names are skipped)', async () => {
+    randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0)
+    getEmployeesMock.mockResolvedValue([
+      { id: 'emp-x', tenant_id: 't', name: '田中太郎', code: null },
+    ])
+
+    const { seedDummyTickets } = useDummySeed()
+    await seedDummyTickets(1)
+
+    // PERSONS 6 名のうち既存の 田中太郎 を除く 5 名が投入される
+    expect(createEmployeeMock).toHaveBeenCalledTimes(5)
+    const createdNames = createEmployeeMock.mock.calls.map(c => (c[0] as { name: string }).name)
+    expect(createdNames).not.toContain('田中太郎')
+  })
+
+  it('assigns a seeded employee id to dummy tasks when random < 0.7', async () => {
+    randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5)
+
+    const { seedDummyTickets } = useDummySeed()
+    await seedDummyTickets(1)
+
+    expect(createTaskMock).toHaveBeenCalled()
+    const payload = createTaskMock.mock.calls[0]![1] as { assigned_to: string | null }
+    expect(payload.assigned_to).toMatch(/^emp-/)
+  })
+
+  it('leaves assigned_to null on dummy tasks when random >= 0.7', async () => {
+    randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.99)
+
+    const { seedDummyTickets } = useDummySeed()
+    await seedDummyTickets(1)
+
+    expect(createTaskMock).toHaveBeenCalled()
+    const payload = createTaskMock.mock.calls[0]![1] as { assigned_to: string | null }
+    expect(payload.assigned_to).toBeNull()
+  })
+
+  it('tolerates getEmployees / createEmployee failures without aborting the seed', async () => {
+    randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    getEmployeesMock.mockRejectedValue(new Error('boom'))
+    createEmployeeMock.mockRejectedValue(new Error('boom'))
+
+    const { error, seedDummyTickets } = useDummySeed()
+    await seedDummyTickets(1)
+
+    expect(error.value).toBeNull()
+    expect(createTicketMock).toHaveBeenCalledTimes(1)
+    // 従業員が 1 人も出来なかったので assigned_to は null
+    const payload = createTaskMock.mock.calls[0]![1] as { assigned_to: string | null }
+    expect(payload.assigned_to).toBeNull()
   })
 
   it('records a fallback error message for non-Error rejections', async () => {

--- a/tests/pages/tickets/print.test.ts
+++ b/tests/pages/tickets/print.test.ts
@@ -66,9 +66,9 @@ describe('print/[id] page', () => {
 
     const table = wrapper.findAll('table').find(t => t.text().includes('経過記録') || t.find('th').exists())
     const headers = wrapper.findAll('thead th').map(th => th.text())
-    // 経過記録テーブルのヘッダーを特定 (種別/対応者を含む方)
+    // 経過記録テーブルのヘッダーを特定 (種別/次の対応者を含む方)
     const taskTableHeaders = wrapper.findAll('table').map(t => t.findAll('th').map(th => th.text()))
-      .find(hs => hs.includes('種別') && hs.includes('対応者'))
+      .find(hs => hs.includes('種別') && hs.includes('次の対応者'))
     expect(taskTableHeaders).toBeDefined()
     expect(taskTableHeaders![0]).toBe('日付')
     expect(headers.length).toBeGreaterThan(0)
@@ -81,7 +81,7 @@ describe('print/[id] page', () => {
 
     const taskTable = wrapper.findAll('table').find(t => {
       const hs = t.findAll('th').map(th => th.text())
-      return hs.includes('種別') && hs.includes('対応者')
+      return hs.includes('種別') && hs.includes('次の対応者')
     })
     expect(taskTable).toBeDefined()
     const firstDataRow = taskTable!.findAll('tbody tr')[0]!

--- a/tests/utils/api-phase3.test.ts
+++ b/tests/utils/api-phase3.test.ts
@@ -22,6 +22,7 @@ import {
   deleteOffice,
   updateOfficeSortOrder,
   getEmployees,
+  createEmployee,
   getWorkflowStates,
   getWorkflowTransitions,
   createWorkflowState,
@@ -199,6 +200,21 @@ describe('Trouble API Phase 3', () => {
           `${API_BASE}/api/employees`,
           expect.objectContaining({ headers: expect.any(Object) }),
         )
+      })
+    })
+  })
+
+  describe('createEmployee', () => {
+    it('creates an employee', async () => {
+      // live では従業員マスタを汚さないため mock のみで検証する
+      if (isLive) return
+      const mockData = { id: 'e1', tenant_id: 't1', name: '田中太郎', code: null }
+      await verifyApi(() => createEmployee({ name: '田中太郎' }), mockData)
+      assertMock(() => {
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/api/employees`)
+        expect(opts.method).toBe('POST')
+        expect(JSON.parse(opts.body)).toEqual({ name: '田中太郎' })
       })
     })
   })


### PR DESCRIPTION
## 概要

Refs #214 / #217 / #218

チケット詳細ページの経過記録一覧で、Row1「対応者:」欄がラベルと中身でテレコになっていた問題の修正 + レビュー指摘・追加報告への対応。

## 原因 (テレコ)

#204 で Row1 のラベルが「担当:」→「対応者:」に rename された際、表示・インライン編集の対象が `next_action_by` (次のアクション対応者) のまま残った。その結果:

- 追加フォーム Row1「対応者」に入力した名前 (`assigned_to` に保存) が一覧のどこにも表示されない
- 編集モーダル「次のアクション対応者」に入れた名前が一覧 Row1「対応者:」に表示される

## 変更内容

### commit 1: テレコ修正 (Refs #214)

- 一覧 Row1 の欄を `assigned_to` に変更 (表示は employee 名解決、編集は名前 → employee id 変換)。Row2「次担当:」(`next_action_by`) は維持
- 印刷ページの経過記録テーブルの列ヘッダを中身に合わせ「次の対応者」に rename

### commit 2: レビュー指摘 + 検索不良対応 (Refs #215 / #217 / #218)

- **従業員検索の自前オートコンプリート化**: production で入力フォームの従業員サジェストが効かない報告に対応。native `<datalist>` は日本語 IME 入力と相性が悪いため、`EmployeeNameInput` component (フィルタ + ドロップダウン自前描画、body へ Teleport) を新設し、対応者・次の対応者の全 6 入力に適用 (production の `/api/employees` は 200 で従業員データを返しており、UI 側の問題と特定)
- **マスタ不一致名は保存せず入力保持 + エラー表示** (Refs #217): 無言で null に落とさない。追加フォーム・インライン編集・編集モーダルの 3 箇所共通。空欄クリアは従来どおり null 保存
- **従業員シード** (Refs #218): `createEmployee` API 追加、ダミーチケット生成の前段でダミー人物 6 名を冪等投入、ダミータスクの `assigned_to` にもシード済み id を設定。staging/preview のマスタ空でもレビューがダミーデータで完結

## テスト

- `npm test`: 360 tests 中 358 pass (fail 2 件は CCoW 環境の `file:` リンク由来 + timeout flake で、変更前ツリーでも再現する既存事象。CI では registry 版で検証される)
- 新規: `EmployeeNameInput.test.ts` (フィルタ/選択/キーボード操作/blur)、不一致名 3 箇所のエラー挙動、従業員シードの冪等性・失敗許容、`createEmployee` API

## レビュー

- **ローカルレビュー用 issue: #216** (1 回目のレビュー済み、再レビュー観点は PR コメント参照)
- draft のまま。ready for review 化 (= merge 許可) は user 判断
- preview: https://trouble-preview.ippoan.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWuwYun45AMry9C4YjVFiN