### PR TITLE
feat: 担当者マスタを一番星 [社員ﾏｽﾀ] から手動同期 (Refs #220)

### DIFF
--- a/app/composables/useIchibanSync.ts
+++ b/app/composables/useIchibanSync.ts
@@ -1,0 +1,78 @@
+import { getEmployees, createEmployee, updateEmployee, getIchibanEmployees } from '~/utils/api'
+import type { Employee } from '~/types'
+
+export interface IchibanSyncSummary {
+  created: number
+  updated: number
+  skipped: number
+}
+
+// 一番星 [社員ﾏｽﾀ] → rust-alc-api employees の手動同期 (Refs #220)。
+//
+// upsert 規則:
+// - 名前は 社員R、コードは 社員C を使う。社員R が空の行は同期対象外 (skipped)
+// - code (=社員C) 一致 → 既存 row を維持 (UUID 不変)。name が違う時だけ update
+// - code 不一致でも「name 一致 && 既存 code が空」なら code を付与する update
+//   (手登録済みの同名担当者と重複させない)。既存 code が別値の行には触らない
+//   (alc-app 側の NFC/コード連携を壊さないため)
+// - どちらにも当たらなければ create
+export function useIchibanSync() {
+  const syncing = ref(false)
+  const progress = ref({ done: 0, total: 0 })
+  const error = ref<string | null>(null)
+  const summary = ref<IchibanSyncSummary | null>(null)
+
+  async function syncEmployees(): Promise<Employee[] | null> {
+    if (syncing.value) return null
+    syncing.value = true
+    error.value = null
+    summary.value = null
+    progress.value = { done: 0, total: 0 }
+    try {
+      const ichiban = await getIchibanEmployees()
+      const rows = ichiban.filter(r => r.employee_r.trim() !== '')
+      const existing = await getEmployees()
+      const byCode = new Map(existing.filter(e => e.code).map(e => [e.code as string, e]))
+      const noCodeByName = new Map(existing.filter(e => !e.code).map(e => [e.name, e]))
+
+      progress.value = { done: 0, total: rows.length }
+      const result: IchibanSyncSummary = { created: 0, updated: 0, skipped: 0 }
+
+      for (const row of rows) {
+        const code = row.employee_code.trim()
+        const name = row.employee_r.trim()
+        const matched = byCode.get(code)
+        if (matched) {
+          if (matched.name !== name) {
+            await updateEmployee(matched.id, { name, code })
+            result.updated++
+          } else {
+            result.skipped++
+          }
+        } else {
+          const sameName = noCodeByName.get(name)
+          if (sameName) {
+            await updateEmployee(sameName.id, { name, code })
+            noCodeByName.delete(name)
+            result.updated++
+          } else {
+            await createEmployee({ name, code })
+            result.created++
+          }
+        }
+        progress.value = { done: progress.value.done + 1, total: rows.length }
+      }
+
+      summary.value = result
+      return await getEmployees()
+    } catch (e) {
+      // useDummySeed と同じ方針: error に格納して UI 側で表示する (rethrow しない)
+      error.value = e instanceof Error ? e.message : '一番星からの同期に失敗しました'
+      return null
+    } finally {
+      syncing.value = false
+    }
+  }
+
+  return { syncing, progress, error, summary, syncEmployees }
+}

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { TroubleCategory, TroubleOffice, TroubleProgressStatus, TroubleNotificationPref, LineworksMember, TroubleTaskType, TroubleTaskStatus } from '~/types'
+import type { TroubleCategory, TroubleOffice, TroubleProgressStatus, TroubleNotificationPref, LineworksMember, TroubleTaskType, TroubleTaskStatus, Employee } from '~/types'
 import { TICKET_CATEGORIES, DEFAULT_TASK_TYPES, NOTIFICATION_EVENT_TYPES } from '~/types'
 import {
   getCategories, createCategory, deleteCategory, updateCategorySortOrder,
@@ -8,6 +8,7 @@ import {
   getTaskTypes, createTaskType, deleteTaskType, updateTaskTypeSortOrder,
   getTaskStatuses, createTaskStatus, deleteTaskStatus, updateTaskStatusSortOrder,
   getNotificationPrefs, upsertNotificationPref, deleteNotificationPref, getLineworksMembers,
+  getEmployees,
 } from '~/utils/api'
 
 const { authWorkerUrl } = useRuntimeConfig().public
@@ -20,9 +21,37 @@ const tabs = [
   { label: '営業所', value: 'offices' },
   { label: '進捗状況', value: 'progress' },
   { label: 'ワークフロー', value: 'workflow' },
+  { label: '担当者', value: 'employees' },
   { label: '通知', value: 'notifications' },
   { label: '入力フォーム表示', value: 'fieldLayout' },
 ]
+
+// Employees (担当者マスタ、一番星 [社員ﾏｽﾀ] からの手動同期。Refs #220)
+const employees = ref<Employee[]>([])
+const employeesLoading = ref(false)
+const {
+  syncing: ichibanSyncing,
+  progress: ichibanProgress,
+  error: ichibanError,
+  summary: ichibanSummary,
+  syncEmployees,
+} = useIchibanSync()
+
+async function fetchEmployees() {
+  employeesLoading.value = true
+  try {
+    employees.value = await getEmployees()
+  } catch (e) {
+    console.error('担当者取得エラー:', e)
+  } finally {
+    employeesLoading.value = false
+  }
+}
+
+async function handleIchibanSync() {
+  const refreshed = await syncEmployees()
+  if (refreshed) employees.value = refreshed
+}
 
 // Field layout
 const { fieldLayout, loading: fieldLayoutLoading, saving: fieldLayoutSaving, error: fieldLayoutError, fetchFieldLayout, saveFieldLayout } = useTicketFieldLayout()
@@ -364,6 +393,7 @@ onMounted(() => {
   fetchProgressStatuses()
   fetchNotifications()
   fetchFieldLayout()
+  fetchEmployees()
 })
 </script>
 
@@ -439,6 +469,41 @@ onMounted(() => {
       />
 
       <WorkflowManager v-if="activeTab === 'workflow'" />
+
+      <div v-if="activeTab === 'employees'" class="space-y-4">
+        <div class="flex items-center justify-between">
+          <h3 class="font-semibold">担当者マスタ</h3>
+          <UButton
+            label="一番星から同期"
+            icon="i-lucide-refresh-cw"
+            size="sm"
+            :loading="ichibanSyncing"
+            data-testid="ichiban-sync-button"
+            @click="handleIchibanSync"
+          />
+        </div>
+        <p class="text-xs text-gray-500">
+          一番星の社員マスタ (社員R) を取り込みます。社員コード (社員C) で突合し、
+          既存の担当者は名前のみ更新されます (削除はしません)。
+        </p>
+        <div v-if="ichibanSyncing" class="text-sm text-gray-500">
+          同期中... {{ ichibanProgress.done }}/{{ ichibanProgress.total }}
+        </div>
+        <div v-if="ichibanError" class="p-3 bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-400 rounded-lg text-sm" data-testid="ichiban-sync-error">
+          {{ ichibanError }}
+        </div>
+        <div v-if="ichibanSummary" class="p-3 bg-green-50 dark:bg-green-950 text-green-700 dark:text-green-400 rounded-lg text-sm" data-testid="ichiban-sync-summary">
+          同期完了: 追加 {{ ichibanSummary.created }} 件 / 更新 {{ ichibanSummary.updated }} 件 / 変更なし {{ ichibanSummary.skipped }} 件
+        </div>
+        <div v-if="employeesLoading" class="text-sm text-gray-500">読み込み中...</div>
+        <ul v-else class="divide-y divide-gray-100 dark:divide-gray-800 text-sm" data-testid="employee-list">
+          <li v-for="e in employees" :key="e.id" class="py-1.5 flex items-center gap-2">
+            <span>{{ e.name }}</span>
+            <span v-if="e.code" class="text-xs text-gray-400">({{ e.code }})</span>
+          </li>
+          <li v-if="employees.length === 0" class="py-1.5 text-gray-400">担当者が登録されていません</li>
+        </ul>
+      </div>
 
       <div v-if="activeTab === 'fieldLayout'" class="space-y-4">
         <div v-if="fieldLayoutError" class="p-3 bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-400 rounded-lg text-sm">

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -153,6 +153,22 @@ export interface CreateEmployeeInput {
   code?: string | null
 }
 
+// rust-alc-api PUT /api/employees/{id} の body (alc_core::models::UpdateEmployee)。
+// role を省略 (undefined) すると既存値が維持される (backend は COALESCE)。
+export interface UpdateEmployeeInput {
+  name: string
+  code?: string | null
+  role?: string[] | null
+}
+
+// 一番星 (rust-ichibanboshi GET /api/employees) の社員ﾏｽﾀ 1 件。
+// 担当者名としては employee_r (社員R) を使う (Refs #220)。
+export interface IchibanEmployee {
+  employee_code: string
+  employee_name: string
+  employee_r: string
+}
+
 // Re-export generated types used by new components
 export type { CreateWorkflowState, CreateWorkflowTransition } from './generated'
 

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -16,6 +16,8 @@ import type {
   CreateTroubleProgressStatus,
   Employee,
   CreateEmployeeInput,
+  UpdateEmployeeInput,
+  IchibanEmployee,
   CreateWorkflowState,
   CreateWorkflowTransition,
   TransitionRequest,
@@ -248,6 +250,35 @@ export async function createEmployee(data: CreateEmployeeInput): Promise<Employe
     method: 'POST',
     body: JSON.stringify(data),
   })
+}
+
+export async function updateEmployee(id: string, data: UpdateEmployeeInput): Promise<Employee> {
+  return request<Employee>(`/api/employees/${encodeURIComponent(id)}`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  })
+}
+
+// --- 一番星 社員ﾏｽﾀ (Refs #220) ---
+
+/**
+ * 一番星 [社員ﾏｽﾀ] の一覧を取得する。
+ * rust-alc-api ではなく同一 Worker の server route (/api/ichiban/employees、
+ * service binding 経由) を叩くため、apiBase (= /api/proxy) を通る request() は
+ * 使わない。認証は共有 cookie に加えて Bearer も明示で送る。
+ */
+export async function getIchibanEmployees(): Promise<IchibanEmployee[]> {
+  const res = await fetch('/api/ichiban/employees', { headers: buildAuthHeaders() })
+  if (res.status === 401) {
+    onUnauthorized?.()
+    throw new Error('Unauthorized')
+  }
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new Error(`API エラー (${res.status}): ${body || res.statusText}`)
+  }
+  const json = (await res.json()) as { data: IchibanEmployee[] }
+  return json.data
 }
 
 // --- Car Inspection (車検証) ---

--- a/server/api/ichiban/employees.get.ts
+++ b/server/api/ichiban/employees.get.ts
@@ -1,0 +1,60 @@
+/**
+ * 一番星 社員ﾏｽﾀ一覧の取得 (Refs #220)
+ *
+ * GET /api/ichiban/employees
+ *   → service binding (ICHIBAN_WORKER = nuxt-ichibanboshi) /api/employees
+ *     → CF Access Service Token → rust-ichibanboshi /api/employees → [社員ﾏｽﾀ]
+ *
+ * 担当者マスタの手動同期 (settings 画面) が呼ぶ read-only route。
+ * - browser JWT を auth-worker introspect (`requireAuth`) で検証してから forward する
+ *   (未認証に社員名一覧を漏らさない)
+ * - binding / secret 未設定は fail-closed 503
+ * - upstream エラーの詳細は response に echo しない (固定文言 + log のみ)
+ */
+import { requireAuth } from '@ippoan/auth-client/server'
+import { cfEnv, resolveSecret } from '../../utils/cfBindings'
+
+export default defineEventHandler(async (event) => {
+  const env = cfEnv(event)
+
+  const sharedSecret = await resolveSecret(env.INTERNAL_SHARED_SECRET)
+  if (!sharedSecret) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: 'INTERNAL_SHARED_SECRET binding が未設定です',
+    })
+  }
+
+  const authWorkerUrl =
+    typeof env.NUXT_PUBLIC_AUTH_WORKER_URL === 'string' ? env.NUXT_PUBLIC_AUTH_WORKER_URL : ''
+  if (!authWorkerUrl) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: 'NUXT_PUBLIC_AUTH_WORKER_URL が未設定です',
+    })
+  }
+
+  await requireAuth(event, { authWorkerUrl, sharedSecret })
+
+  const ichiban = env.ICHIBAN_WORKER as
+    | { fetch: (input: string, init?: RequestInit) => Promise<Response> }
+    | undefined
+  if (!ichiban || typeof ichiban.fetch !== 'function') {
+    throw createError({
+      statusCode: 503,
+      statusMessage: 'ICHIBAN_WORKER service binding が未設定です',
+    })
+  }
+
+  // service binding の fetch は URL の host を無視して bound worker に届くが、
+  // 形式上 absolute URL が必要 (host は bound worker 名で判別しやすい値にする)。
+  const res = await ichiban.fetch('https://nuxt-ichibanboshi/api/employees')
+  if (!res.ok) {
+    console.error(`ichiban employees fetch failed: status=${res.status}`)
+    throw createError({
+      statusCode: 502,
+      statusMessage: '一番星からの社員一覧取得に失敗しました',
+    })
+  }
+  return res.json()
+})

--- a/server/api/proxy/[...path].ts
+++ b/server/api/proxy/[...path].ts
@@ -10,21 +10,8 @@
  * X-Alc-Proxy-Secret を constant-time 検証してから JWT 検証 + ACL + OIDC mint +
  * X-Tenant-ID/X-User-* 注入を行う。AUTH_WORKER は方式 B で必須 (未設定は 503)。
  */
-import type { H3Event } from 'h3'
 import { createAuthWorkerProxyHandler } from '@ippoan/auth-client/server'
-
-function cfEnv(event: H3Event): Record<string, unknown> {
-  return (event.context.cloudflare as { env?: Record<string, unknown> } | undefined)?.env ?? {}
-}
-
-/** Secrets Store binding (`.get()`) / 文字列 のいずれでも値を取り出す。 */
-async function resolveSecret(binding: unknown): Promise<string | null> {
-  if (typeof binding === 'string') return binding
-  if (binding && typeof (binding as { get?: unknown }).get === 'function') {
-    return (await (binding as { get(): Promise<string> }).get()) ?? null
-  }
-  return null
-}
+import { cfEnv, resolveSecret } from '../../utils/cfBindings'
 
 export default defineEventHandler(async (event) => {
   const env = cfEnv(event)

--- a/server/utils/cfBindings.ts
+++ b/server/utils/cfBindings.ts
@@ -1,0 +1,20 @@
+/**
+ * Cloudflare Workers binding 取り出しの共通 helper。
+ * server/api/proxy/[...path].ts と server/api/ichiban/employees.get.ts が共用する
+ * (Refs #220 で 2 箇所目が出来たため extract)。
+ */
+import type { H3Event } from 'h3'
+
+/** nitro cloudflare_module の event から Workers env (bindings) を取り出す。 */
+export function cfEnv(event: H3Event): Record<string, unknown> {
+  return (event.context.cloudflare as { env?: Record<string, unknown> } | undefined)?.env ?? {}
+}
+
+/** Secrets Store binding (`.get()`) / 文字列 のいずれでも値を取り出す。 */
+export async function resolveSecret(binding: unknown): Promise<string | null> {
+  if (typeof binding === 'string') return binding
+  if (binding && typeof (binding as { get?: unknown }).get === 'function') {
+    return (await (binding as { get(): Promise<string> }).get()) ?? null
+  }
+  return null
+}

--- a/tests/composables/useIchibanSync.test.ts
+++ b/tests/composables/useIchibanSync.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const getIchibanEmployeesMock = vi.fn()
+const getEmployeesMock = vi.fn()
+const createEmployeeMock = vi.fn()
+const updateEmployeeMock = vi.fn()
+
+vi.mock('~/utils/api', async (importOriginal) => ({
+  ...(await importOriginal()),
+  getIchibanEmployees: (...args: unknown[]) => getIchibanEmployeesMock(...args),
+  getEmployees: (...args: unknown[]) => getEmployeesMock(...args),
+  createEmployee: (...args: unknown[]) => createEmployeeMock(...args),
+  updateEmployee: (...args: unknown[]) => updateEmployeeMock(...args),
+}))
+
+import { useIchibanSync } from '~/composables/useIchibanSync'
+
+function emp(id: string, name: string, code: string | null) {
+  return { id, tenant_id: 't', name, code }
+}
+
+function ichiban(code: string, r: string, n = '') {
+  return { employee_code: code, employee_name: n || r, employee_r: r }
+}
+
+beforeEach(() => {
+  getIchibanEmployeesMock.mockReset()
+  getEmployeesMock.mockReset()
+  createEmployeeMock.mockReset()
+  updateEmployeeMock.mockReset()
+  createEmployeeMock.mockImplementation(async (d: { name: string; code: string }) =>
+    emp('new-' + d.code, d.name, d.code),
+  )
+  updateEmployeeMock.mockImplementation(async (id: string, d: { name: string; code: string }) =>
+    emp(id, d.name, d.code),
+  )
+})
+
+describe('useIchibanSync', () => {
+  it('新規の社員は createEmployee する (code=社員C, name=社員R)', async () => {
+    getIchibanEmployeesMock.mockResolvedValue([ichiban('1001', '田中')])
+    getEmployeesMock.mockResolvedValueOnce([]).mockResolvedValueOnce([emp('e1', '田中', '1001')])
+
+    const { syncEmployees, summary, error } = useIchibanSync()
+    const result = await syncEmployees()
+
+    expect(createEmployeeMock).toHaveBeenCalledWith({ name: '田中', code: '1001' })
+    expect(updateEmployeeMock).not.toHaveBeenCalled()
+    expect(summary.value).toEqual({ created: 1, updated: 0, skipped: 0 })
+    expect(error.value).toBeNull()
+    expect(result).toEqual([emp('e1', '田中', '1001')])
+  })
+
+  it('code 一致で名前が同じならスキップ (UUID 維持・API 呼ばない)', async () => {
+    getIchibanEmployeesMock.mockResolvedValue([ichiban('1001', '田中')])
+    getEmployeesMock.mockResolvedValue([emp('e1', '田中', '1001')])
+
+    const { syncEmployees, summary } = useIchibanSync()
+    await syncEmployees()
+
+    expect(createEmployeeMock).not.toHaveBeenCalled()
+    expect(updateEmployeeMock).not.toHaveBeenCalled()
+    expect(summary.value).toEqual({ created: 0, updated: 0, skipped: 1 })
+  })
+
+  it('code 一致で名前が違えば update する (名前のみ追従)', async () => {
+    getIchibanEmployeesMock.mockResolvedValue([ichiban('1001', '田中(新姓)')])
+    getEmployeesMock.mockResolvedValue([emp('e1', '田中', '1001')])
+
+    const { syncEmployees, summary } = useIchibanSync()
+    await syncEmployees()
+
+    expect(updateEmployeeMock).toHaveBeenCalledWith('e1', { name: '田中(新姓)', code: '1001' })
+    expect(summary.value).toEqual({ created: 0, updated: 1, skipped: 0 })
+  })
+
+  it('code 未設定の同名既存には code を付与する (重複作成しない)', async () => {
+    getIchibanEmployeesMock.mockResolvedValue([ichiban('1001', '田中')])
+    getEmployeesMock.mockResolvedValue([emp('e1', '田中', null)])
+
+    const { syncEmployees, summary } = useIchibanSync()
+    await syncEmployees()
+
+    expect(updateEmployeeMock).toHaveBeenCalledWith('e1', { name: '田中', code: '1001' })
+    expect(createEmployeeMock).not.toHaveBeenCalled()
+    expect(summary.value).toEqual({ created: 0, updated: 1, skipped: 0 })
+  })
+
+  it('別 code を持つ同名既存には触らず新規作成する (alc-app 連携を壊さない)', async () => {
+    getIchibanEmployeesMock.mockResolvedValue([ichiban('1001', '田中')])
+    getEmployeesMock.mockResolvedValue([emp('e1', '田中', 'NFC-77')])
+
+    const { syncEmployees, summary } = useIchibanSync()
+    await syncEmployees()
+
+    expect(updateEmployeeMock).not.toHaveBeenCalled()
+    expect(createEmployeeMock).toHaveBeenCalledWith({ name: '田中', code: '1001' })
+    expect(summary.value).toEqual({ created: 1, updated: 0, skipped: 0 })
+  })
+
+  it('社員R が空の行は同期対象外', async () => {
+    getIchibanEmployeesMock.mockResolvedValue([ichiban('9999', '  '), ichiban('1001', '田中')])
+    getEmployeesMock.mockResolvedValue([])
+
+    const { syncEmployees, progress, summary } = useIchibanSync()
+    await syncEmployees()
+
+    expect(createEmployeeMock).toHaveBeenCalledTimes(1)
+    expect(progress.value).toEqual({ done: 1, total: 1 })
+    expect(summary.value).toEqual({ created: 1, updated: 0, skipped: 0 })
+  })
+
+  it('失敗時は error に格納して null を返す (rethrow しない)', async () => {
+    getIchibanEmployeesMock.mockRejectedValue(new Error('API エラー (502)'))
+
+    const { syncEmployees, error, summary, syncing } = useIchibanSync()
+    const result = await syncEmployees()
+
+    expect(result).toBeNull()
+    expect(error.value).toBe('API エラー (502)')
+    expect(summary.value).toBeNull()
+    expect(syncing.value).toBe(false)
+  })
+
+  it('Error 以外の throw は固定文言にする', async () => {
+    getIchibanEmployeesMock.mockRejectedValue('boom')
+
+    const { syncEmployees, error } = useIchibanSync()
+    await syncEmployees()
+
+    expect(error.value).toBe('一番星からの同期に失敗しました')
+  })
+
+  it('同期中の再入は no-op (null 返し)', async () => {
+    let resolveIchiban: (v: unknown[]) => void = () => {}
+    getIchibanEmployeesMock.mockReturnValue(new Promise(r => (resolveIchiban = r)))
+    getEmployeesMock.mockResolvedValue([])
+
+    const { syncEmployees, syncing } = useIchibanSync()
+    const first = syncEmployees()
+    expect(syncing.value).toBe(true)
+    await expect(syncEmployees()).resolves.toBeNull()
+    resolveIchiban([])
+    await first
+    expect(getIchibanEmployeesMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/server/ichiban-employees.test.ts
+++ b/tests/server/ichiban-employees.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// /api/ichiban/employees (Refs #220) の wiring テスト。
+// - requireAuth (introspect 検証) は @ippoan/auth-client/server 側の責務なので mock し、
+//   「secret / URL / binding の fail-closed」と「認証 → binding fetch → data 透過」の
+//   wiring だけをここで固定する (proxy.test.ts と同じ方針)。
+const { requireAuthMock } = vi.hoisted(() => {
+  ;(globalThis as Record<string, unknown>).defineEventHandler = (fn: unknown) => fn
+  return { requireAuthMock: vi.fn(async () => ({ active: true as const })) }
+})
+
+vi.mock('@ippoan/auth-client/server', () => ({
+  requireAuth: requireAuthMock,
+}))
+
+import handler from '../../server/api/ichiban/employees.get'
+
+const call = (event: unknown) => (handler as unknown as (e: unknown) => Promise<unknown>)(event)
+const eventWith = (env: Record<string, unknown>) => ({ context: { cloudflare: { env } } })
+
+const BASE_ENV = {
+  INTERNAL_SHARED_SECRET: 'secret-x',
+  NUXT_PUBLIC_AUTH_WORKER_URL: 'https://auth.example',
+}
+
+function okBinding(data: unknown = { source_table: '社員ﾏｽﾀ', data: [] }) {
+  return {
+    fetch: vi.fn(async () => ({ ok: true, status: 200, json: async () => data })),
+  }
+}
+
+describe('ichiban employees handler wiring', () => {
+  beforeEach(() => {
+    requireAuthMock.mockClear()
+    requireAuthMock.mockResolvedValue({ active: true as const })
+  })
+
+  it('認証 → service binding fetch → data をそのまま返す', async () => {
+    const data = {
+      source_table: '社員ﾏｽﾀ',
+      data: [{ employee_code: '1001', employee_name: '田中太郎', employee_r: '田中' }],
+    }
+    const binding = okBinding(data)
+    const event = eventWith({ ...BASE_ENV, ICHIBAN_WORKER: binding })
+
+    const res = await call(event)
+
+    expect(requireAuthMock).toHaveBeenCalledTimes(1)
+    expect(requireAuthMock.mock.calls[0]![1]).toEqual({
+      authWorkerUrl: 'https://auth.example',
+      sharedSecret: 'secret-x',
+    })
+    expect(binding.fetch).toHaveBeenCalledWith('https://nuxt-ichibanboshi/api/employees')
+    expect(res).toEqual(data)
+  })
+
+  it('INTERNAL_SHARED_SECRET が Secrets Store binding (.get()) でも解決する', async () => {
+    const binding = okBinding()
+    const event = eventWith({
+      ...BASE_ENV,
+      INTERNAL_SHARED_SECRET: { get: async () => 'from-store' },
+      ICHIBAN_WORKER: binding,
+    })
+    await call(event)
+    expect(requireAuthMock.mock.calls[0]![1]).toMatchObject({ sharedSecret: 'from-store' })
+  })
+
+  it('INTERNAL_SHARED_SECRET 未設定なら認証前に throw (fail-closed)', async () => {
+    const event = eventWith({
+      NUXT_PUBLIC_AUTH_WORKER_URL: 'https://auth.example',
+      ICHIBAN_WORKER: okBinding(),
+    })
+    await expect(call(event)).rejects.toThrow()
+    expect(requireAuthMock).not.toHaveBeenCalled()
+  })
+
+  it('NUXT_PUBLIC_AUTH_WORKER_URL 未設定なら認証前に throw (fail-closed)', async () => {
+    const event = eventWith({
+      INTERNAL_SHARED_SECRET: 'secret-x',
+      ICHIBAN_WORKER: okBinding(),
+    })
+    await expect(call(event)).rejects.toThrow()
+    expect(requireAuthMock).not.toHaveBeenCalled()
+  })
+
+  it('requireAuth が 401 を throw したら binding fetch に到達しない', async () => {
+    requireAuthMock.mockRejectedValueOnce(new Error('Unauthorized'))
+    const binding = okBinding()
+    const event = eventWith({ ...BASE_ENV, ICHIBAN_WORKER: binding })
+    await expect(call(event)).rejects.toThrow('Unauthorized')
+    expect(binding.fetch).not.toHaveBeenCalled()
+  })
+
+  it('ICHIBAN_WORKER binding 未設定なら throw (fail-closed 503)', async () => {
+    const event = eventWith({ ...BASE_ENV })
+    await expect(call(event)).rejects.toThrow()
+    expect(requireAuthMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('upstream が non-ok なら 502 相当で throw (詳細は echo しない)', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const binding = {
+      fetch: vi.fn(async () => ({ ok: false, status: 500, json: async () => ({}) })),
+    }
+    const event = eventWith({ ...BASE_ENV, ICHIBAN_WORKER: binding })
+    await expect(call(event)).rejects.toThrow('一番星からの社員一覧取得に失敗しました')
+    consoleError.mockRestore()
+  })
+})

--- a/tests/utils/api-ichiban.test.ts
+++ b/tests/utils/api-ichiban.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  setupApi,
+  teardownApi,
+  mockFetch,
+  assertMock,
+  verifyApi,
+  callApi,
+  expectMock,
+  isLive,
+  API_BASE,
+  restoreNativeApis,
+} from '../helpers/api-test-env'
+import { initApi, updateEmployee, getIchibanEmployees } from '~/utils/api'
+
+// 一番星 社員ﾏｽﾀ同期まわりの API client (Refs #220)
+
+describe('Employees update / Ichiban employees API', () => {
+  beforeEach(async () => {
+    restoreNativeApis()
+    await setupApi()
+  })
+  afterEach(() => teardownApi())
+
+  describe('updateEmployee', () => {
+    it('PUT /api/employees/{id} を叩く', async () => {
+      await callApi(() =>
+        verifyApi(
+          () => updateEmployee('e1', { name: '田中', code: '1001' }),
+          { id: 'e1', tenant_id: 't', name: '田中', code: '1001' },
+        ),
+      )
+      assertMock(() => {
+        expectMock(mockFetch).toHaveBeenCalledWith(
+          `${API_BASE}/api/employees/e1`,
+          expect.objectContaining({
+            method: 'PUT',
+            body: JSON.stringify({ name: '田中', code: '1001' }),
+          }),
+        )
+      })
+    })
+  })
+
+  // /api/ichiban/employees は同一 Worker の server route (相対 URL) なので
+  // live mode (実 rust-alc-api 直叩き) では検証できない → mock mode のみ。
+  describe.skipIf(isLive)('getIchibanEmployees', () => {
+    it('server route から data 配列を取り出して返す', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            source_table: '社員ﾏｽﾀ',
+            data: [{ employee_code: '1001', employee_name: '田中太郎', employee_r: '田中' }],
+          }),
+      })
+      const rows = await getIchibanEmployees()
+      expect(rows).toEqual([
+        { employee_code: '1001', employee_name: '田中太郎', employee_r: '田中' },
+      ])
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/ichiban/employees',
+        expect.objectContaining({ headers: expect.any(Object) }),
+      )
+    })
+
+    it('401 なら onUnauthorized を呼んで Unauthorized を throw する', async () => {
+      const onUnauthorized = vi.fn()
+      initApi(API_BASE, () => 'tok', undefined, undefined, onUnauthorized)
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 401, statusText: 'Unauthorized' })
+      await expect(getIchibanEmployees()).rejects.toThrow('Unauthorized')
+      expect(onUnauthorized).toHaveBeenCalled()
+    })
+
+    it('エラー時は body 付きの API エラーを throw する', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        statusText: 'Bad Gateway',
+        text: () => Promise.resolve('一番星からの社員一覧取得に失敗しました'),
+      })
+      await expect(getIchibanEmployees()).rejects.toThrow('API エラー (502)')
+    })
+
+    it('body が読めない時は statusText へフォールバックする', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+        text: () => Promise.reject(new Error('no body')),
+      })
+      await expect(getIchibanEmployees()).rejects.toThrow('Service Unavailable')
+    })
+  })
+})

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -42,6 +42,14 @@ secret_name = "INTERNAL_SHARED_SECRET"
 binding = "AUTH_WORKER"
 service = "auth-worker"
 
+# 一番星 (nuxt-ichibanboshi) の /api/employees を叩く service binding。
+# 担当者マスタの手動同期 (Refs #220) 用。CF Access Service Token は
+# nuxt-ichibanboshi 側が保持するため本 worker は secret を持たない。
+# nuxt-ichibanboshi は single-env (staging = prod) なので全 env 同じ worker を指す。
+[[services]]
+binding = "ICHIBAN_WORKER"
+service = "nuxt-ichibanboshi"
+
 [env.staging]
 name = "nuxt-trouble-staging"
 
@@ -65,6 +73,10 @@ secret_name = "INTERNAL_SHARED_SECRET"
 [[env.staging.services]]
 binding = "AUTH_WORKER"
 service = "auth-worker-staging"
+
+[[env.staging.services]]
+binding = "ICHIBAN_WORKER"
+service = "nuxt-ichibanboshi"
 
 # push のたびに更新される軽量プレビュー環境 (Refs ippoan/secrets-inventory#85)。
 # staging とは別の Worker resource として固定 URL を持たせ、staging 自体は
@@ -94,3 +106,7 @@ secret_name = "INTERNAL_SHARED_SECRET"
 [[env.preview.services]]
 binding = "AUTH_WORKER"
 service = "auth-worker-staging"
+
+[[env.preview.services]]
+binding = "ICHIBAN_WORKER"
+service = "nuxt-ichibanboshi"


### PR DESCRIPTION
## 概要

チケット/タスクの担当者候補 (employees) を一番星 CAPE#01 の [社員ﾏｽﾀ] から手動同期できるようにする。dtako 運行データ由来の乗務員名では事務員を担当者に指定できないため、[社員ﾏｽﾀ] (`社員R` を名前として使用) を取り込み元にする。

Refs #220

## 設計

```
settings 画面「一番星から同期」ボタン (手動のみ)
 → GET /api/ichiban/employees (新 server route、requireAuth で introspect 認証)
   → service binding ICHIBAN_WORKER → nuxt-ichibanboshi /api/employees
     → CF Access Service Token → rust-ichibanboshi /api/employees → [社員ﾏｽﾀ]
 ← 社員一覧 (社員C / 社員R)
 → ブラウザから既存 /api/proxy 経由で createEmployee / updateEmployee を upsert
   (auth-worker が X-Tenant-ID 注入 → tenant 制限維持)
```

- **secret 追加なし** (service binding + nuxt-ichibanboshi の既存 Service Token 再利用)
- **rust-alc-api 変更なし**、既存 employee の UUID は維持 (assigned_to 参照を壊さない)

## 変更内容

- `wrangler.toml`: `ICHIBAN_WORKER` service binding を prod / staging / preview に追加 (nuxt-ichibanboshi は single-env のため全て同一 worker)
- `server/api/ichiban/employees.get.ts`: requireAuth → binding fetch。binding/secret 未設定は fail-closed 503、upstream エラーは固定文言 502 (詳細は log のみ)
- `server/utils/cfBindings.ts`: `cfEnv` / `resolveSecret` を proxy route から extract (2 箇所目が出来たため)
- `app/composables/useIchibanSync.ts`: upsert ロジック — code=社員C 突合、name=社員R。code 一致は名前のみ追従、code 未設定の同名既存には code 付与、別 code の同名既存には触らない (alc-app の NFC/コード連携を壊さない)、社員R 空行はスキップ
- `app/pages/settings.vue`: 「担当者」タブ (一覧表示 + 同期ボタン + 進捗/結果表示)
- `app/utils/api.ts`: `updateEmployee` / `getIchibanEmployees` を追加
- テスト: server route wiring / composable upsert 規則 / api client の 3 ファイル追加 (383 tests green、api.ts は coverage 100% 維持)

## テスト / 動作確認

- `vitest run` 383 passed / `nuxi typecheck` green
- merge 前に PR staging (trouble-staging.ippoan.org) の settings → 担当者タブで同期を実行して確認可能 (backend 3 段が全て live になるのは rust-ichibanboshi 側 PR の merge 後)

関連 PR: ohishi-exp/rust-ichibanboshi (backend、#74 実装)、ohishi-exp/nuxt-ichibanboshi (proxy route、#120 実装)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZAdsfPrFbuW8k6FNEjQ5a

---
_Generated by [Claude Code](https://claude.ai/code/session_01TZAdsfPrFbuW8k6FNEjQ5a)_